### PR TITLE
Refactor TrailingSlashMiddleware for improved handling

### DIFF
--- a/src/Goldfinch.Web/Middleware/TrailingSlashMiddleware.cs
+++ b/src/Goldfinch.Web/Middleware/TrailingSlashMiddleware.cs
@@ -82,8 +82,15 @@ public sealed class TrailingSlashMiddleware
         {
             // Build safe relative URL
             var target = UriHelper.BuildRelative(pathBase, newPath, query);
+            
+            // Enhanced safety check - ensure the target is truly relative and safe
+            if (!Uri.TryCreate(target, UriKind.Relative, out var uri))
+            {
+                await _next(context);
+                return;
+            }
 
-            // Additional safety check - ensure the target is relative
+            // Also check for double slash (protocol-relative) and must start with single slash
             if (!target.StartsWith('/') || target.StartsWith("//"))
             {
                 await _next(context);

--- a/src/Goldfinch.Web/Middleware/TrailingSlashMiddleware.cs
+++ b/src/Goldfinch.Web/Middleware/TrailingSlashMiddleware.cs
@@ -124,7 +124,8 @@ public sealed class TrailingSlashMiddleware
     /// </summary>
     private static bool LooksLikeFile(string path)
     {
-        var lastSegment = path.Split('/').LastOrDefault();
+        int lastSlash = path.LastIndexOf('/');
+        var lastSegment = lastSlash >= 0 ? path.Substring(lastSlash + 1) : path;
         return !string.IsNullOrEmpty(lastSegment) && lastSegment.Contains('.');
     }
 }

--- a/src/Goldfinch.Web/Program.cs
+++ b/src/Goldfinch.Web/Program.cs
@@ -100,6 +100,8 @@ builder.Services
     .AddHttpContextAccessor()
     .AddDefaultSitemapServices<HttpContextBaseUrlProvider>();
 
+builder.Services.AddTrailingSlash(builder.Configuration);
+
 var app = builder.Build();
 
 app.InitKentico();

--- a/src/Goldfinch.Web/appsettings.json
+++ b/src/Goldfinch.Web/appsettings.json
@@ -22,7 +22,7 @@
     }
   },
   "TrailingSlash": {
-    "Mode": 2
+    "Mode": "AlwaysRemove"
   },
   "ImageProcessing": {
     "ProcessMediaLibrary": false,


### PR DESCRIPTION
- Introduced `TrailingSlashMode` enum with three modes: `DoNothing`, `AlwaysAdd`, and `AlwaysRemove`.
- Added `TrailingSlashOptions` class for middleware configuration.
- Updated `TrailingSlashMiddleware` constructor to accept `IOptions<TrailingSlashOptions>`.
- Streamlined `InvokeAsync` method to utilize new options and added safety checks against open redirect vulnerabilities.
- Added `AddTrailingSlash` extension method for registering options in `IServiceCollection`.
- Updated `Program.cs` to configure middleware with settings from `appsettings.json`.
- Changed `TrailingSlash` mode in `appsettings.json` from numeric to string representation, setting it to `"AlwaysRemove"`.