### PR TITLE
Enable nullable reference types across the project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -379,3 +379,6 @@ src/Goldfinch.Web/App_Data/playwright
 # Continuous Deployment
 /src/Goldfinch.Web/$CDRepository
 DeploymentPackage.zip
+
+# Claude Code configuration
+.claude/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,181 @@
+# Claude Code Context
+
+This document provides context for Claude Code when working on the Goldfinch.me project.
+
+## Project Overview
+
+Goldfinch.me is a personal website/blog for Liam Goldfinch featuring articles about Kentico development and .NET technologies. The site is built on Xperience by Kentico (a content management system) with ASP.NET Core MVC.
+
+## Technology Stack
+
+- **Framework:** .NET 9.0
+- **CMS:** Xperience by Kentico
+- **Frontend:** Tailwind CSS, Vite, React (admin customizations)
+- **Storage:** Azure Blob Storage (production), local filesystem (development)
+- **Database:** Microsoft SQL Server
+
+### Key NuGet Packages
+
+- `Kentico.Xperience.WebApp` - Core Kentico framework
+- `Kentico.Xperience.Admin` - Admin interface
+- `Kentico.Xperience.AzureStorage` - Azure blob storage integration
+- `Schema.NET` - Structured data/schema markup
+- `Sidio.Sitemap.AspNetCore` - XML sitemap generation
+- `SixLabors.ImageSharp` - Image processing
+
+## Project Structure
+
+```
+src/
+├── Goldfinch.Core/          # Shared business logic & data models
+│   ├── BlogPosts/           # Blog post repository & models
+│   ├── ContentTypes/        # Kentico content type definitions
+│   ├── MediaAssets/         # Media/asset management
+│   ├── PublicSpeaking/      # Speaking engagement functionality
+│   ├── SEO/                 # SEO models (breadcrumbs, meta fields)
+│   └── Sitemap/             # Sitemap generation logic
+├── Goldfinch.Admin/         # Kentico admin customizations
+└── Goldfinch.Web/           # Main web application
+    ├── Components/
+    │   ├── ViewComponents/  # Reusable view components (Header, SEO, etc.)
+    │   └── Widgets/         # Page builder widgets (Image, Video, CodeBlock, etc.)
+    ├── Features/            # Feature-based organization
+    │   ├── BlogDetail/      # Blog post detail pages
+    │   ├── BlogList/        # Blog listing/pagination
+    │   ├── ErrorPage/       # Error page handling (404, 500)
+    │   └── PublicSpeakingPage/
+    └── Infrastructure/      # Cross-cutting concerns (storage, etc.)
+```
+
+## Architecture & Patterns
+
+### Content Management
+
+- **Kentico Content Types:** Defined in `Goldfinch.Core/ContentTypes/`
+- **Repository Pattern:** Data access is abstracted through repository classes (e.g., `BlogPostRepository`, `ErrorPageRepository`)
+- **Progressive Caching:** All repositories use Kentico's `IProgressiveCache` for performance
+- **CI/CD:** Uses Kentico's Continuous Integration system - objects stored as serialized files in `App_Data/CIRepository/`
+
+### Web Layer
+
+- **Feature Folders:** Organized by feature rather than technical layer
+- **View Components:** Used extensively for reusable UI components
+- **Page Builder:** Kentico's page builder with custom widgets for content editing
+- **Controllers:** MVC controllers handle routing and orchestrate repositories/view models
+
+### Data Access Patterns
+
+All repository methods that use `FirstOrDefault()` return nullable types:
+
+```csharp
+public async Task<BlogPost?> GetBlogPost(int webPageItemID)
+{
+    return await ProgressiveCache.LoadAsync(async (cs) =>
+    {
+        var pages = await Executor.GetMappedWebPageResult<BlogPost>(queryBuilder);
+        return pages.FirstOrDefault(); // Can be null
+    }, cacheSettings);
+}
+```
+
+Calling code must handle null returns appropriately.
+
+## Code Conventions
+
+### Nullable Reference Types
+
+- **Enabled project-wide** as of 2025 (see `Directory.Build.props`)
+- Use `required` modifier for essential properties that must be set during initialization
+- Use default values (e.g., `string.Empty`) for optional properties
+- Repository methods returning `FirstOrDefault()` should have nullable return types
+
+### View Models
+
+```csharp
+public class BlogPostViewModel
+{
+    public required string Title { get; set; }        // Essential - required
+    public required string Url { get; set; }          // Essential - required
+    public string Schema { get; set; } = string.Empty; // Optional - default value
+}
+```
+
+### Naming Conventions
+
+- **Repositories:** `{EntityName}Repository` (e.g., `BlogPostRepository`)
+- **ViewModels:** `{Feature}ViewModel` (e.g., `BlogPostViewModel`)
+- **View Components:** `{Name}ViewComponent` (e.g., `HeaderViewComponent`)
+- **Widgets:** `{Name}Widget` (e.g., `ImageWidget`)
+
+### Project Settings
+
+- **Target Framework:** net9.0
+- **Nullable:** enable
+- **ImplicitUsings:** disable (explicit usings required)
+- **WarningsAsErrors:** nullable
+
+## Common Tasks
+
+### Adding a New Content Type
+
+1. Define in Kentico admin UI
+2. Create strongly-typed class in `Goldfinch.Core/ContentTypes/`
+3. Create repository in appropriate folder (e.g., `BlogPosts/BlogPostRepository.cs`)
+4. Inherit from `WebPageRepository` for web page types
+
+### Adding a New Widget
+
+1. Create folder in `Goldfinch.Web/Components/Widgets/{WidgetName}/`
+2. Create `{WidgetName}WidgetProperties.cs` (IWidgetProperties)
+3. Create `{WidgetName}WidgetViewModel.cs`
+4. Create `{WidgetName}WidgetViewComponent.cs` (ViewComponent)
+5. Create `{WidgetName}Widget.cshtml` (view)
+6. Register with `[RegisterWidget]` attribute
+
+### Running the Project
+
+```bash
+# First time setup - restore CI objects
+cd src/Goldfinch.Web
+dotnet run --kxp-ci-restore
+
+# Normal development
+dotnet run
+```
+
+**Local URL:** https://localhost:52623
+
+**Admin Login:** admin / Test123! (local only)
+
+## Testing & Build
+
+- Build command: `dotnet build`
+- No automated tests currently in the project
+- Manual testing via local environment
+
+## Deployment
+
+- **Production:** https://www.goldfinch.me
+- Uses Azure Blob Storage for media assets in production
+- Continuous Deployment via Kentico CI/CD system
+
+## Important Notes
+
+- **No database backups in repo** - use CI files to restore Kentico objects
+- **Connection strings** stored in `connectionstrings.json` (gitignored)
+- **Do not commit** `.claude/` directory (in .gitignore)
+- **Admin credentials** in README are for local development only
+- **Contributions** not expected - personal project
+
+## Git Workflow
+
+- Main branch: `main`
+- Feature branches: `feature/{feature-name}`
+- Recent work: Enabled nullable reference types across entire project
+
+## Contact & Resources
+
+- **Author:** Liam Goldfinch
+- **Website:** https://www.goldfinch.me
+- **License:** MIT
+- **Kentico Docs:** https://docs.kentico.com/x/6wocCQ

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -3,7 +3,7 @@
 
 	<PropertyGroup>
 		<TargetFramework>net9.0</TargetFramework>
