### PR TITLE
Add concurrency control to deployment workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,6 +4,10 @@ on:
   push:
     branches: [ "main" ]
 
+concurrency:
+  group: production-deploy
+  cancel-in-progress: true
+
 permissions:
   contents: read
 


### PR DESCRIPTION
## Summary

- Added `concurrency` control to the deployment workflow
- Sets `cancel-in-progress: true` to cancel older deployments when new ones start

## Problem

Without concurrency control, when multiple PRs are merged in quick succession:
1. First PR triggers deployment (commit A)
2. Second PR triggers deployment (commit B)
3. Both workflows run simultaneously or overlap
4. Race condition: Whichever finishes last wins, potentially deploying **stale code**

## Solution

The `concurrency` block ensures:
- Only one deployment runs at a time
- Older in-progress deployments are cancelled when a newer one starts
- Latest code is always deployed, preventing race conditions

## Test plan

- [x] YAML syntax is valid
- [ ] Merge two PRs quickly and verify only the latest deployment completes
- [ ] Verify older in-progress deployment is cancelled

🤖 Generated with [Claude Code](https://claude.com/claude-code)