### PR TITLE
Center YouTube video embeds

### DIFF
--- a/src/Goldfinch.Web/Components/Widgets/YouTubeVideo/YouTubeVideoWidget.cshtml
+++ b/src/Goldfinch.Web/Components/Widgets/YouTubeVideo/YouTubeVideoWidget.cshtml
@@ -1,5 +1,5 @@
 ﻿@model Goldfinch.Web.Components.Widgets.YouTubeVideo.YouTubeVideoWidgetViewModel
 
-<div>
+<div class="flex justify-center">
     <iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/@Model.VideoId" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 </div>


### PR DESCRIPTION
## Summary

Centers YouTube video embeds by adding `flex justify-center` Tailwind classes to the container div.

## Problem

YouTube videos were left-aligned on blog posts instead of being centered with the rest of the content.

## Solution

Added `class="flex justify-center"` to the wrapping div in `YouTubeVideoWidget.cshtml`.

## Test Plan

- [x] Built frontend assets
- [x] Tested locally on https://localhost:52623/blog/guest-appearance-on-ask-the-experts
- [x] Verified video is now centered
- [ ] Deploy and verify on production

🤖 Generated with [Claude Code](https://claude.com/claude-code)