### PR TITLE
Update XperienceCommunity.CSP to version 5.0.0

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,8 +1,8 @@
 {
   "servers": {
-    "context7": {
+    "kentico.docs.mcp": {
       "type": "http",
-      "url": "https://mcp.context7.com/mcp"
+      "url": "https://docs.kentico.com/mcp"
     }
   }
 }

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -16,7 +16,7 @@
     <PackageVersion Include="Schema.NET" Version="13.0.0" />
     <PackageVersion Include="Sidio.Sitemap.AspNetCore" Version="3.0.3" />
     <PackageVersion Include="System.ServiceModel.Syndication" Version="10.0.0" />
-    <PackageVersion Include="XperienceCommunity.CSP" Version="4.0.1" />
+    <PackageVersion Include="XperienceCommunity.CSP" Version="5.0.0" />
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
   </ItemGroup>

--- a/Goldfinch.sln
+++ b/Goldfinch.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 17
-VisualStudioVersion = 17.0.32112.339
+# Visual Studio Version 18
+VisualStudioVersion = 18.0.11205.157 d18.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Goldfinch.Web", "src\Goldfinch.Web\Goldfinch.Web.csproj", "{15C4A0CA-7DF7-4B72-AC66-87FE759854B7}"
 EndProject
@@ -20,6 +20,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "config", "config", "{6781B3
 	ProjectSection(SolutionItems) = preProject
 		.editorconfig = .editorconfig
 		.gitignore = .gitignore
+		.mcp.json = .mcp.json
 		nuget.config = nuget.config
 	EndProjectSection
 EndProject

--- a/src/Goldfinch.Web/packages.lock.json
+++ b/src/Goldfinch.Web/packages.lock.json
@@ -84,11 +84,11 @@
       },
       "XperienceCommunity.CSP": {
         "type": "Direct",
-        "requested": "[4.0.1, )",
-        "resolved": "4.0.1",
-        "contentHash": "q4iTQOEhYc5rndwm/9yUkGf/CfJTkWqEsFCcOMC3RQxVryDdFtu58a0wajaC6b9dzxvrjF9ecLPf8lIShu//Cg==",
+        "requested": "[5.0.0, )",
+        "resolved": "5.0.0",
+        "contentHash": "SYW9HJvf275D4u4ZFzVuAJdTjh9DGGFytZjGaVtw+3ppj5C90W0e2LwhmhQci31VgF0wYLGZYw5T3UmPJ9Dy5w==",
         "dependencies": {
-          "Kentico.Xperience.Admin": "30.1.3"
+          "Kentico.Xperience.Admin": "30.11.0"
         }
       },
       "AngleSharp": {


### PR DESCRIPTION
Updated the `XperienceCommunity.CSP` package from version 4.0.1 to 5.0.0 in `Directory.Packages.props`.

Updated `packages.lock.json` to reflect the version change:
- Changed `requested` version range to `[5.0.0, )`.
- Updated `resolved` version to `5.0.0`.
- Updated `contentHash` for the new version.
- Updated `Kentico.Xperience.Admin` dependency from version 30.1.3 to 30.11.0.