### PR TITLE
apply v30.9.1 hotfix

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -6,10 +6,10 @@
     <DisableImplicitNuGetFallbackFolder>true</DisableImplicitNuGetFallbackFolder>
   </PropertyGroup>
   <ItemGroup>
-    <PackageVersion Include="Kentico.Xperience.Admin" Version="30.9.0" />
-    <PackageVersion Include="Kentico.Xperience.AzureStorage" Version="30.9.0" />
+    <PackageVersion Include="Kentico.Xperience.Admin" Version="30.9.1" />
+    <PackageVersion Include="Kentico.Xperience.AzureStorage" Version="30.9.1" />
     <PackageVersion Include="Kentico.Xperience.MiniProfiler" Version="2.1.0" />
-    <PackageVersion Include="Kentico.Xperience.WebApp" Version="30.9.0" />
+    <PackageVersion Include="Kentico.Xperience.WebApp" Version="30.9.1" />
     <PackageVersion Include="Schema.NET" Version="13.0.0" />
     <PackageVersion Include="Sidio.Sitemap.AspNetCore" Version="2.7.6" />
     <PackageVersion Include="SixLabors.ImageSharp" Version="3.1.11" />

--- a/src/Goldfinch.Admin/packages.lock.json
+++ b/src/Goldfinch.Admin/packages.lock.json
@@ -4,12 +4,12 @@
     "net9.0": {
       "Kentico.Xperience.Admin": {
         "type": "Direct",
-        "requested": "[30.9.0, )",
-        "resolved": "30.9.0",
-        "contentHash": "PEfDS0v3ZRhRKEqza/kgAFSJQOSGXX3HSz1Bm7Kn7dKc0qYHtvPUH5sV2kBjJXSBfB0gubeWw1rghFy9JMzoYw==",
+        "requested": "[30.9.1, )",
+        "resolved": "30.9.1",
+        "contentHash": "qdw9WG8TT4gtmRRW2qVZGni2rJecYKAzvV5uQ9BseXRQ0aQdzL1mD1QxmqUBW07K8Yf9+2azEWP8ZRqntp3VsA==",
         "dependencies": {
           "Kentico.Aira.Client": "3.6.1",
-          "Kentico.Xperience.WebApp": "[30.9.0]",
+          "Kentico.Xperience.WebApp": "[30.9.1]",
           "Microsoft.AspNetCore.SpaServices.Extensions": "8.0.19",
           "Microsoft.Extensions.FileProviders.Embedded": "8.0.19",
           "Microsoft.SemanticKernel": "1.62.0",
@@ -19,15 +19,15 @@
       },
       "Kentico.Xperience.WebApp": {
         "type": "Direct",
-        "requested": "[30.9.0, )",
-        "resolved": "30.9.0",
-        "contentHash": "ECiq2eWZ//ndZnlSFKaI5HZYEdkg5cRa1F651r2M+8nhcnehULq8qzNQj+1mOL/7Cr6H+HTh0vWbv/K1yfD8Ww==",
+        "requested": "[30.9.1, )",
+        "resolved": "30.9.1",
+        "contentHash": "CrAIVnnaXnjmLVXOuk1kaHLmjqPQsg4rtPuAxxvIygvwOaTHIjZNxCj+DvyFUS7muZwPyQPj3IbCxIbS/JhL0A==",
         "dependencies": {
           "CommandLineParser": "2.9.1",
           "HotChocolate.AspNetCore": "15.0.3",
           "HotChocolate.Data": "15.0.3",
           "HtmlSanitizer": "9.0.886",
-          "Kentico.Xperience.Core": "[30.9.0]",
+          "Kentico.Xperience.Core": "[30.9.1]",
           "Microsoft.AspNetCore.Components": "8.0.19",
           "Microsoft.Extensions.Caching.Memory": "8.0.1",
           "Microsoft.Extensions.FileProviders.Embedded": "8.0.19"
@@ -461,12 +461,12 @@
       },
       "Kentico.Xperience.Core": {
         "type": "Transitive",
-        "resolved": "30.9.0",
-        "contentHash": "R71dxFHGuMm4epZQYvSk7GsYiVING7a6PR/fdNTbdhZ4r4zxU1VxowCuNCZP52D4iBY/UmdL//XAdSxuDfEa9A==",
+        "resolved": "30.9.1",
+        "contentHash": "jVyaYsP5sOq5wtz8kdsYzh3snRbYKjrmBEyMa9mgJQCuEeoj+0hcUXUKdozGPO9hGl3f/BWNwWxCLApXjtJo1w==",
         "dependencies": {
           "AngleSharp": "0.17.1",
           "Kentico.Aira.Client": "3.6.1",
-          "Magick.NET-Q8-AnyCPU": "14.7.0",
+          "Magick.NET-Q8-AnyCPU": "14.8.1",
           "MailKit": "4.13.0",
           "Microsoft.Data.SqlClient": "5.2.3",
           "Microsoft.Extensions.Caching.Memory": "8.0.1",
@@ -484,16 +484,16 @@
       },
       "Magick.NET-Q8-AnyCPU": {
         "type": "Transitive",
-        "resolved": "14.7.0",
-        "contentHash": "JQiOjOPXJar57Ew5YeD28zE1pbHpSKBYYQZBNkqhvXbLxCcTmu8djfVLKkqTcTAxFX/Mcj14j2RB+ORkCYD9Jw==",
+        "resolved": "14.8.1",
+        "contentHash": "Q8+Y2ht0w015IIgomYVUJl45uYIEUmG1fTQ/cwL9iHsQ5z6TBofLAkGD2trOpPEHQlpHK9qD837bN34Ak8VS1g==",
         "dependencies": {
-          "Magick.NET.Core": "14.7.0"
+          "Magick.NET.Core": "14.8.1"
         }
       },
       "Magick.NET.Core": {
         "type": "Transitive",
-        "resolved": "14.7.0",
-        "contentHash": "eXNEgZwUQ+QerJgIoAe9BlFolm3RzQ0k677AK5PLiLh701XQX1p878mt+jEQYJD58Jwcayto1UtFvtvnChyGyg=="
+        "resolved": "14.8.1",
+        "contentHash": "XkfFOOpak9Rsj6El18x3z+4Gr/W71uDQvoHz3WvEfZUUh32G2X6HC+r1VzR/DgUssvsbkDLr5a82/QCf7Xrbxw=="
       },
       "MailKit": {
         "type": "Transitive",
@@ -1113,8 +1113,8 @@
       "goldfinch.core": {
         "type": "Project",
         "dependencies": {
-          "Kentico.Xperience.Admin": "[30.9.0, )",
-          "Kentico.Xperience.WebApp": "[30.9.0, )",
+          "Kentico.Xperience.Admin": "[30.9.1, )",
+          "Kentico.Xperience.WebApp": "[30.9.1, )",
           "Sidio.Sitemap.AspNetCore": "[2.7.6, )"
         }
       },

--- a/src/Goldfinch.Core/packages.lock.json
+++ b/src/Goldfinch.Core/packages.lock.json
@@ -4,12 +4,12 @@
     "net9.0": {
       "Kentico.Xperience.Admin": {
         "type": "Direct",
-        "requested": "[30.9.0, )",
-        "resolved": "30.9.0",
-        "contentHash": "PEfDS0v3ZRhRKEqza/kgAFSJQOSGXX3HSz1Bm7Kn7dKc0qYHtvPUH5sV2kBjJXSBfB0gubeWw1rghFy9JMzoYw==",
+        "requested": "[30.9.1, )",
+        "resolved": "30.9.1",
+        "contentHash": "qdw9WG8TT4gtmRRW2qVZGni2rJecYKAzvV5uQ9BseXRQ0aQdzL1mD1QxmqUBW07K8Yf9+2azEWP8ZRqntp3VsA==",
         "dependencies": {
           "Kentico.Aira.Client": "3.6.1",
-          "Kentico.Xperience.WebApp": "[30.9.0]",
+          "Kentico.Xperience.WebApp": "[30.9.1]",
           "Microsoft.AspNetCore.SpaServices.Extensions": "8.0.19",
           "Microsoft.Extensions.FileProviders.Embedded": "8.0.19",
           "Microsoft.SemanticKernel": "1.62.0",
@@ -19,15 +19,15 @@
       },
       "Kentico.Xperience.WebApp": {
         "type": "Direct",
-        "requested": "[30.9.0, )",
-        "resolved": "30.9.0",
-        "contentHash": "ECiq2eWZ//ndZnlSFKaI5HZYEdkg5cRa1F651r2M+8nhcnehULq8qzNQj+1mOL/7Cr6H+HTh0vWbv/K1yfD8Ww==",
+        "requested": "[30.9.1, )",
+        "resolved": "30.9.1",
+        "contentHash": "CrAIVnnaXnjmLVXOuk1kaHLmjqPQsg4rtPuAxxvIygvwOaTHIjZNxCj+DvyFUS7muZwPyQPj3IbCxIbS/JhL0A==",
         "dependencies": {
           "CommandLineParser": "2.9.1",
           "HotChocolate.AspNetCore": "15.0.3",
           "HotChocolate.Data": "15.0.3",
           "HtmlSanitizer": "9.0.886",
-          "Kentico.Xperience.Core": "[30.9.0]",
+          "Kentico.Xperience.Core": "[30.9.1]",
           "Microsoft.AspNetCore.Components": "8.0.19",
           "Microsoft.Extensions.Caching.Memory": "8.0.1",
           "Microsoft.Extensions.FileProviders.Embedded": "8.0.19"
@@ -470,12 +470,12 @@
       },
       "Kentico.Xperience.Core": {
         "type": "Transitive",
-        "resolved": "30.9.0",
-        "contentHash": "R71dxFHGuMm4epZQYvSk7GsYiVING7a6PR/fdNTbdhZ4r4zxU1VxowCuNCZP52D4iBY/UmdL//XAdSxuDfEa9A==",
+        "resolved": "30.9.1",
+        "contentHash": "jVyaYsP5sOq5wtz8kdsYzh3snRbYKjrmBEyMa9mgJQCuEeoj+0hcUXUKdozGPO9hGl3f/BWNwWxCLApXjtJo1w==",
         "dependencies": {
           "AngleSharp": "0.17.1",
           "Kentico.Aira.Client": "3.6.1",
-          "Magick.NET-Q8-AnyCPU": "14.7.0",
+          "Magick.NET-Q8-AnyCPU": "14.8.1",
           "MailKit": "4.13.0",
           "Microsoft.Data.SqlClient": "5.2.3",
           "Microsoft.Extensions.Caching.Memory": "8.0.1",
@@ -493,16 +493,16 @@
       },
       "Magick.NET-Q8-AnyCPU": {
         "type": "Transitive",
-        "resolved": "14.7.0",
-        "contentHash": "JQiOjOPXJar57Ew5YeD28zE1pbHpSKBYYQZBNkqhvXbLxCcTmu8djfVLKkqTcTAxFX/Mcj14j2RB+ORkCYD9Jw==",
+        "resolved": "14.8.1",
+        "contentHash": "Q8+Y2ht0w015IIgomYVUJl45uYIEUmG1fTQ/cwL9iHsQ5z6TBofLAkGD2trOpPEHQlpHK9qD837bN34Ak8VS1g==",
         "dependencies": {
-          "Magick.NET.Core": "14.7.0"
+          "Magick.NET.Core": "14.8.1"
         }
       },
       "Magick.NET.Core": {
         "type": "Transitive",
-        "resolved": "14.7.0",
-        "contentHash": "eXNEgZwUQ+QerJgIoAe9BlFolm3RzQ0k677AK5PLiLh701XQX1p878mt+jEQYJD58Jwcayto1UtFvtvnChyGyg=="
+        "resolved": "14.8.1",
+        "contentHash": "XkfFOOpak9Rsj6El18x3z+4Gr/W71uDQvoHz3WvEfZUUh32G2X6HC+r1VzR/DgUssvsbkDLr5a82/QCf7Xrbxw=="
       },
       "MailKit": {
         "type": "Transitive",

--- a/src/Goldfinch.Web/packages.lock.json
+++ b/src/Goldfinch.Web/packages.lock.json
@@ -4,12 +4,12 @@
     "net9.0": {
       "Kentico.Xperience.Admin": {
         "type": "Direct",
-        "requested": "[30.9.0, )",
-        "resolved": "30.9.0",
-        "contentHash": "PEfDS0v3ZRhRKEqza/kgAFSJQOSGXX3HSz1Bm7Kn7dKc0qYHtvPUH5sV2kBjJXSBfB0gubeWw1rghFy9JMzoYw==",
+        "requested": "[30.9.1, )",
+        "resolved": "30.9.1",
+        "contentHash": "qdw9WG8TT4gtmRRW2qVZGni2rJecYKAzvV5uQ9BseXRQ0aQdzL1mD1QxmqUBW07K8Yf9+2azEWP8ZRqntp3VsA==",
         "dependencies": {
           "Kentico.Aira.Client": "3.6.1",
-          "Kentico.Xperience.WebApp": "[30.9.0]",
+          "Kentico.Xperience.WebApp": "[30.9.1]",
           "Microsoft.AspNetCore.SpaServices.Extensions": "8.0.19",
           "Microsoft.Extensions.FileProviders.Embedded": "8.0.19",
           "Microsoft.SemanticKernel": "1.62.0",
@@ -19,12 +19,12 @@
       },
       "Kentico.Xperience.AzureStorage": {
         "type": "Direct",
-        "requested": "[30.9.0, )",
-        "resolved": "30.9.0",
-        "contentHash": "JYMMOXP6/EiH6N7OmB6AM4cDxKfb86oHydTt/KRwHRwS2+7Gax25ah7RPSjiWyM//9YzL2WmggSzQ4WpmDdANQ==",
+        "requested": "[30.9.1, )",
+        "resolved": "30.9.1",
+        "contentHash": "Hln3F/Rg/pFB2z1C9chKzp/YAY8qdDO1RZPhfDACUKtaSykVgzX6Xv7+jXYUT5PKadauDqiG52ndYu3btBi+jw==",
         "dependencies": {
           "Azure.Storage.Blobs": "12.25.0",
-          "Kentico.Xperience.Core": "30.9.0",
+          "Kentico.Xperience.Core": "30.9.1",
           "Newtonsoft.Json": "13.0.3",
           "System.IO.Hashing": "9.0.8"
         }
@@ -42,15 +42,15 @@
       },
       "Kentico.Xperience.WebApp": {
         "type": "Direct",
-        "requested": "[30.9.0, )",
-        "resolved": "30.9.0",
-        "contentHash": "ECiq2eWZ//ndZnlSFKaI5HZYEdkg5cRa1F651r2M+8nhcnehULq8qzNQj+1mOL/7Cr6H+HTh0vWbv/K1yfD8Ww==",
+        "requested": "[30.9.1, )",
+        "resolved": "30.9.1",
+        "contentHash": "CrAIVnnaXnjmLVXOuk1kaHLmjqPQsg4rtPuAxxvIygvwOaTHIjZNxCj+DvyFUS7muZwPyQPj3IbCxIbS/JhL0A==",
         "dependencies": {
           "CommandLineParser": "2.9.1",
           "HotChocolate.AspNetCore": "15.0.3",
           "HotChocolate.Data": "15.0.3",
           "HtmlSanitizer": "9.0.886",
-          "Kentico.Xperience.Core": "[30.9.0]",
+          "Kentico.Xperience.Core": "[30.9.1]",
           "Microsoft.AspNetCore.Components": "8.0.19",
           "Microsoft.Extensions.Caching.Memory": "8.0.1",
           "Microsoft.Extensions.FileProviders.Embedded": "8.0.19"
@@ -562,12 +562,12 @@
       },
       "Kentico.Xperience.Core": {
         "type": "Transitive",
-        "resolved": "30.9.0",
-        "contentHash": "R71dxFHGuMm4epZQYvSk7GsYiVING7a6PR/fdNTbdhZ4r4zxU1VxowCuNCZP52D4iBY/UmdL//XAdSxuDfEa9A==",
+        "resolved": "30.9.1",
+        "contentHash": "jVyaYsP5sOq5wtz8kdsYzh3snRbYKjrmBEyMa9mgJQCuEeoj+0hcUXUKdozGPO9hGl3f/BWNwWxCLApXjtJo1w==",
         "dependencies": {
           "AngleSharp": "0.17.1",
           "Kentico.Aira.Client": "3.6.1",
-          "Magick.NET-Q8-AnyCPU": "14.7.0",
+          "Magick.NET-Q8-AnyCPU": "14.8.1",
           "MailKit": "4.13.0",
           "Microsoft.Data.SqlClient": "5.2.3",
           "Microsoft.Extensions.Caching.Memory": "8.0.1",
@@ -585,16 +585,16 @@
       },
       "Magick.NET-Q8-AnyCPU": {
         "type": "Transitive",
-        "resolved": "14.7.0",
-        "contentHash": "JQiOjOPXJar57Ew5YeD28zE1pbHpSKBYYQZBNkqhvXbLxCcTmu8djfVLKkqTcTAxFX/Mcj14j2RB+ORkCYD9Jw==",
+        "resolved": "14.8.1",
+        "contentHash": "Q8+Y2ht0w015IIgomYVUJl45uYIEUmG1fTQ/cwL9iHsQ5z6TBofLAkGD2trOpPEHQlpHK9qD837bN34Ak8VS1g==",
         "dependencies": {
-          "Magick.NET.Core": "14.7.0"
+          "Magick.NET.Core": "14.8.1"
         }
       },
       "Magick.NET.Core": {
         "type": "Transitive",
-        "resolved": "14.7.0",
-        "contentHash": "eXNEgZwUQ+QerJgIoAe9BlFolm3RzQ0k677AK5PLiLh701XQX1p878mt+jEQYJD58Jwcayto1UtFvtvnChyGyg=="
+        "resolved": "14.8.1",
+        "contentHash": "XkfFOOpak9Rsj6El18x3z+4Gr/W71uDQvoHz3WvEfZUUh32G2X6HC+r1VzR/DgUssvsbkDLr5a82/QCf7Xrbxw=="
       },
       "MailKit": {
         "type": "Transitive",
@@ -1271,15 +1271,15 @@
         "type": "Project",
         "dependencies": {
           "Goldfinch.Core": "[1.0.0, )",
-          "Kentico.Xperience.Admin": "[30.9.0, )",
-          "Kentico.Xperience.WebApp": "[30.9.0, )"
+          "Kentico.Xperience.Admin": "[30.9.1, )",
+          "Kentico.Xperience.WebApp": "[30.9.1, )"
         }
       },
       "goldfinch.core": {
         "type": "Project",
         "dependencies": {
-          "Kentico.Xperience.Admin": "[30.9.0, )",
-          "Kentico.Xperience.WebApp": "[30.9.0, )",
+          "Kentico.Xperience.Admin": "[30.9.1, )",
+          "Kentico.Xperience.WebApp": "[30.9.1, )",
           "Sidio.Sitemap.AspNetCore": "[2.7.6, )"
         }
       }


### PR DESCRIPTION
This pull request updates several Kentico Xperience NuGet package dependencies across the solution to the latest patch version (30.9.1), and also updates the Magick.NET image processing libraries to version 14.8.1. These changes ensure that all projects are using the most recent bug fixes and improvements from these upstream packages.

**Dependency version updates:**

* Updated `Kentico.Xperience.Admin`, `Kentico.Xperience.AzureStorage`, and `Kentico.Xperience.WebApp` package references to version 30.9.1 in `Directory.Packages.props` and all affected `packages.lock.json` files. [[1]](diffhunk://#diff-5baf5f9e448ad54ab25a091adee0da05d4d228481c9200518fcb1b53a65d4156L9-R12) [[2]](diffhunk://#diff-10dcdf155f648344a7b4d2a5cbf963319d01ad54b00744b4a6eaf7cfebeb5efaL7-R12) [[3]](diffhunk://#diff-10dcdf155f648344a7b4d2a5cbf963319d01ad54b00744b4a6eaf7cfebeb5efaL22-R30) [[4]](diffhunk://#diff-d16291ef0536196c01f44cbba7cab4b51af63ce952019805c7b286e4a49ef474L7-R12) [[5]](diffhunk://#diff-d16291ef0536196c01f44cbba7cab4b51af63ce952019805c7b286e4a49ef474L22-R30) [[6]](diffhunk://#diff-0ba9626ad49cd3879a16417b11a7b29ddd987522a65e2862b0ea7421cbdd8ed7L7-R12) [[7]](diffhunk://#diff-0ba9626ad49cd3879a16417b11a7b29ddd987522a65e2862b0ea7421cbdd8ed7L22-R27) [[8]](diffhunk://#diff-0ba9626ad49cd3879a16417b11a7b29ddd987522a65e2862b0ea7421cbdd8ed7L45-R53)

**Transitive dependency updates:**

* Updated transitive dependency `Kentico.Xperience.Core` to version 30.9.1 wherever referenced, ensuring consistency with direct dependencies. [[1]](diffhunk://#diff-10dcdf155f648344a7b4d2a5cbf963319d01ad54b00744b4a6eaf7cfebeb5efaL22-R30) [[2]](diffhunk://#diff-10dcdf155f648344a7b4d2a5cbf963319d01ad54b00744b4a6eaf7cfebeb5efaL464-R469) [[3]](diffhunk://#diff-d16291ef0536196c01f44cbba7cab4b51af63ce952019805c7b286e4a49ef474L22-R30) [[4]](diffhunk://#diff-d16291ef0536196c01f44cbba7cab4b51af63ce952019805c7b286e4a49ef474L473-R478) [[5]](diffhunk://#diff-0ba9626ad49cd3879a16417b11a7b29ddd987522a65e2862b0ea7421cbdd8ed7L45-R53) [[6]](diffhunk://#diff-0ba9626ad49cd3879a16417b11a7b29ddd987522a65e2862b0ea7421cbdd8ed7L565-R570)
* Updated `Magick.NET-Q8-AnyCPU` and `Magick.NET.Core` to version 14.8.1 in all relevant lock files, bringing in the latest fixes and improvements for image processing. [[1]](diffhunk://#diff-10dcdf155f648344a7b4d2a5cbf963319d01ad54b00744b4a6eaf7cfebeb5efaL464-R469) [[2]](diffhunk://#diff-10dcdf155f648344a7b4d2a5cbf963319d01ad54b00744b4a6eaf7cfebeb5efaL487-R496) [[3]](diffhunk://#diff-d16291ef0536196c01f44cbba7cab4b51af63ce952019805c7b286e4a49ef474L473-R478) [[4]](diffhunk://#diff-d16291ef0536196c01f44cbba7cab4b51af63ce952019805c7b286e4a49ef474L496-R505) [[5]](diffhunk://#diff-0ba9626ad49cd3879a16417b11a7b29ddd987522a65e2862b0ea7421cbdd8ed7L565-R570) [[6]](diffhunk://#diff-0ba9626ad49cd3879a16417b11a7b29ddd987522a65e2862b0ea7421cbdd8ed7L588-R597)

**Project dependency alignment:**

* Updated project-level dependencies in `packages.lock.json` files to reference the new Kentico Xperience versions, ensuring all projects build against the updated libraries. [[1]](diffhunk://#diff-10dcdf155f648344a7b4d2a5cbf963319d01ad54b00744b4a6eaf7cfebeb5efaL1116-R1117) [[2]](diffhunk://#diff-0ba9626ad49cd3879a16417b11a7b29ddd987522a65e2862b0ea7421cbdd8ed7L1274-R1282)

These updates are important for keeping the codebase secure, stable, and compatible with upstream improvements.