### PR TITLE
Moved StorageInitializationModule

### DIFF
--- a/src/Goldfinch.Web/Infrastructure/Storage/StorageInitializationModule.cs
+++ b/src/Goldfinch.Web/Infrastructure/Storage/StorageInitializationModule.cs
@@ -2,14 +2,14 @@
 using CMS.Core;
 using CMS.DataEngine;
 using CMS.IO;
-using Goldfinch.Web;
+using Goldfinch.Web.Infrastructure.Storage;
 using Kentico.Xperience.AzureStorage;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Hosting;
 
 [assembly: RegisterModule(typeof(StorageInitializationModule))]
 
-namespace Goldfinch.Web;
+namespace Goldfinch.Web.Infrastructure.Storage;
 
 public class StorageInitializationModule : Module
 {


### PR DESCRIPTION
This pull request makes a minor change by moving the `StorageInitializationModule` class into a new namespace and directory for better organization. No functional changes were made.

* Moved `StorageInitializationModule` from the root namespace and directory to `Goldfinch.Web.Infrastructure.Storage`, renaming the file to reflect its new location.