### PR TITLE
Remove unused test reporter action

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -9,7 +9,6 @@ on:
 
 permissions:
   contents: read
-  checks: write
 
 jobs:
   e2e-tests:
@@ -46,15 +45,6 @@ jobs:
         run: dotnet test tests/Goldfinch.Tests.E2E/Goldfinch.Tests.E2E.csproj --configuration Release --no-build --filter "Category=Smoke" --logger "trx;LogFileName=test-results.trx" --logger "console;verbosity=detailed"
         env:
           BASE_URL: 'https://www.goldfinch.me'
-
-      - name: Publish test results
-        if: always()
-        uses: dorny/test-reporter@v1
-        with:
-          name: E2E Test Results
-          path: tests/Goldfinch.Tests.E2E/TestResults/*.trx
-          reporter: dotnet-trx
-          fail-on-error: true
 
       - name: Upload test results
         if: always()


### PR DESCRIPTION
## Summary
Remove the `dorny/test-reporter` action from the E2E test workflow as it doesn't provide value in our setup.

## Issue
The test reporter action doesn't work properly with `workflow_run` triggers. It attempts to create check runs on the triggering commit (from the deploy workflow) rather than being visible in the expected location.

## Solution
- Remove `dorny/test-reporter@v1` step
- Remove `checks: write` permission (no longer needed)
- Keep detailed console output via `--logger "console;verbosity=detailed"`
- Keep TRX artifact upload for detailed analysis if needed

## Result
Test results are already clearly displayed in the workflow logs with:
- Pass/fail status for each test
- Execution timing
- Summary statistics (20/20 passed)

The detailed console output provides all the information needed without the complexity of the test reporter action.

🤖 Generated with [Claude Code](https://claude.com/claude-code)