-		<Nullable>disable</Nullable>
+		<Nullable>enable</Nullable>
 		<WarningsAsErrors>nullable</WarningsAsErrors>
 		<ImplicitUsings>disable</ImplicitUsings>
 		<NoWarn>$(NoWarn)</NoWarn>

--- a/src/Goldfinch.Core/BlogListings/BlogListingRepository.cs
+++ b/src/Goldfinch.Core/BlogListings/BlogListingRepository.cs
@@ -14,7 +14,7 @@ public class BlogListingRepository : WebPageRepository
     {
     }
 
-    public async Task<BlogListing> GetBlogListing()
+    public async Task<BlogListing?> GetBlogListing()
     {
         return await ProgressiveCache.LoadAsync(async (cs) =>
         {

--- a/src/Goldfinch.Core/BlogPosts/BlogPostRepository.cs
+++ b/src/Goldfinch.Core/BlogPosts/BlogPostRepository.cs
@@ -21,7 +21,7 @@ public class BlogPostRepository : WebPageRepository
     {
     }
 
-    public async Task<BlogPost> GetBlogPost(int webPageItemID)
+    public async Task<BlogPost?> GetBlogPost(int webPageItemID)
     {
         return await ProgressiveCache.LoadAsync(async (cs) =>
         {

--- a/src/Goldfinch.Core/ErrorPages/ErrorPageRepository.cs
+++ b/src/Goldfinch.Core/ErrorPages/ErrorPageRepository.cs
@@ -14,7 +14,7 @@ public class ErrorPageRepository : WebPageRepository
     {
     }
 
-    public async Task<ErrorPage> GetErrorPage(int webPageItemID)
+    public async Task<ErrorPage?> GetErrorPage(int webPageItemID)
     {
         return await ProgressiveCache.LoadAsync(async (cs) =>
         {
@@ -35,7 +35,7 @@ public class ErrorPageRepository : WebPageRepository
     /// <summary>
     ///     Returns the site 404 error page document.
     /// </summary>
-    public async Task<ErrorPage> Get404Page()
+    public async Task<ErrorPage?> Get404Page()
     {
         return await ProgressiveCache.LoadAsync(async (cs) =>
         {
@@ -56,7 +56,7 @@ public class ErrorPageRepository : WebPageRepository
     /// <summary>
     ///     Returns the site 500 error page document.
     /// </summary>
-    public async Task<ErrorPage> Get500Page()
+    public async Task<ErrorPage?> Get500Page()
     {
         return await ProgressiveCache.LoadAsync(async (cs) =>
         {

--- a/src/Goldfinch.Core/HomePages/HomeRepository.cs
+++ b/src/Goldfinch.Core/HomePages/HomeRepository.cs
@@ -14,7 +14,7 @@ public class HomeRepository : WebPageRepository
     {
     }
 
-    public async Task<Home> GetHome()
+    public async Task<Home?> GetHome()
     {
         return await ProgressiveCache.LoadAsync(async (cs) =>
         {

--- a/src/Goldfinch.Core/InnerPages/InnerPageRepository.cs
+++ b/src/Goldfinch.Core/InnerPages/InnerPageRepository.cs
@@ -15,7 +15,7 @@ public class InnerPageRepository : WebPageRepository
     {
     }
 
-    public async Task<InnerPage> GetInnerPage(int webPageItemID)
+    public async Task<InnerPage?> GetInnerPage(int webPageItemID)
     {
         return await ProgressiveCache.LoadAsync(async (cs) =>
         {

--- a/src/Goldfinch.Core/MediaAssets/MediaAssetRepository.cs
+++ b/src/Goldfinch.Core/MediaAssets/MediaAssetRepository.cs
@@ -18,7 +18,7 @@ public class MediaAssetRepository
         _executor = executor;
     }
 
-    public async Task<MediaAssetContent> GetMediaAssetContent(Guid identifier)
+    public async Task<MediaAssetContent?> GetMediaAssetContent(Guid identifier)
     {
         return await _progressiveCache.LoadAsync(async cs =>
         {

--- a/src/Goldfinch.Core/PublicSpeaking/PublicSpeakingModel.cs
+++ b/src/Goldfinch.Core/PublicSpeaking/PublicSpeakingModel.cs
@@ -5,14 +5,14 @@ namespace Goldfinch.Core.PublicSpeaking;
 
 public class PublicSpeakingModel
 {
-    public PublicSpeakingPage Page { get; set; }
+    public required PublicSpeakingPage Page { get; set; }
 
-    public IReadOnlyList<SpeakingEngagementYear> Years { get; set; }
+    public required IReadOnlyList<SpeakingEngagementYear> Years { get; set; }
 }
 
 public class SpeakingEngagementYear
 {
     public int Year { get; set; }
 
-    public IReadOnlyList<SpeakingEngagement> SpeakingEngagements { get; set; }
+    public required IReadOnlyList<SpeakingEngagement> SpeakingEngagements { get; set; }
 }

--- a/src/Goldfinch.Core/PublicSpeaking/PublicSpeakingRepository.cs
+++ b/src/Goldfinch.Core/PublicSpeaking/PublicSpeakingRepository.cs
@@ -14,7 +14,7 @@ public class PublicSpeakingRepository : WebPageRepository
     {
     }
 
-    public async Task<PublicSpeakingModel> GetPublicSpeakingPage(int webPageItemID)
+    public async Task<PublicSpeakingModel?> GetPublicSpeakingPage(int webPageItemID)
     {
         return await ProgressiveCache.LoadAsync(async (cs) =>
         {
@@ -28,6 +28,11 @@ public class PublicSpeakingRepository : WebPageRepository
             var pages = await Executor.GetMappedWebPageResult<PublicSpeakingPage>(queryBuilder);
 
             var listingPage = pages.FirstOrDefault();
+
+            if (listingPage == null)
+            {
+                return null;
+            }
 
             queryBuilder = new ContentItemQueryBuilder()
                 .ForContentType(SpeakingEngagement.CONTENT_TYPE_NAME);

--- a/src/Goldfinch.Core/SEO/Models/Breadcrumbs.cs
+++ b/src/Goldfinch.Core/SEO/Models/Breadcrumbs.cs
@@ -2,9 +2,9 @@
 {
     public class Breadcrumb
     {
-        public string Name { get; set; }
+        public required string Name { get; set; }
 
-        public string Url { get; set; }
+        public required string Url { get; set; }
 
         public int Position { get; set; }
     }

--- a/src/Goldfinch.Core/SEO/Models/SeoPageFields.cs
+++ b/src/Goldfinch.Core/SEO/Models/SeoPageFields.cs
@@ -7,31 +7,31 @@ public class SeoPageFields : ISeoFields, IBaseContentFields
     /// <summary>
     /// SeoTitle.
     /// </summary>
-    public string SeoTitle { get; set; }
+    public required string SeoTitle { get; set; }
 
 
     /// <summary>
     /// SeoShortDescription.
     /// </summary>
-    public string SeoShortDescription { get; set; }
+    public required string SeoShortDescription { get; set; }
 
 
     /// <summary>
     /// SeoCanonicalUrl.
     /// </summary>
-    public string SeoCanonicalUrl { get; set; }
+    public required string SeoCanonicalUrl { get; set; }
 
 
     /// <summary>
     /// BaseContentTitle.
     /// </summary>
-    public string BaseContentTitle { get; set; }
+    public required string BaseContentTitle { get; set; }
 
 
     /// <summary>
     /// BaseContentShortDescription.
     /// </summary>
-    public string BaseContentShortDescription { get; set; }
+    public required string BaseContentShortDescription { get; set; }
 
 
     public string MetaTitle => string.IsNullOrWhiteSpace(SeoTitle) ? BaseContentTitle : SeoTitle;

--- a/src/Goldfinch.Core/Sitemap/SitemapRepository.cs
+++ b/src/Goldfinch.Core/Sitemap/SitemapRepository.cs
@@ -65,7 +65,7 @@ public class SitemapRepository : WebPageRepository
                 .WhereEquals(nameof(ContentItemLanguageMetadataInfo.ContentItemLanguageMetadataContentItemID), page.SystemFields.ContentItemID)
                 .FirstOrDefault();
 
-            var lastModified = metadata.ContentItemLanguageMetadataModifiedWhen;
+            var lastModified = metadata?.ContentItemLanguageMetadataModifiedWhen ?? DateTime.UtcNow;
 
             sitemapNodes.Add(new SitemapNode(absoluteUrl)
             {

--- a/src/Goldfinch.Web/Components/ViewComponents/Canonical/CanonicalViewModel.cs
+++ b/src/Goldfinch.Web/Components/ViewComponents/Canonical/CanonicalViewModel.cs
@@ -2,10 +2,10 @@
 {
     public class CanonicalViewModel
     {
-        public string CanonicalUrl { get; set; }
+        public string CanonicalUrl { get; set; } = string.Empty;
 
-        public string PreviousUrl { get; set; }
+        public string PreviousUrl { get; set; } = string.Empty;
 
-        public string NextUrl { get; set; }
+        public string NextUrl { get; set; } = string.Empty;
     }
 }

--- a/src/Goldfinch.Web/Components/ViewComponents/Header/HeaderViewModel.cs
+++ b/src/Goldfinch.Web/Components/ViewComponents/Header/HeaderViewModel.cs
@@ -4,14 +4,14 @@ namespace Goldfinch.Web.Components.ViewComponents.Header
 {
     public class HeaderViewModel
     {
-        public ICollection<NavigationItem> NavigationItems { get; set; }
+        public ICollection<NavigationItem> NavigationItems { get; set; } = [];
     }
 
     public class NavigationItem
     {
-        public string Title { get; set; }
+        public required string Title { get; set; }
 
-        public string Url { get; set; }
+        public required string Url { get; set; }
 
         public bool IsActive { get; set; }
     }

--- a/src/Goldfinch.Web/Components/ViewComponents/LatestBlogPosts/LatestBlogPostsViewModel.cs
+++ b/src/Goldfinch.Web/Components/ViewComponents/LatestBlogPosts/LatestBlogPostsViewModel.cs
@@ -5,8 +5,8 @@ namespace Goldfinch.Web.Components.ViewComponents.LatestBlogPosts
 {
     public class LatestBlogPostsViewModel
     {
-        public string Title { get; set; }
+        public required string Title { get; set; }
 
-        public ICollection<BlogPostViewModel> BlogPosts { get; set; }
+        public ICollection<BlogPostViewModel> BlogPosts { get; set; } = [];
     }
 }

--- a/src/Goldfinch.Web/Components/ViewComponents/PageTitle/PageTitleViewModel.cs
+++ b/src/Goldfinch.Web/Components/ViewComponents/PageTitle/PageTitleViewModel.cs
@@ -2,6 +2,6 @@
 {
     public class PageTitleViewModel
     {
-        public string Title { get; set; }
+        public required string Title { get; set; }
     }
 }

--- a/src/Goldfinch.Web/Components/ViewComponents/SEO/SEOViewModel.cs
+++ b/src/Goldfinch.Web/Components/ViewComponents/SEO/SEOViewModel.cs
@@ -2,16 +2,16 @@
 {
     public class SEOViewModel
     {
-        public string Title { get; set; }
+        public required string Title { get; set; }
 
-        public string Description { get; set; }
+        public required string Description { get; set; }
 
-        public string ContentType { get; set; }
+        public required string ContentType { get; set; }
 
-        public string Image { get; set; }
+        public string Image { get; set; } = string.Empty;
 
-        public string Url { get; set; }
+        public required string Url { get; set; }
 
-        public string Schema { get; set; }
+        public string Schema { get; set; } = string.Empty;
     }
 }

--- a/src/Goldfinch.Web/Components/Widgets/CodeBlock/CodeBlockWidgetProperties.cs
+++ b/src/Goldfinch.Web/Components/Widgets/CodeBlock/CodeBlockWidgetProperties.cs
@@ -11,6 +11,6 @@ namespace Goldfinch.Web.Components.Widgets.CodeBlock
         public string Language { get; set; } = "csharp";
 
         [TextAreaComponent(Label = "Code", Order = 2)]
-        public string Code { get; set; }
+        public string Code { get; set; } = string.Empty;
     }
 }

--- a/src/Goldfinch.Web/Components/Widgets/CodeBlock/CodeBlockWidgetViewModel.cs
+++ b/src/Goldfinch.Web/Components/Widgets/CodeBlock/CodeBlockWidgetViewModel.cs
@@ -2,8 +2,8 @@
 {
     public class CodeBlockWidgetViewModel
     {
-        public string CodeClassName { get; set; }
+        public required string CodeClassName { get; set; }
 
-        public string CodeText { get; set; }
+        public required string CodeText { get; set; }
     }
 }

--- a/src/Goldfinch.Web/Components/Widgets/Image/ImageWidgetViewComponent.cs
+++ b/src/Goldfinch.Web/Components/Widgets/Image/ImageWidgetViewComponent.cs
@@ -25,7 +25,14 @@ namespace Goldfinch.Web.Components.Widgets.Image
         {
             var viewModel = new ImageWidgetViewModel
             {
-                ImageSet = null,
+                ImageSet = new ImageWidgetImageSet
+                {
+                    FullWidthUrl = string.Empty,
+                    Width480Url = string.Empty,
+                    Width800Url = string.Empty,
+                    Width1000Url = string.Empty,
+                },
+                Description = string.Empty,
             };
 
             if (properties.SelectedAssets.Any())

--- a/src/Goldfinch.Web/Components/Widgets/Image/ImageWidgetViewModel.cs
+++ b/src/Goldfinch.Web/Components/Widgets/Image/ImageWidgetViewModel.cs
@@ -2,19 +2,19 @@
 {
     public class ImageWidgetViewModel
     {
-        public ImageWidgetImageSet ImageSet { get; set; }
+        public required ImageWidgetImageSet ImageSet { get; set; }
 
-        public string Description { get; set; }
+        public string Description { get; set; } = string.Empty;
     }
 
     public class ImageWidgetImageSet
     {
-        public string FullWidthUrl { get; set; }
+        public required string FullWidthUrl { get; set; }
 
-        public string Width480Url { get; set; }
+        public required string Width480Url { get; set; }
 
-        public string Width800Url { get; set; }
+        public required string Width800Url { get; set; }
 
-        public string Width1000Url { get; set; }
+        public required string Width1000Url { get; set; }
     }
 }

--- a/src/Goldfinch.Web/Components/Widgets/Video/VideoWidgetViewComponent.cs
+++ b/src/Goldfinch.Web/Components/Widgets/Video/VideoWidgetViewComponent.cs
@@ -25,7 +25,7 @@ namespace Goldfinch.Web.Components.Widgets.Video
         {
             var viewModel = new VideoWidgetViewModel
             {
-                VideoUrl = null,
+                VideoUrl = string.Empty,
             };
 
             if (properties.SelectedAssets.Any())
@@ -43,7 +43,7 @@ namespace Goldfinch.Web.Components.Widgets.Video
                         {
                             VideoUrl = url,
                             Description = mediaFile.MediaAssetContentShortDescription,
-                            PosterImage = mediaFile.MediaAssetContentPosterImage?.Url,
+                            PosterImage = mediaFile.MediaAssetContentPosterImage?.Url ?? string.Empty,
                         };
 
                         return View(ViewName, viewModel);

--- a/src/Goldfinch.Web/Components/Widgets/Video/VideoWidgetViewComponent.cs
+++ b/src/Goldfinch.Web/Components/Widgets/Video/VideoWidgetViewComponent.cs
@@ -23,10 +23,7 @@ namespace Goldfinch.Web.Components.Widgets.Video
 
         public async Task<IViewComponentResult> InvokeAsync(VideoWidgetProperties properties)
         {
-            var viewModel = new VideoWidgetViewModel
-            {
-                VideoUrl = string.Empty,
-            };
+            var viewModel = new VideoWidgetViewModel();
 
             if (properties.SelectedAssets.Any())
             {
@@ -37,16 +34,9 @@ namespace Goldfinch.Web.Components.Widgets.Video
                     var mediaFile = await _mediaAssetRepository.GetMediaAssetContent(asset.Identifier);
                     if (mediaFile != null)
                     {
-                        var url = mediaFile.MediaAssetContentAsset.Url;
-
-                        viewModel = new VideoWidgetViewModel
-                        {
-                            VideoUrl = url,
-                            Description = mediaFile.MediaAssetContentShortDescription,
-                            PosterImage = mediaFile.MediaAssetContentPosterImage?.Url ?? string.Empty,
-                        };
-
-                        return View(ViewName, viewModel);
+                        viewModel.VideoUrl = mediaFile.MediaAssetContentAsset.Url;
+                        viewModel.Description = mediaFile.MediaAssetContentShortDescription;
+                        viewModel.PosterImage = mediaFile.MediaAssetContentPosterImage?.Url ?? string.Empty;
                     }
                 }
             }

--- a/src/Goldfinch.Web/Components/Widgets/Video/VideoWidgetViewModel.cs
+++ b/src/Goldfinch.Web/Components/Widgets/Video/VideoWidgetViewModel.cs
@@ -2,7 +2,7 @@
 {
     public class VideoWidgetViewModel
     {
-        public required string VideoUrl { get; set; }
+        public string? VideoUrl { get; set; }
 
         public string PosterImage { get; set; } = string.Empty;
 

--- a/src/Goldfinch.Web/Components/Widgets/Video/VideoWidgetViewModel.cs
+++ b/src/Goldfinch.Web/Components/Widgets/Video/VideoWidgetViewModel.cs
@@ -2,10 +2,10 @@
 {
     public class VideoWidgetViewModel
     {
-        public string VideoUrl { get; set; }
+        public required string VideoUrl { get; set; }
 
-        public string PosterImage { get; set; }
+        public string PosterImage { get; set; } = string.Empty;
 
-        public string Description { get; set; }
+        public string Description { get; set; } = string.Empty;
     }
 }

--- a/src/Goldfinch.Web/Components/Widgets/YouTubeVideo/YouTubeVideoWidgetProperties.cs
+++ b/src/Goldfinch.Web/Components/Widgets/YouTubeVideo/YouTubeVideoWidgetProperties.cs
@@ -6,6 +6,6 @@ namespace Goldfinch.Web.Components.Widgets.YouTubeVideo
     public class YouTubeVideoWidgetProperties : IWidgetProperties
     {
         [TextInputComponent(Label = "YouTube Video ID", Order = 1)]
-        public string VideoId { get; set; }
+        public string VideoId { get; set; } = string.Empty;
     }
 }

--- a/src/Goldfinch.Web/Components/Widgets/YouTubeVideo/YouTubeVideoWidgetViewModel.cs
+++ b/src/Goldfinch.Web/Components/Widgets/YouTubeVideo/YouTubeVideoWidgetViewModel.cs
@@ -2,6 +2,6 @@
 {
     public class YouTubeVideoWidgetViewModel
     {
-        public string VideoId { get; set; }
+        public required string VideoId { get; set; }
     }
 }

--- a/src/Goldfinch.Web/Features/BlogDetail/BlogDetailController.cs
+++ b/src/Goldfinch.Web/Features/BlogDetail/BlogDetailController.cs
@@ -41,6 +41,11 @@ public class BlogDetailController : Controller
 
         var currentPage = await _blogPostRepository.GetBlogPost(page.WebPageItemID);
 
+        if (currentPage == null)
+        {
+            return NotFound();
+        }
+
         var viewModel = await BlogPostViewModel.GetViewModelAsync(currentPage, _webPageUrlRetriever);
 
         viewModel.Schema = GetSchema(viewModel);

--- a/src/Goldfinch.Web/Features/BlogDetail/BlogPostViewModel.cs
+++ b/src/Goldfinch.Web/Features/BlogDetail/BlogPostViewModel.cs
@@ -7,15 +7,15 @@ namespace Goldfinch.Web.Features.BlogDetail;
 
 public class BlogPostViewModel
 {
-    public string Title { get; private set; }
+    public required string Title { get; set; }
 
-    public string Summary { get; private set; }
+    public required string Summary { get; set; }
 
-    public string Url { get; private set; }
+    public required string Url { get; set; }
 
-    public DateTime BlogPostDate { get; private set; }
+    public DateTime BlogPostDate { get; set; }
 
-    public string Schema { get; set; }
+    public string Schema { get; set; } = string.Empty;
 
     public static async Task<BlogPostViewModel> GetViewModelAsync(BlogPost blogPost, IWebPageUrlRetriever pageUrlRetriever)
     {

--- a/src/Goldfinch.Web/Features/BlogList/BlogListController.cs
+++ b/src/Goldfinch.Web/Features/BlogList/BlogListController.cs
@@ -55,7 +55,13 @@ namespace Goldfinch.Web.Features.BlogList
             {
                 return NotFound();
             }
+
             var blogListing = await _blogListingRepository.GetBlogListing();
+
+            if (blogListing == null)
+            {
+                return NotFound();
+            }
 
             var languageName = _preferredLanguageRetriever.Get();
 

--- a/src/Goldfinch.Web/Features/BlogList/BlogListViewModel.cs
+++ b/src/Goldfinch.Web/Features/BlogList/BlogListViewModel.cs
@@ -8,21 +8,21 @@ namespace Goldfinch.Web.Features.BlogList
 {
     public class BlogListViewModel
     {
-        public string Title { get; private set; }
+        public required string Title { get; set; }
 
-        public string Url { get; private set; }
+        public required string Url { get; set; }
 
-        public string PreviousUrl { get; set; }
+        public string PreviousUrl { get; set; } = string.Empty;
 
-        public string NextUrl { get; set; }
+        public string NextUrl { get; set; } = string.Empty;
 
-        public int PageIndex { get; private set; }
+        public int PageIndex { get; set; }
 
-        public int PageCount { get; private set; }
+        public int PageCount { get; set; }
 
         public ICollection<BlogPostViewModel> BlogPosts { get; set; } = [];
 
-        public string Schema { get; set; }
+        public string Schema { get; set; } = string.Empty;
 
         public static async Task<BlogListViewModel> GetViewModelAsync(BlogListing blogListing, IWebPageUrlRetriever pageUrlRetriever, int pageIndex, int pageCount)
         {

--- a/src/Goldfinch.Web/Features/ErrorPage/HttpErrorsController.cs
+++ b/src/Goldfinch.Web/Features/ErrorPage/HttpErrorsController.cs
@@ -25,7 +25,7 @@ namespace Goldfinch.Web.Features.ErrorPage
 
         public async Task<IActionResult> ErrorAsync(int code)
         {
-            Core.ContentTypes.ErrorPage errorPage;
+            Core.ContentTypes.ErrorPage? errorPage;
 
             switch (code)
             {

--- a/src/Goldfinch.Web/Infrastructure/Storage/StorageInitializationModule.cs
+++ b/src/Goldfinch.Web/Infrastructure/Storage/StorageInitializationModule.cs
@@ -13,18 +13,23 @@ namespace Goldfinch.Web.Infrastructure.Storage;
 
 public class StorageInitializationModule : Module
 {
-    private readonly IWebHostEnvironment _environment;
+    private IWebHostEnvironment? _environment;
 
     public StorageInitializationModule()
          : base(nameof(StorageInitializationModule))
     {
-        _environment = Service.Resolve<IWebHostEnvironment>();
     }
 
     /// <summary>
     /// Gets the web hosting environment information.
     /// </summary>
-    public IWebHostEnvironment Environment => _environment;
+    public IWebHostEnvironment Environment
+    {
+        get
+        {
+            return _environment ??= Service.Resolve<IWebHostEnvironment>();
+        }
+    }
 
     protected override void OnInit()
     {

--- a/src/Goldfinch.Web/Infrastructure/Storage/StorageInitializationModule.cs
+++ b/src/Goldfinch.Web/Infrastructure/Storage/StorageInitializationModule.cs
@@ -13,7 +13,7 @@ namespace Goldfinch.Web.Infrastructure.Storage;
 
 public class StorageInitializationModule : Module
 {
-    private IWebHostEnvironment _environment;
+    private IWebHostEnvironment? _environment;
 
     /// <summary>
     /// Gets the web hosting environment information.

--- a/src/Goldfinch.Web/Infrastructure/Storage/StorageInitializationModule.cs
+++ b/src/Goldfinch.Web/Infrastructure/Storage/StorageInitializationModule.cs
@@ -13,23 +13,18 @@ namespace Goldfinch.Web.Infrastructure.Storage;
 
 public class StorageInitializationModule : Module
 {
-    private IWebHostEnvironment? _environment;
-
-    /// <summary>
-    /// Gets the web hosting environment information.
-    /// </summary>
-    public IWebHostEnvironment Environment
-    {
-        get
-        {
-            return _environment ??= Service.Resolve<IWebHostEnvironment>();
-        }
-    }
+    private readonly IWebHostEnvironment _environment;
 
     public StorageInitializationModule()
          : base(nameof(StorageInitializationModule))
     {
+        _environment = Service.Resolve<IWebHostEnvironment>();
     }
+
+    /// <summary>
+    /// Gets the web hosting environment information.
+    /// </summary>
+    public IWebHostEnvironment Environment => _environment;
 
     protected override void OnInit()
     {


### PR DESCRIPTION
## Summary

- Enabled nullable reference types project-wide in Directory.Build.props
- Updated all view models to properly handle nullable properties using `required` modifier and default values
- Fixed repository return types to be nullable where `FirstOrDefault()` is used
- Added null checks in controllers to handle missing data scenarios
- Added CLAUDE.md documentation for AI assistant context
- Updated .gitignore to exclude .claude/ directory

## Changes by Area

### Configuration
- Enabled `<Nullable>enable</Nullable>` in Directory.Build.props

### Repositories
- Updated return types to nullable for methods using `FirstOrDefault()`
- Affected: BlogPostRepository, BlogListingRepository, ErrorPageRepository, HomeRepository, InnerPageRepository, MediaAssetRepository, PublicSpeakingRepository, SitemapRepository

### View Models
- Applied `required` modifier to essential properties
- Added default values (e.g., `string.Empty`) for optional properties
- Affected: BlogPostViewModel, BlogListViewModel, SEOViewModel, HeaderViewModel, CanonicalViewModel, PageTitleViewModel, and all widget view models

### Controllers
- Added null checks and appropriate responses for missing content
- Affected: BlogDetailController, BlogListController, HttpErrorsController

### SEO Models
- Updated Breadcrumbs and SeoPageFields models with proper nullable annotations

## Test Plan

- [x] Project builds without warnings
- [x] All nullable warnings treated as errors and resolved
- [x] Local development environment tested
- [x] Verify blog listing pages work correctly
- [x] Verify blog detail pages handle missing content gracefully
- [x] Verify error pages (404/500) display correctly
- [x] Verify admin interface functions properly

🤖 Generated with [Claude Code](https://claude.com/claude-code)