### PR TITLE
Add E2E smoke tests with Playwright

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -9,6 +9,7 @@ on:
 
 permissions:
   contents: read
+  checks: write
 
 jobs:
   e2e-tests:
@@ -42,9 +43,18 @@ jobs:
         run: sleep 60
 
       - name: Run E2E smoke tests against production
-        run: dotnet test tests/Goldfinch.Tests.E2E/Goldfinch.Tests.E2E.csproj --configuration Release --no-build --filter "Category=Smoke" --logger "trx;LogFileName=test-results.trx"
+        run: dotnet test tests/Goldfinch.Tests.E2E/Goldfinch.Tests.E2E.csproj --configuration Release --no-build --filter "Category=Smoke" --logger "trx;LogFileName=test-results.trx" --logger "console;verbosity=detailed"
         env:
           BASE_URL: 'https://www.goldfinch.me'
+
+      - name: Publish test results
+        if: always()
+        uses: dorny/test-reporter@v1
+        with:
+          name: E2E Test Results
+          path: tests/Goldfinch.Tests.E2E/TestResults/*.trx
+          reporter: dotnet-trx
+          fail-on-error: true
 
       - name: Upload test results
         if: always()


### PR DESCRIPTION
## Summary
- Add E2E test infrastructure using Playwright and xUnit
- Create post-deployment smoke tests that run against production
- Add GitHub Actions workflow that triggers after successful deployment
- Configure visual test reporting for better result visibility

## Test Coverage
Created content-agnostic smoke tests covering:
- Home page (structure and navigation)
- Blog listing page (pagination and article links)
- Blog detail pages (content rendering and code highlighting)
- Error page (404 handling)

Tests are designed to check structural elements rather than specific content to avoid breaking when CMS content changes.

## CI/CD Integration
- New workflow `.github/workflows/e2e-tests.yml` triggers after successful deployment
- Waits 60 seconds for Azure deployment to stabilize
- Runs smoke tests against live production site (https://www.goldfinch.me)
- Displays results both in workflow logs (detailed console output) and Checks tab (visual summary)
- Uploads TRX artifact for detailed analysis if needed

## Test Infrastructure
- Base test class with Playwright setup and configurable BASE_URL
- Tests can run locally or in CI by setting BASE_URL environment variable
- Tests categorized as "Smoke" for filtering in CI

## Documentation
Updated CLAUDE.md with test infrastructure details and GitHub Actions CI/CD info.

🤖 Generated with [Claude Code](https://claude.com/claude-code)