### PR TITLE
Remove unused SixLabors.ImageSharp packages

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -15,8 +15,6 @@
     <PackageVersion Include="Microsoft.Playwright" Version="1.55.0" />
     <PackageVersion Include="Schema.NET" Version="13.0.0" />
     <PackageVersion Include="Sidio.Sitemap.AspNetCore" Version="2.7.6" />
-    <PackageVersion Include="SixLabors.ImageSharp" Version="3.1.11" />
-    <PackageVersion Include="SixLabors.ImageSharp.Drawing" Version="2.1.7" />
     <PackageVersion Include="System.ServiceModel.Syndication" Version="9.0.10" />
     <PackageVersion Include="XperienceCommunity.CSP" Version="4.0.1" />
     <PackageVersion Include="xunit" Version="2.9.3" />

--- a/src/Goldfinch.Web/Goldfinch.Web.csproj
+++ b/src/Goldfinch.Web/Goldfinch.Web.csproj
@@ -6,8 +6,6 @@
 		<PackageReference Include="Kentico.Xperience.WebApp" />
 		<PackageReference Include="Schema.NET" />
 		<PackageReference Include="Sidio.Sitemap.AspNetCore" />
-		<PackageReference Include="SixLabors.ImageSharp" />
-		<PackageReference Include="SixLabors.ImageSharp.Drawing" />
 		<PackageReference Include="System.ServiceModel.Syndication" />
 		<PackageReference Include="XperienceCommunity.CSP" />
 	</ItemGroup>

--- a/src/Goldfinch.Web/packages.lock.json
+++ b/src/Goldfinch.Web/packages.lock.json
@@ -75,22 +75,6 @@
           "Sidio.Sitemap.Core": "2.7.5"
         }
       },
-      "SixLabors.ImageSharp": {
-        "type": "Direct",
-        "requested": "[3.1.11, )",
-        "resolved": "3.1.11",
-        "contentHash": "JfPLyigLthuE50yi6tMt7Amrenr/fA31t2CvJyhy/kQmfulIBAqo5T/YFUSRHtuYPXRSaUHygFeh6Qd933EoSw=="
-      },
-      "SixLabors.ImageSharp.Drawing": {
-        "type": "Direct",
-        "requested": "[2.1.7, )",
-        "resolved": "2.1.7",
-        "contentHash": "9KwCo9Fa350cx6ckpsy8NqXQZKwir4RQ8Kj0sdCmJA7wsK9FMyfgC527Sn4l/D6bj2ditSHlhS7dGzcgGszvSQ==",
-        "dependencies": {
-          "SixLabors.Fonts": "2.1.3",
-          "SixLabors.ImageSharp": "3.1.11"
-        }
-      },
       "System.ServiceModel.Syndication": {
         "type": "Direct",
         "requested": "[9.0.10, )",
@@ -1087,11 +1071,6 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection.Abstractions": "9.0.5"
         }
-      },
-      "SixLabors.Fonts": {
-        "type": "Transitive",
-        "resolved": "2.1.3",
-        "contentHash": "ORWbZ5BHrC/LZvo+Y09MnoJq5VUKD85LsYALk+YI7CHFra+m5arCkz00IntDM6SrAiB22bvSdKtKmuCyHOKlqg=="
       },
       "System.Buffers": {
         "type": "Transitive",


### PR DESCRIPTION
## Summary

- Removed `SixLabors.ImageSharp` (v3.1.11) and `SixLabors.ImageSharp.Drawing` (v2.1.7) packages
- These packages are no longer used after migrating to Xperience by Kentico's native Image Variant functionality
- Updated `Directory.Packages.props`, `Goldfinch.Web.csproj`, and `packages.lock.json`

## Context

The project previously used `XperienceCommunity.ImageProcessing` which depended on ImageSharp. After migration to Kentico's native Standard Media Dimensions for responsive image delivery via the `ImageAssetTagHelper`, these dependencies became redundant.

## Test plan

- [x] Project builds successfully with no errors or warnings
- [x] No references to `SixLabors.ImageSharp` found in the codebase
- [ ] Verify responsive images still work correctly on the site

🤖 Generated with [Claude Code](https://claude.com/claude-code)