### PR TITLE
Add localization and routing configurations

### DIFF
--- a/src/Goldfinch.Web/Program.cs
+++ b/src/Goldfinch.Web/Program.cs
@@ -5,6 +5,7 @@ using Kentico.Content.Web.Mvc.Routing;
 using Kentico.Membership;
 using Kentico.PageBuilder.Web.Mvc;
 using Kentico.Web.Mvc;
+using Kentico.Xperience.Admin.Base;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Routing;
@@ -47,6 +48,19 @@ builder.Services.AddAuthentication();
 // services.AddAuthorization();
 
 builder.Services.AddControllersWithViews();
+
+builder.Services.Configure<AdminLocalizationOptions>(options =>
+{
+    options.DefaultCultureCode = "en-GB";
+    options.SupportedCultures =
+    [
+        new AdminCulture
+        {
+            CultureCode = "en-GB",
+            DisplayName = "English (United Kingdom)",
+        },
+    ];
+});
 
 builder.Services.Configure<RouteOptions>(options =>
 {


### PR DESCRIPTION
This pull request introduces configuration for admin localization in the `Program.cs` file, ensuring the admin interface uses British English as the default and only supported culture. This change helps standardize the language and culture settings for all admin users.

Localization configuration:

* Added a configuration for `AdminLocalizationOptions` to set the default culture code to `en-GB` and restrict supported cultures to British English in `Program.cs`.
* Imported `Kentico.Xperience.Admin.Base` to enable admin localization configuration in `Program.cs`.