### PR TITLE
Add clean flag to Azure deployment to prevent stale DLLs

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -65,3 +65,4 @@ jobs:
           app-name: goldfinch-blog
           publish-profile: ${{ secrets.AZURE_WEBAPP_PUBLISH_PROFILE }}
           package: ./out
+          clean: true


### PR DESCRIPTION
## Summary

Adds `clean: true` flag to the Azure Web Apps Deploy action to ensure old files are removed before deploying new ones.

## Problem

The site crashed in production with:
```
System.IO.FileNotFoundException: Could not load file or assembly 'XperienceCommunity.ImageProcessing'
```

Even though this package was removed in PR #68/#70, the DLL remained in Azure because the deployment action only overwrites/adds files - it doesn't remove old ones.

## Solution

The `clean: true` parameter tells Azure to wipe the destination folder before deploying, ensuring only current files exist in production.

## Notes

- **Manual cleanup still needed once**: The old DLL is already in Azure, so you'll need to manually clear it via Kudu or stop/restart the app
- **Future deployments**: Will automatically clean before deploying, preventing this issue

## Test Plan

- [x] Add `clean: true` to deploy.yml
- [ ] Manually clean Azure wwwroot folder via Kudu
- [ ] Merge and deploy to verify clean deployment works
- [ ] Verify site loads without FileNotFoundException

🤖 Generated with [Claude Code](https://claude.com/claude-code)