### PR TITLE
build(sln): update to Xperience v31.0.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -7,10 +7,10 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="coverlet.collector" Version="6.0.4" />
-    <PackageVersion Include="Kentico.Xperience.Admin" Version="30.12.0" />
-    <PackageVersion Include="Kentico.Xperience.AzureStorage" Version="30.12.0" />
+    <PackageVersion Include="Kentico.Xperience.Admin" Version="31.0.0" />
+    <PackageVersion Include="Kentico.Xperience.AzureStorage" Version="31.0.0" />
     <PackageVersion Include="Kentico.Xperience.MiniProfiler" Version="2.1.0" />
-    <PackageVersion Include="Kentico.Xperience.WebApp" Version="30.12.0" />
+    <PackageVersion Include="Kentico.Xperience.WebApp" Version="31.0.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
     <PackageVersion Include="Microsoft.Playwright" Version="1.56.0" />
     <PackageVersion Include="Schema.NET" Version="13.0.0" />

--- a/src/Goldfinch.Admin/Client/package-lock.json
+++ b/src/Goldfinch.Admin/Client/package-lock.json
@@ -8,8 +8,8 @@
       "name": "goldfinch-web-admin",
       "version": "1.0.0",
       "dependencies": {
-        "@kentico/xperience-admin-base": "30.12.0",
-        "@kentico/xperience-admin-components": "30.12.0",
+        "@kentico/xperience-admin-base": "^31.0.0",
+        "@kentico/xperience-admin-components": "^31.0.0",
         "react": "^19.1.1",
         "react-dom": "^19.1.1"
       },
@@ -19,7 +19,7 @@
         "@babel/preset-env": "^7.28.5",
         "@babel/preset-react": "^7.28.5",
         "@babel/preset-typescript": "^7.28.5",
-        "@kentico/xperience-webpack-config": "30.12.0",
+        "@kentico/xperience-webpack-config": "^31.0.0",
         "@types/react": "^19.1.16",
         "@types/react-dom": "^19.1.9",
         "babel-loader": "^10.0.0",
@@ -2401,28 +2401,28 @@
       "license": "Apache-2.0"
     },
     "node_modules/@kentico/xperience-admin-base": {
-      "version": "30.12.0",
-      "resolved": "https://registry.npmjs.org/@kentico/xperience-admin-base/-/xperience-admin-base-30.12.0.tgz",
-      "integrity": "sha512-vZV0XOHD92vOcaZK9W6J7VnXC3U9xmRMUmRbvVU2rhztEPb1u5CxMHczxzJfMgc03HCOsOe39JgYOne3tpYmXw==",
+      "version": "31.0.0",
+      "resolved": "https://registry.npmjs.org/@kentico/xperience-admin-base/-/xperience-admin-base-31.0.0.tgz",
+      "integrity": "sha512-whHmICXoRaxZIaoTA9+yklVjFuq7iLsLB56U/yhWU7gfiCalgaNW4uv5IMkfKczSUOsbShZcwYLrxyWQXrwAFg==",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "^18.0.1",
-        "@kentico/xperience-admin-components": "30.12.0",
+        "@kentico/xperience-admin-components": "31.0.0",
         "@react-aria/focus": "^3.21.2",
         "@react-aria/i18n": "^3.12.13",
         "@react-aria/visually-hidden": "^3.8.28",
         "classnames": "^2.5.1",
         "date-fns": "^4.1.0",
-        "i18next": "^25.6.1",
+        "i18next": "^25.7.1",
         "react": "^18.3.1",
         "react-cool-inview": "^3.0.1",
         "react-dnd": "^16.0.1",
         "react-dnd-html5-backend": "^16.0.1",
         "react-dom": "^18.3.1",
-        "react-i18next": "^16.2.4",
+        "react-i18next": "^16.3.5",
         "react-image-crop": "^11.0.10",
         "react-markdown": "^10.1.0",
-        "react-router-dom": "6.30.1",
+        "react-router-dom": "6.30.2",
         "react-select": "^5.10.2",
         "react-select-async-paginate": "^0.7.11",
         "remark-gfm": "^4.0.1",
@@ -2432,9 +2432,9 @@
       }
     },
     "node_modules/@kentico/xperience-admin-components": {
-      "version": "30.12.0",
-      "resolved": "https://registry.npmjs.org/@kentico/xperience-admin-components/-/xperience-admin-components-30.12.0.tgz",
-      "integrity": "sha512-7n5FaNdQZTbSGnOZWvmpJK5fMxLaTK7Xk3hNUpokM5zO9r9YT+O41keXHnRSKX0zp6QOUyTfcsfGC386A5eK3A==",
+      "version": "31.0.0",
+      "resolved": "https://registry.npmjs.org/@kentico/xperience-admin-components/-/xperience-admin-components-31.0.0.tgz",
+      "integrity": "sha512-lTxMJca7BZJZ0Sh5r6TOfCyb4ZFM5SA/HpixtPFFNwwAuGZ/3z17y84c48Ai+IR+ShFmbEc7TjREd5e9HaN2aw==",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@amcharts/amcharts5": "5.14.4",
@@ -2456,27 +2456,27 @@
         "@tippyjs/react": "^4.2.6",
         "@uiw/react-codemirror": "^4.25.3",
         "classnames": "^2.5.1",
-        "froala-editor": "^4.7.0",
-        "i18next": "^25.6.1",
+        "froala-editor": "^4.7.1",
+        "i18next": "^25.7.1",
         "react": "^18.3.1",
         "react-aria-components": "1.13.0",
         "react-datepicker": "^8.4.0",
         "react-dnd": "^16.0.1",
         "react-dnd-html5-backend": "^16.0.1",
         "react-dom": "^18.3.1",
-        "react-froala-wysiwyg": "^4.7.0",
-        "react-i18next": "^16.2.4",
+        "react-froala-wysiwyg": "^4.7.1",
+        "react-i18next": "^16.3.5",
         "react-modal": "^3.16.3",
-        "react-router-dom": "6.30.1",
+        "react-router-dom": "6.30.2",
         "react-textarea-autosize": "8.5.9",
         "use-debounce": "^10.0.6",
         "use-resize-observer": "9.1.0"
       }
     },
     "node_modules/@kentico/xperience-webpack-config": {
-      "version": "30.12.0",
-      "resolved": "https://registry.npmjs.org/@kentico/xperience-webpack-config/-/xperience-webpack-config-30.12.0.tgz",
-      "integrity": "sha512-APj32scMBak392H2NFrqNswO88EKuphtT5h2nnLEuP7UkYZagHUCIwY1cfemCUEgKd3yRvrzBFFktLxooft9GA==",
+      "version": "31.0.0",
+      "resolved": "https://registry.npmjs.org/@kentico/xperience-webpack-config/-/xperience-webpack-config-31.0.0.tgz",
+      "integrity": "sha512-RNFd0SWExlLVGjkXFjjRY5YgQClv08fHhtVOYed1P1GRjq1IVIgSSOYVT2kj6EI4kGBHFOFoDzcHPfTQ3ooyQg==",
       "dev": true,
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
@@ -4386,9 +4386,9 @@
       }
     },
     "node_modules/@remix-run/router": {
-      "version": "1.23.0",
-      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.0.tgz",
-      "integrity": "sha512-O3rHJzAQKamUz1fvE0Qaw0xSFqsA/yafi2iqeE0pvdFtCO1viYx8QL6f3Ln/aCCTLxs68SLf0KPM9eSeM8yBnA==",
+      "version": "1.23.1",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.1.tgz",
+      "integrity": "sha512-vDbaOzF7yT2Qs4vO6XV1MHcJv+3dgR1sT+l3B8xxOVhUC336prMvqrvsLL/9Dnw2xr6Qhz4J0dmS0llNAbnUmQ==",
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
@@ -10114,12 +10114,12 @@
       }
     },
     "node_modules/react-router": {
-      "version": "6.30.1",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.1.tgz",
-      "integrity": "sha512-X1m21aEmxGXqENEPG3T6u0Th7g0aS4ZmoNynhbs+Cn+q+QGTLt+d5IQ2bHAXKzKcxGJjxACpVbnYQSCRcfxHlQ==",
+      "version": "6.30.2",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.2.tgz",
+      "integrity": "sha512-H2Bm38Zu1bm8KUE5NVWRMzuIyAV8p/JrOaBJAwVmp37AXG72+CZJlEBw6pdn9i5TBgLMhNDgijS4ZlblpHyWTA==",
       "license": "MIT",
       "dependencies": {
-        "@remix-run/router": "1.23.0"
+        "@remix-run/router": "1.23.1"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -10129,13 +10129,13 @@
       }
     },
     "node_modules/react-router-dom": {
-      "version": "6.30.1",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.1.tgz",
-      "integrity": "sha512-llKsgOkZdbPU1Eg3zK8lCn+sjD9wMRZZPuzmdWWX5SUs8OFkN5HnFVC0u5KMeMaC9aoancFI/KoLuKPqN+hxHw==",
+      "version": "6.30.2",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.2.tgz",
+      "integrity": "sha512-l2OwHn3UUnEVUqc6/1VMmR1cvZryZ3j3NzapC2eUXO1dB0sYp5mvwdjiXhpUbRb21eFow3qSxpP8Yv6oAU824Q==",
       "license": "MIT",
       "dependencies": {
-        "@remix-run/router": "1.23.0",
-        "react-router": "6.30.1"
+        "@remix-run/router": "1.23.1",
+        "react-router": "6.30.2"
       },
       "engines": {
         "node": ">=14.0.0"

--- a/src/Goldfinch.Admin/Client/package.json
+++ b/src/Goldfinch.Admin/Client/package.json
@@ -11,8 +11,8 @@
     "build": "webpack --mode=production"
   },
   "dependencies": {
-    "@kentico/xperience-admin-base": "30.12.0",
-    "@kentico/xperience-admin-components": "30.12.0",
+    "@kentico/xperience-admin-base": "^31.0.0",
+    "@kentico/xperience-admin-components": "^31.0.0",
     "react": "^19.1.1",
     "react-dom": "^19.1.1"
   },
@@ -22,7 +22,7 @@
     "@babel/preset-env": "^7.28.5",
     "@babel/preset-react": "^7.28.5",
     "@babel/preset-typescript": "^7.28.5",
-    "@kentico/xperience-webpack-config": "30.12.0",
+    "@kentico/xperience-webpack-config": "^31.0.0",
     "@types/react": "^19.1.16",
     "@types/react-dom": "^19.1.9",
     "babel-loader": "^10.0.0",

--- a/src/Goldfinch.Admin/packages.lock.json
+++ b/src/Goldfinch.Admin/packages.lock.json
@@ -4,14 +4,14 @@
     "net9.0": {
       "Kentico.Xperience.Admin": {
         "type": "Direct",
-        "requested": "[30.12.0, )",
-        "resolved": "30.12.0",
-        "contentHash": "10ibuKjLc9dZIsb/lHR639UHihFeMKDDdxUp8wO3CsdXPuZH+GX1cgoaAMEkU+Z44p2Gj5zwQAZNcBsmMtWmbA==",
+        "requested": "[31.0.0, )",
+        "resolved": "31.0.0",
+        "contentHash": "8IC208QUcTv5RuCOxkr7D65UHaLeqpQ9ekw9kZ7RiNosi690iv24p6/5mS/Vb+s1nmoXIzsTyq334pOPxv+SdQ==",
         "dependencies": {
-          "Kentico.Aira.Client": "3.6.1",
-          "Kentico.Xperience.WebApp": "[30.12.0]",
-          "Microsoft.AspNetCore.SpaServices.Extensions": "8.0.21",
-          "Microsoft.Extensions.FileProviders.Embedded": "8.0.21",
+          "Kentico.Aira.Client": "4.0.0",
+          "Kentico.Xperience.WebApp": "[31.0.0]",
+          "Microsoft.AspNetCore.SpaServices.Extensions": "8.0.22",
+          "Microsoft.Extensions.FileProviders.Embedded": "8.0.22",
           "Microsoft.SemanticKernel": "1.67.1",
           "Microsoft.SemanticKernel.Agents.Core": "1.67.1",
           "Microsoft.SemanticKernel.Connectors.AzureOpenAI": "1.67.1"
@@ -19,18 +19,18 @@
       },
       "Kentico.Xperience.WebApp": {
         "type": "Direct",
-        "requested": "[30.12.0, )",
-        "resolved": "30.12.0",
-        "contentHash": "ztw9185n0rQ54Vd/unMXdd419C+Ju5/6NOZuO+uhgyCQXxL0rTHMYenEuUI9wLPgnafCd53xGXQFOyrgqI8JcA==",
+        "requested": "[31.0.0, )",
+        "resolved": "31.0.0",
+        "contentHash": "2BEEcrQRc37BFBstUngGbUYtnb3PD2m/Go1zwYH2/YTve0tY85EnAsoLT2NFuoFzivhMp17zmtIZFDr1yaeybA==",
         "dependencies": {
           "CommandLineParser": "2.9.1",
           "HotChocolate.AspNetCore": "15.0.3",
           "HotChocolate.Data": "15.0.3",
-          "HtmlSanitizer": "9.0.886",
-          "Kentico.Xperience.Core": "[30.12.0]",
-          "Microsoft.AspNetCore.Components": "8.0.21",
+          "HtmlSanitizer": "9.0.889",
+          "Kentico.Xperience.Core": "[31.0.0]",
+          "Microsoft.AspNetCore.Components": "8.0.22",
           "Microsoft.Extensions.Caching.Memory": "8.0.1",
-          "Microsoft.Extensions.FileProviders.Embedded": "8.0.21"
+          "Microsoft.Extensions.FileProviders.Embedded": "8.0.22"
         }
       },
       "AngleSharp": {
@@ -438,8 +438,8 @@
       },
       "HtmlSanitizer": {
         "type": "Transitive",
-        "resolved": "9.0.886",
-        "contentHash": "qw87Q+bffcs2Fw/Rd3VXWg/QK+K9eIxeE9QidQLz3C/ffgUGuOB0X4MWUuuolUnnBvoD/u6FqXhsqIA67nL4kg==",
+        "resolved": "9.0.889",
+        "contentHash": "gYEkdYFozRH28YvwekP2Ha5NONbpullgsrruBmJvtlAVDIP4NPvD7ma1P90J24c9nPXMaDxOTWJX8c6Jd6IdjQ==",
         "dependencies": {
           "AngleSharp": "[0.17.1]",
           "AngleSharp.Css": "[0.17.0]"
@@ -447,25 +447,25 @@
       },
       "Kentico.Aira.Client": {
         "type": "Transitive",
-        "resolved": "3.6.1",
-        "contentHash": "KwDjaB7JkuyVsqChevFJK+UnZq0oXQP3zgXIf6uhuYvdgEsjADtflFJIi3kTg3mOHRxP6Z/8taQONdLNFQF00A==",
+        "resolved": "4.0.0",
+        "contentHash": "cBW7qahkfmUJfrDI2Cmnjj8RpbwLLpiZDz5j+CFy+vpYUoQNhrsdIKGbTnLAtp+d+N7SHT3MHcwKLOdZKBDi5g==",
         "dependencies": {
           "Azure.Core": "1.47.1",
           "Microsoft.Extensions.DependencyInjection": "8.0.1",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "9.0.7",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "9.0.8",
           "Microsoft.Extensions.Http": "8.0.1",
-          "Microsoft.Extensions.Options": "8.0.2",
+          "Microsoft.Extensions.Options": "9.0.8",
           "Microsoft.Extensions.Options.ConfigurationExtensions": "8.0.0",
-          "Microsoft.IdentityModel.JsonWebTokens": "7.6.2"
+          "Microsoft.IdentityModel.JsonWebTokens": "8.14.0"
         }
       },
       "Kentico.Xperience.Core": {
         "type": "Transitive",
-        "resolved": "30.12.0",
-        "contentHash": "rDbplli6ar9sG3ulgCVXEtJqYnPzbXBct49whpswu1OtBs279pn4s6CyzHGo1JYmiFveFMYp1/wITS+iK9TXvg==",
+        "resolved": "31.0.0",
+        "contentHash": "j/8Uni3hy1R15CpjFPckAGk5svnbFsHXrMm5dG62xiL1HsWZTR3V9QKbTVs654pO8siDKySWMEgKPoYJPTZlPQ==",
         "dependencies": {
           "AngleSharp": "0.17.1",
-          "Kentico.Aira.Client": "3.6.1",
+          "Kentico.Aira.Client": "4.0.0",
           "Magick.NET-Q8-AnyCPU": "14.9.1",
           "MailKit": "4.14.1",
           "Microsoft.Data.SqlClient": "5.2.3",
@@ -474,13 +474,13 @@
           "Microsoft.Extensions.DependencyInjection": "8.0.1",
           "Microsoft.Extensions.FileProviders.Physical": "8.0.0",
           "Microsoft.Extensions.Hosting.Abstractions": "8.0.1",
-          "Microsoft.Extensions.Localization": "8.0.21",
+          "Microsoft.Extensions.Localization": "8.0.22",
           "Microsoft.Extensions.Logging": "8.0.1",
           "Microsoft.Extensions.Options.ConfigurationExtensions": "8.0.0",
           "Mono.Cecil": "0.11.6",
           "Newtonsoft.Json": "13.0.3",
           "System.CodeDom": "8.0.0",
-          "System.IO.Hashing": "9.0.10"
+          "System.IO.Hashing": "9.0.11"
         }
       },
       "Magick.NET-Q8-AnyCPU": {
@@ -517,37 +517,37 @@
       },
       "Microsoft.AspNetCore.Authorization": {
         "type": "Transitive",
-        "resolved": "8.0.21",
-        "contentHash": "ckniZ/HilMC311SNZM0Tb5+4f4IWmNniEy893pAmjVsN0veXIyegl9yDp6vn2iBooJB9qfxy4kVkFjEKEOFrng==",
+        "resolved": "8.0.22",
+        "contentHash": "D7GY8e30UCkjQO9z2cQ1XT/+T1CSAae+KxojcI5SRb8iKmhVjMrAyspdslGMVhS5zOnPgObUp1666BriQmzv3g==",
         "dependencies": {
-          "Microsoft.AspNetCore.Metadata": "8.0.21",
+          "Microsoft.AspNetCore.Metadata": "8.0.22",
           "Microsoft.Extensions.Logging.Abstractions": "8.0.3",
           "Microsoft.Extensions.Options": "8.0.2"
         }
       },
       "Microsoft.AspNetCore.Components": {
         "type": "Transitive",
-        "resolved": "8.0.21",
-        "contentHash": "O1UE1JgTFQKz0easeZ9rMg8sdsMC3Qois3oc4NNubLP7S4v25C602mCvnLjv1pF6mgXWEeGLpRQYQAqKx3ZcqQ==",
+        "resolved": "8.0.22",
+        "contentHash": "qlW2tz9umukb/XTA+D7p+OiOz6l10rtn0jwh2A46LN8VwikutX5HbCE3pdc1x7eG2LdSKb2OLOTpdhaDp4NB3g==",
         "dependencies": {
-          "Microsoft.AspNetCore.Authorization": "8.0.21",
-          "Microsoft.AspNetCore.Components.Analyzers": "8.0.21"
+          "Microsoft.AspNetCore.Authorization": "8.0.22",
+          "Microsoft.AspNetCore.Components.Analyzers": "8.0.22"
         }
       },
       "Microsoft.AspNetCore.Components.Analyzers": {
         "type": "Transitive",
-        "resolved": "8.0.21",
-        "contentHash": "rYzZWBgSBCtJSsqZTrXtSUY+vhJTRCL4+5fLZayPrXQjphQUUOpIyDT1hp3b8q5ytWwP0lUMCZH7lSBQ8C5tTw=="
+        "resolved": "8.0.22",
+        "contentHash": "Xf/+WuHI1obDwkxUb8w5P+JnaQJEau6r/fDkTvikUvTsMJOwsMAlaG67mJBx31z21jv2SGSPiOWLysBcLagcIQ=="
       },
       "Microsoft.AspNetCore.Metadata": {
         "type": "Transitive",
-        "resolved": "8.0.21",
-        "contentHash": "3C7OfvuSY+ODBe/uOrX/S/7cjVGQSzduXamkpoFv1GTcHMoPttK7VmUXTNSiVWerC14v/OtT52zL6+U+T3gx4A=="
+        "resolved": "8.0.22",
+        "contentHash": "Ha5M7eC//ZyBzJTc7CmUs0RJkqfBRXc38xzewR8VqZov8jURWuyaSv2XNiokjt7H77cZjQ7sLL0I/RD5JnQ/nA=="
       },
       "Microsoft.AspNetCore.SpaServices.Extensions": {
         "type": "Transitive",
-        "resolved": "8.0.21",
-        "contentHash": "UUOK6JldBc41XJGPMG5UrlnPkbFxWdWHq+W3I4b2noSoQDBnwiNTaRLG6mfcJkCsmEyypLY/PbX6RXzWsOneNg==",
+        "resolved": "8.0.22",
+        "contentHash": "Wz53AWozQhgtte+WtWfqSGnL9FF/YiEonf5PZTQYj3xYZWoXTZziWCo/ON0ni9AVXvEZ5SwsXK/WSGUXTrWaDQ==",
         "dependencies": {
           "Microsoft.Extensions.FileProviders.Physical": "8.0.0"
         }
@@ -705,8 +705,8 @@
       },
       "Microsoft.Extensions.FileProviders.Embedded": {
         "type": "Transitive",
-        "resolved": "8.0.21",
-        "contentHash": "JmAFU1Iuw84BbgPoHRPeEdlmyZHpTh3xdcM3+mYyNLm2OADHTvDMjoHnMLsxE7Qb5C18aWZror8Qr0+dsf0kcw==",
+        "resolved": "8.0.22",
+        "contentHash": "5Hrl2EyoqmSN/0YKfuYp4qRP8+RU4xguUVMg0J/5J+nDYobiBM4VgCTUN4oaCpIk9063hTsd/WoheKMlZBkVjA==",
         "dependencies": {
           "Microsoft.Extensions.FileProviders.Abstractions": "8.0.0"
         }
@@ -753,19 +753,19 @@
       },
       "Microsoft.Extensions.Localization": {
         "type": "Transitive",
-        "resolved": "8.0.21",
-        "contentHash": "pD4ypbFCTxDJuCKLw0F1lmK/z0wZBPgaNRRjHZlpkFWW9cNUq+9SiWGzf6DPd7tXCGSyhrs/CPv6qJBr21nzhg==",
+        "resolved": "8.0.22",
+        "contentHash": "qJtpGMta4v1yqj04c9DCqFC6cqtioEi5TBXml2O7I8p6SrfMan2Twj2AmCG/IcepXiS9wKgJwcMnAKriQoyo5w==",
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection.Abstractions": "8.0.2",
-          "Microsoft.Extensions.Localization.Abstractions": "8.0.21",
+          "Microsoft.Extensions.Localization.Abstractions": "8.0.22",
           "Microsoft.Extensions.Logging.Abstractions": "8.0.3",
           "Microsoft.Extensions.Options": "8.0.2"
         }
       },
       "Microsoft.Extensions.Localization.Abstractions": {
         "type": "Transitive",
-        "resolved": "8.0.21",
-        "contentHash": "+i3LqUjP+qG8xRaTHIHCRKfuZWm54MigfZFXGyTxEScwAgRCHvRrcwWDLRJpsvmue6c/VTJnprHCtLs+8nJdVw=="
+        "resolved": "8.0.22",
+        "contentHash": "8cpr20qkP74aNODW+78wcPmAg/RbMR+So1mGcLkJTrLGCJ7LJPOF6nngvUg6VOS050op7FruMFJm/9PuxWm9oQ=="
       },
       "Microsoft.Extensions.Logging": {
         "type": "Transitive",
@@ -845,23 +845,23 @@
       },
       "Microsoft.IdentityModel.Abstractions": {
         "type": "Transitive",
-        "resolved": "7.6.2",
-        "contentHash": "ULeyJwfYTMHOAArrBZorjPyM/BL5PFfwRzDtxlOxawO9vB/wVmHmbzZnOyHCOLJjel7XiVNmVnAs3H0jh4/9jQ=="
+        "resolved": "8.14.0",
+        "contentHash": "iwbCpSjD3ehfTwBhtSNEtKPK0ICun6ov7Ibx6ISNA9bfwIyzI2Siwyi9eJFCJBwxowK9xcA1mj+jBWiigeqgcQ=="
       },
       "Microsoft.IdentityModel.JsonWebTokens": {
         "type": "Transitive",
-        "resolved": "7.6.2",
-        "contentHash": "ySbY72MsWw7BnSZw0fCsmp/oMou8ntJkfuZUBcplV3ncXMzxcXCn3fK6Gg2YLnTT6F2G9JXl9zc2lwfVfGOWEA==",
+        "resolved": "8.14.0",
+        "contentHash": "4jOpiA4THdtpLyMdAb24dtj7+6GmvhOhxf5XHLYWmPKF8ApEnApal1UnJsKO4HxUWRXDA6C4WQVfYyqsRhpNpQ==",
         "dependencies": {
-          "Microsoft.IdentityModel.Tokens": "7.6.2"
+          "Microsoft.IdentityModel.Tokens": "8.14.0"
         }
       },
       "Microsoft.IdentityModel.Logging": {
         "type": "Transitive",
-        "resolved": "7.6.2",
-        "contentHash": "0brV311MYxGz7Numa+pbVsxbz5tfe2nbAig1b5tQb3h/L1y5lkoPyOgD0qAfI0iX1njbwr8l9NdxIT1cDbzWKA==",
+        "resolved": "8.14.0",
+        "contentHash": "eqqnemdW38CKZEHS6diA50BV94QICozDZEvSrsvN3SJXUFwVB9gy+/oz76gldP7nZliA16IglXjXTCTdmU/Ejg==",
         "dependencies": {
-          "Microsoft.IdentityModel.Abstractions": "7.6.2"
+          "Microsoft.IdentityModel.Abstractions": "8.14.0"
         }
       },
       "Microsoft.IdentityModel.Protocols": {
@@ -884,10 +884,11 @@
       },
       "Microsoft.IdentityModel.Tokens": {
         "type": "Transitive",
-        "resolved": "7.6.2",
-        "contentHash": "pLnhCq9UNKWkn83zutkObYuzA+sOzx6VZpPI8hB8gD/vAXVt14D0SJ0sKPftwufvAbYGSNRda1vw/IFLbkjxNg==",
+        "resolved": "8.14.0",
+        "contentHash": "lKIZiBiGd36k02TCdMHp1KlNWisyIvQxcYJvIkz7P4gSQ9zi8dgh6S5Grj8NNG7HWYIPfQymGyoZ6JB5d1Lo1g==",
         "dependencies": {
-          "Microsoft.IdentityModel.Logging": "7.6.2"
+          "Microsoft.Extensions.Logging.Abstractions": "8.0.0",
+          "Microsoft.IdentityModel.Logging": "8.14.0"
         }
       },
       "Microsoft.SemanticKernel": {
@@ -1052,8 +1053,8 @@
       },
       "System.IO.Hashing": {
         "type": "Transitive",
-        "resolved": "9.0.10",
-        "contentHash": "9gv5z71xaWWmcGEs4bXdreIhKp2kYLK2fvPK5gQkgnWMYvZ8ieaxKofDjxL3scZiEYfi/yW2nJTiKV2awcWEdA=="
+        "resolved": "9.0.11",
+        "contentHash": "c9tFngnvHiUsBPLW22QQBgcGe9xFvac9rg3QIRHxrY2gCUdy4s2M/gQHimH+Z4yR9Cj6xWTOsa8IYY5CIG8QFA=="
       },
       "System.IO.Pipelines": {
         "type": "Transitive",
@@ -1127,8 +1128,8 @@
       "goldfinch.core": {
         "type": "Project",
         "dependencies": {
-          "Kentico.Xperience.Admin": "[30.12.0, )",
-          "Kentico.Xperience.WebApp": "[30.12.0, )",
+          "Kentico.Xperience.Admin": "[31.0.0, )",
+          "Kentico.Xperience.WebApp": "[31.0.0, )",
           "Sidio.Sitemap.AspNetCore": "[3.0.3, )"
         }
       },

--- a/src/Goldfinch.Core/packages.lock.json
+++ b/src/Goldfinch.Core/packages.lock.json
@@ -4,14 +4,14 @@
     "net9.0": {
       "Kentico.Xperience.Admin": {
         "type": "Direct",
-        "requested": "[30.12.0, )",
-        "resolved": "30.12.0",
-        "contentHash": "10ibuKjLc9dZIsb/lHR639UHihFeMKDDdxUp8wO3CsdXPuZH+GX1cgoaAMEkU+Z44p2Gj5zwQAZNcBsmMtWmbA==",
+        "requested": "[31.0.0, )",
+        "resolved": "31.0.0",
+        "contentHash": "8IC208QUcTv5RuCOxkr7D65UHaLeqpQ9ekw9kZ7RiNosi690iv24p6/5mS/Vb+s1nmoXIzsTyq334pOPxv+SdQ==",
         "dependencies": {
-          "Kentico.Aira.Client": "3.6.1",
-          "Kentico.Xperience.WebApp": "[30.12.0]",
-          "Microsoft.AspNetCore.SpaServices.Extensions": "8.0.21",
-          "Microsoft.Extensions.FileProviders.Embedded": "8.0.21",
+          "Kentico.Aira.Client": "4.0.0",
+          "Kentico.Xperience.WebApp": "[31.0.0]",
+          "Microsoft.AspNetCore.SpaServices.Extensions": "8.0.22",
+          "Microsoft.Extensions.FileProviders.Embedded": "8.0.22",
           "Microsoft.SemanticKernel": "1.67.1",
           "Microsoft.SemanticKernel.Agents.Core": "1.67.1",
           "Microsoft.SemanticKernel.Connectors.AzureOpenAI": "1.67.1"
@@ -19,18 +19,18 @@
       },
       "Kentico.Xperience.WebApp": {
         "type": "Direct",
-        "requested": "[30.12.0, )",
-        "resolved": "30.12.0",
-        "contentHash": "ztw9185n0rQ54Vd/unMXdd419C+Ju5/6NOZuO+uhgyCQXxL0rTHMYenEuUI9wLPgnafCd53xGXQFOyrgqI8JcA==",
+        "requested": "[31.0.0, )",
+        "resolved": "31.0.0",
+        "contentHash": "2BEEcrQRc37BFBstUngGbUYtnb3PD2m/Go1zwYH2/YTve0tY85EnAsoLT2NFuoFzivhMp17zmtIZFDr1yaeybA==",
         "dependencies": {
           "CommandLineParser": "2.9.1",
           "HotChocolate.AspNetCore": "15.0.3",
           "HotChocolate.Data": "15.0.3",
-          "HtmlSanitizer": "9.0.886",
-          "Kentico.Xperience.Core": "[30.12.0]",
-          "Microsoft.AspNetCore.Components": "8.0.21",
+          "HtmlSanitizer": "9.0.889",
+          "Kentico.Xperience.Core": "[31.0.0]",
+          "Microsoft.AspNetCore.Components": "8.0.22",
           "Microsoft.Extensions.Caching.Memory": "8.0.1",
-          "Microsoft.Extensions.FileProviders.Embedded": "8.0.21"
+          "Microsoft.Extensions.FileProviders.Embedded": "8.0.22"
         }
       },
       "Sidio.Sitemap.AspNetCore": {
@@ -448,8 +448,8 @@
       },
       "HtmlSanitizer": {
         "type": "Transitive",
-        "resolved": "9.0.886",
-        "contentHash": "qw87Q+bffcs2Fw/Rd3VXWg/QK+K9eIxeE9QidQLz3C/ffgUGuOB0X4MWUuuolUnnBvoD/u6FqXhsqIA67nL4kg==",
+        "resolved": "9.0.889",
+        "contentHash": "gYEkdYFozRH28YvwekP2Ha5NONbpullgsrruBmJvtlAVDIP4NPvD7ma1P90J24c9nPXMaDxOTWJX8c6Jd6IdjQ==",
         "dependencies": {
           "AngleSharp": "[0.17.1]",
           "AngleSharp.Css": "[0.17.0]"
@@ -457,25 +457,25 @@
       },
       "Kentico.Aira.Client": {
         "type": "Transitive",
-        "resolved": "3.6.1",
-        "contentHash": "KwDjaB7JkuyVsqChevFJK+UnZq0oXQP3zgXIf6uhuYvdgEsjADtflFJIi3kTg3mOHRxP6Z/8taQONdLNFQF00A==",
+        "resolved": "4.0.0",
+        "contentHash": "cBW7qahkfmUJfrDI2Cmnjj8RpbwLLpiZDz5j+CFy+vpYUoQNhrsdIKGbTnLAtp+d+N7SHT3MHcwKLOdZKBDi5g==",
         "dependencies": {
           "Azure.Core": "1.47.1",
           "Microsoft.Extensions.DependencyInjection": "8.0.1",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "9.0.7",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "9.0.8",
           "Microsoft.Extensions.Http": "8.0.1",
-          "Microsoft.Extensions.Options": "8.0.2",
+          "Microsoft.Extensions.Options": "9.0.8",
           "Microsoft.Extensions.Options.ConfigurationExtensions": "8.0.0",
-          "Microsoft.IdentityModel.JsonWebTokens": "7.6.2"
+          "Microsoft.IdentityModel.JsonWebTokens": "8.14.0"
         }
       },
       "Kentico.Xperience.Core": {
         "type": "Transitive",
-        "resolved": "30.12.0",
-        "contentHash": "rDbplli6ar9sG3ulgCVXEtJqYnPzbXBct49whpswu1OtBs279pn4s6CyzHGo1JYmiFveFMYp1/wITS+iK9TXvg==",
+        "resolved": "31.0.0",
+        "contentHash": "j/8Uni3hy1R15CpjFPckAGk5svnbFsHXrMm5dG62xiL1HsWZTR3V9QKbTVs654pO8siDKySWMEgKPoYJPTZlPQ==",
         "dependencies": {
           "AngleSharp": "0.17.1",
-          "Kentico.Aira.Client": "3.6.1",
+          "Kentico.Aira.Client": "4.0.0",
           "Magick.NET-Q8-AnyCPU": "14.9.1",
           "MailKit": "4.14.1",
           "Microsoft.Data.SqlClient": "5.2.3",
@@ -484,13 +484,13 @@
           "Microsoft.Extensions.DependencyInjection": "8.0.1",
           "Microsoft.Extensions.FileProviders.Physical": "8.0.0",
           "Microsoft.Extensions.Hosting.Abstractions": "8.0.1",
-          "Microsoft.Extensions.Localization": "8.0.21",
+          "Microsoft.Extensions.Localization": "8.0.22",
           "Microsoft.Extensions.Logging": "8.0.1",
           "Microsoft.Extensions.Options.ConfigurationExtensions": "8.0.0",
           "Mono.Cecil": "0.11.6",
           "Newtonsoft.Json": "13.0.3",
           "System.CodeDom": "8.0.0",
-          "System.IO.Hashing": "9.0.10"
+          "System.IO.Hashing": "9.0.11"
         }
       },
       "Magick.NET-Q8-AnyCPU": {
@@ -527,37 +527,37 @@
       },
       "Microsoft.AspNetCore.Authorization": {
         "type": "Transitive",
-        "resolved": "8.0.21",
-        "contentHash": "ckniZ/HilMC311SNZM0Tb5+4f4IWmNniEy893pAmjVsN0veXIyegl9yDp6vn2iBooJB9qfxy4kVkFjEKEOFrng==",
+        "resolved": "8.0.22",
+        "contentHash": "D7GY8e30UCkjQO9z2cQ1XT/+T1CSAae+KxojcI5SRb8iKmhVjMrAyspdslGMVhS5zOnPgObUp1666BriQmzv3g==",
         "dependencies": {
-          "Microsoft.AspNetCore.Metadata": "8.0.21",
+          "Microsoft.AspNetCore.Metadata": "8.0.22",
           "Microsoft.Extensions.Logging.Abstractions": "8.0.3",
           "Microsoft.Extensions.Options": "8.0.2"
         }
       },
       "Microsoft.AspNetCore.Components": {
         "type": "Transitive",
-        "resolved": "8.0.21",
-        "contentHash": "O1UE1JgTFQKz0easeZ9rMg8sdsMC3Qois3oc4NNubLP7S4v25C602mCvnLjv1pF6mgXWEeGLpRQYQAqKx3ZcqQ==",
+        "resolved": "8.0.22",
+        "contentHash": "qlW2tz9umukb/XTA+D7p+OiOz6l10rtn0jwh2A46LN8VwikutX5HbCE3pdc1x7eG2LdSKb2OLOTpdhaDp4NB3g==",
         "dependencies": {
-          "Microsoft.AspNetCore.Authorization": "8.0.21",
-          "Microsoft.AspNetCore.Components.Analyzers": "8.0.21"
+          "Microsoft.AspNetCore.Authorization": "8.0.22",
+          "Microsoft.AspNetCore.Components.Analyzers": "8.0.22"
         }
       },
       "Microsoft.AspNetCore.Components.Analyzers": {
         "type": "Transitive",
-        "resolved": "8.0.21",
-        "contentHash": "rYzZWBgSBCtJSsqZTrXtSUY+vhJTRCL4+5fLZayPrXQjphQUUOpIyDT1hp3b8q5ytWwP0lUMCZH7lSBQ8C5tTw=="
+        "resolved": "8.0.22",
+        "contentHash": "Xf/+WuHI1obDwkxUb8w5P+JnaQJEau6r/fDkTvikUvTsMJOwsMAlaG67mJBx31z21jv2SGSPiOWLysBcLagcIQ=="
       },
       "Microsoft.AspNetCore.Metadata": {
         "type": "Transitive",
-        "resolved": "8.0.21",
-        "contentHash": "3C7OfvuSY+ODBe/uOrX/S/7cjVGQSzduXamkpoFv1GTcHMoPttK7VmUXTNSiVWerC14v/OtT52zL6+U+T3gx4A=="
+        "resolved": "8.0.22",
+        "contentHash": "Ha5M7eC//ZyBzJTc7CmUs0RJkqfBRXc38xzewR8VqZov8jURWuyaSv2XNiokjt7H77cZjQ7sLL0I/RD5JnQ/nA=="
       },
       "Microsoft.AspNetCore.SpaServices.Extensions": {
         "type": "Transitive",
-        "resolved": "8.0.21",
-        "contentHash": "UUOK6JldBc41XJGPMG5UrlnPkbFxWdWHq+W3I4b2noSoQDBnwiNTaRLG6mfcJkCsmEyypLY/PbX6RXzWsOneNg==",
+        "resolved": "8.0.22",
+        "contentHash": "Wz53AWozQhgtte+WtWfqSGnL9FF/YiEonf5PZTQYj3xYZWoXTZziWCo/ON0ni9AVXvEZ5SwsXK/WSGUXTrWaDQ==",
         "dependencies": {
           "Microsoft.Extensions.FileProviders.Physical": "8.0.0"
         }
@@ -715,8 +715,8 @@
       },
       "Microsoft.Extensions.FileProviders.Embedded": {
         "type": "Transitive",
-        "resolved": "8.0.21",
-        "contentHash": "JmAFU1Iuw84BbgPoHRPeEdlmyZHpTh3xdcM3+mYyNLm2OADHTvDMjoHnMLsxE7Qb5C18aWZror8Qr0+dsf0kcw==",
+        "resolved": "8.0.22",
+        "contentHash": "5Hrl2EyoqmSN/0YKfuYp4qRP8+RU4xguUVMg0J/5J+nDYobiBM4VgCTUN4oaCpIk9063hTsd/WoheKMlZBkVjA==",
         "dependencies": {
           "Microsoft.Extensions.FileProviders.Abstractions": "8.0.0"
         }
@@ -763,19 +763,19 @@
       },
       "Microsoft.Extensions.Localization": {
         "type": "Transitive",
-        "resolved": "8.0.21",
-        "contentHash": "pD4ypbFCTxDJuCKLw0F1lmK/z0wZBPgaNRRjHZlpkFWW9cNUq+9SiWGzf6DPd7tXCGSyhrs/CPv6qJBr21nzhg==",
+        "resolved": "8.0.22",
+        "contentHash": "qJtpGMta4v1yqj04c9DCqFC6cqtioEi5TBXml2O7I8p6SrfMan2Twj2AmCG/IcepXiS9wKgJwcMnAKriQoyo5w==",
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection.Abstractions": "8.0.2",
-          "Microsoft.Extensions.Localization.Abstractions": "8.0.21",
+          "Microsoft.Extensions.Localization.Abstractions": "8.0.22",
           "Microsoft.Extensions.Logging.Abstractions": "8.0.3",
           "Microsoft.Extensions.Options": "8.0.2"
         }
       },
       "Microsoft.Extensions.Localization.Abstractions": {
         "type": "Transitive",
-        "resolved": "8.0.21",
-        "contentHash": "+i3LqUjP+qG8xRaTHIHCRKfuZWm54MigfZFXGyTxEScwAgRCHvRrcwWDLRJpsvmue6c/VTJnprHCtLs+8nJdVw=="
+        "resolved": "8.0.22",
+        "contentHash": "8cpr20qkP74aNODW+78wcPmAg/RbMR+So1mGcLkJTrLGCJ7LJPOF6nngvUg6VOS050op7FruMFJm/9PuxWm9oQ=="
       },
       "Microsoft.Extensions.Logging": {
         "type": "Transitive",
@@ -855,23 +855,23 @@
       },
       "Microsoft.IdentityModel.Abstractions": {
         "type": "Transitive",
-        "resolved": "7.6.2",
-        "contentHash": "ULeyJwfYTMHOAArrBZorjPyM/BL5PFfwRzDtxlOxawO9vB/wVmHmbzZnOyHCOLJjel7XiVNmVnAs3H0jh4/9jQ=="
+        "resolved": "8.14.0",
+        "contentHash": "iwbCpSjD3ehfTwBhtSNEtKPK0ICun6ov7Ibx6ISNA9bfwIyzI2Siwyi9eJFCJBwxowK9xcA1mj+jBWiigeqgcQ=="
       },
       "Microsoft.IdentityModel.JsonWebTokens": {
         "type": "Transitive",
-        "resolved": "7.6.2",
-        "contentHash": "ySbY72MsWw7BnSZw0fCsmp/oMou8ntJkfuZUBcplV3ncXMzxcXCn3fK6Gg2YLnTT6F2G9JXl9zc2lwfVfGOWEA==",
+        "resolved": "8.14.0",
+        "contentHash": "4jOpiA4THdtpLyMdAb24dtj7+6GmvhOhxf5XHLYWmPKF8ApEnApal1UnJsKO4HxUWRXDA6C4WQVfYyqsRhpNpQ==",
         "dependencies": {
-          "Microsoft.IdentityModel.Tokens": "7.6.2"
+          "Microsoft.IdentityModel.Tokens": "8.14.0"
         }
       },
       "Microsoft.IdentityModel.Logging": {
         "type": "Transitive",
-        "resolved": "7.6.2",
-        "contentHash": "0brV311MYxGz7Numa+pbVsxbz5tfe2nbAig1b5tQb3h/L1y5lkoPyOgD0qAfI0iX1njbwr8l9NdxIT1cDbzWKA==",
+        "resolved": "8.14.0",
+        "contentHash": "eqqnemdW38CKZEHS6diA50BV94QICozDZEvSrsvN3SJXUFwVB9gy+/oz76gldP7nZliA16IglXjXTCTdmU/Ejg==",
         "dependencies": {
-          "Microsoft.IdentityModel.Abstractions": "7.6.2"
+          "Microsoft.IdentityModel.Abstractions": "8.14.0"
         }
       },
       "Microsoft.IdentityModel.Protocols": {
@@ -894,10 +894,11 @@
       },
       "Microsoft.IdentityModel.Tokens": {
         "type": "Transitive",
-        "resolved": "7.6.2",
-        "contentHash": "pLnhCq9UNKWkn83zutkObYuzA+sOzx6VZpPI8hB8gD/vAXVt14D0SJ0sKPftwufvAbYGSNRda1vw/IFLbkjxNg==",
+        "resolved": "8.14.0",
+        "contentHash": "lKIZiBiGd36k02TCdMHp1KlNWisyIvQxcYJvIkz7P4gSQ9zi8dgh6S5Grj8NNG7HWYIPfQymGyoZ6JB5d1Lo1g==",
         "dependencies": {
-          "Microsoft.IdentityModel.Logging": "7.6.2"
+          "Microsoft.Extensions.Logging.Abstractions": "8.0.0",
+          "Microsoft.IdentityModel.Logging": "8.14.0"
         }
       },
       "Microsoft.SemanticKernel": {
@@ -1062,8 +1063,8 @@
       },
       "System.IO.Hashing": {
         "type": "Transitive",
-        "resolved": "9.0.10",
-        "contentHash": "9gv5z71xaWWmcGEs4bXdreIhKp2kYLK2fvPK5gQkgnWMYvZ8ieaxKofDjxL3scZiEYfi/yW2nJTiKV2awcWEdA=="
+        "resolved": "9.0.11",
+        "contentHash": "c9tFngnvHiUsBPLW22QQBgcGe9xFvac9rg3QIRHxrY2gCUdy4s2M/gQHimH+Z4yR9Cj6xWTOsa8IYY5CIG8QFA=="
       },
       "System.IO.Pipelines": {
         "type": "Transitive",

--- a/src/Goldfinch.Web/App_Data/CIRepository/@global/cms.alternativeform/cms.class_cms.scheduledtaskconfiguration/create.xml
+++ b/src/Goldfinch.Web/App_Data/CIRepository/@global/cms.alternativeform/cms.class_cms.scheduledtaskconfiguration/create.xml
@@ -77,7 +77,6 @@
       <field column="StartTime" columnprecision="7" columntype="datetime" dummy="altform" enabled="true" guid="a0809a2a-0e97-406e-949c-06490e8f8cb6" system="true" visible="true" order="21">
         <properties>
           <defaultvalue ismacro="true">{% Now %}</defaultvalue>
-          <explanationtext>{$base.scheduledtasks.starttime.explanationtext$}</explanationtext>
           <explanationtextashtml>False</explanationtextashtml>
           <fieldcaption>{$base.scheduledtasks.starttime$}</fieldcaption>
           <fielddescription>{$base.scheduledtasks.starttime.tooltip$}</fielddescription>

--- a/src/Goldfinch.Web/App_Data/CIRepository/@global/cms.alternativeform/cms.class_commerce.promotion/create.xml
+++ b/src/Goldfinch.Web/App_Data/CIRepository/@global/cms.alternativeform/cms.class_commerce.promotion/create.xml
@@ -1,0 +1,77 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<cms.alternativeform>
+  <FormClassID>
+    <CodeName>Commerce.Promotion</CodeName>
+    <GUID>ab59f73e-52f1-43ec-b9cb-edbc91b011fa</GUID>
+    <ObjectType>cms.class</ObjectType>
+  </FormClassID>
+  <FormCustomizedColumns />
+  <FormDefinition>
+    <form>
+      <field column="PromotionID" guid="eab0124a-706e-4788-b112-b3e01e3f316b" enabled="" />
+      <field column="PromotionGUID" guid="8e08153e-ce43-4a33-a54d-1546d3882d20" enabled="" order="1" />
+      <field column="PromotionCreatedWhen" guid="1972decf-2692-46c5-b250-54940857d779" enabled="" order="2" />
+      <field column="PromotionCreatedByUserID" guid="cf2648d2-4fee-4636-99f2-2c5e2f4b669a" enabled="" order="3" />
+      <field column="PromotionModifiedWhen" guid="cdf9102f-8f1c-497d-afbb-8d6ab51d5d0d" enabled="" order="4" />
+      <field column="PromotionModifiedByUserID" guid="e8be80b6-50f0-4add-a4e5-511778b50ce1" enabled="" order="5" />
+      <field column="PromotionActiveFromWhen" guid="b0cb650c-4ac0-4477-866b-832897990847" enabled="" order="6" />
+      <field column="PromotionActiveToWhen" guid="fb428099-9edc-4822-b30e-d8aea0da75a0" enabled="" order="7" />
+      <field column="PromotionType" guid="8ac9828a-9999-4730-8d9c-f751dd076cc8" enabled="" order="8" />
+      <category name="General" order="9">
+        <properties>
+          <caption>
+            <![CDATA[{$digitalcommerce.promotions.edit.general.headline$}]]>
+          </caption>
+          <visible>true</visible>
+        </properties>
+      </category>
+      <field column="PromotionDisplayName" enabled="true" guid="8ae46dc2-c55c-4cc7-baca-0cce24a23240" visible="true" order="10">
+        <settings>
+          <controlname>Kentico.Administration.TextInput</controlname>
+        </settings>
+        <properties>
+          <explanationtextashtml>False</explanationtextashtml>
+          <fieldcaption>
+            <![CDATA[{$digitalcommerce.promotions.edit.displayname.caption$}]]>
+          </fieldcaption>
+          <fielddescriptionashtml>False</fielddescriptionashtml>
+        </properties>
+      </field>
+      <field column="PromotionName" enabled="true" guid="c1f9efa9-1109-4618-b221-be668bd8dfa0" visible="true" order="11">
+        <settings>
+          <controlname>Kentico.Administration.CodeName</controlname>
+          <HasAutomaticCodeNameGenerationOption>True</HasAutomaticCodeNameGenerationOption>
+          <IsCollapsed>True</IsCollapsed>
+        </settings>
+        <properties>
+          <explanationtextashtml>False</explanationtextashtml>
+          <fieldcaption>
+            <![CDATA[{$digitalcommerce.promotioninfo.edit.name.caption$}]]>
+          </fieldcaption>
+          <fielddescriptionashtml>False</fielddescriptionashtml>
+        </properties>
+      </field>
+      <field column="PromotionDescription" enabled="true" guid="f6ffb212-fb11-476e-958a-66e75a3625d7" visible="true" order="12">
+        <settings>
+          <controlname>Kentico.Administration.TextArea</controlname>
+          <CopyButtonVisible>False</CopyButtonVisible>
+          <MaxRowsNumber>5</MaxRowsNumber>
+          <MinRowsNumber>3</MinRowsNumber>
+        </settings>
+        <properties>
+          <explanationtextashtml>False</explanationtextashtml>
+          <fieldcaption>
+            <![CDATA[{$digitalcommerce.promotions.edit.description.caption$}]]>
+          </fieldcaption>
+          <fielddescriptionashtml>False</fielddescriptionashtml>
+        </properties>
+      </field>
+      <field column="PromotionRuleConfiguration" guid="8419163c-7f62-47f3-8c5f-fd034bef93b1" enabled="" />
+      <field column="PromotionRuleIdentifier" guid="64ad0f50-f11b-45af-bfc9-c99825ba0230" enabled="" order="14" />
+    </form>
+  </FormDefinition>
+  <FormDisplayName>Create promotion</FormDisplayName>
+  <FormGUID>dc8b6bba-3d0f-4206-b4bf-0bbd451e0592</FormGUID>
+  <FormIsCustom>False</FormIsCustom>
+  <FormName>create</FormName>
+</cms.alternativeform>

--- a/src/Goldfinch.Web/App_Data/CIRepository/@global/cms.alternativeform/cms.class_commerce.promotion/edit.xml
+++ b/src/Goldfinch.Web/App_Data/CIRepository/@global/cms.alternativeform/cms.class_commerce.promotion/edit.xml
@@ -1,0 +1,77 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<cms.alternativeform>
+  <FormClassID>
+    <CodeName>Commerce.Promotion</CodeName>
+    <GUID>ab59f73e-52f1-43ec-b9cb-edbc91b011fa</GUID>
+    <ObjectType>cms.class</ObjectType>
+  </FormClassID>
+  <FormCustomizedColumns />
+  <FormDefinition>
+    <form>
+      <field column="PromotionID" guid="eab0124a-706e-4788-b112-b3e01e3f316b" enabled="" />
+      <field column="PromotionGUID" guid="8e08153e-ce43-4a33-a54d-1546d3882d20" enabled="" order="1" />
+      <field column="PromotionCreatedWhen" guid="1972decf-2692-46c5-b250-54940857d779" enabled="" order="2" />
+      <field column="PromotionCreatedByUserID" guid="cf2648d2-4fee-4636-99f2-2c5e2f4b669a" enabled="" order="3" />
+      <field column="PromotionModifiedWhen" guid="cdf9102f-8f1c-497d-afbb-8d6ab51d5d0d" enabled="" order="4" />
+      <field column="PromotionModifiedByUserID" guid="e8be80b6-50f0-4add-a4e5-511778b50ce1" enabled="" order="5" />
+      <field column="PromotionActiveFromWhen" guid="b0cb650c-4ac0-4477-866b-832897990847" enabled="" order="6" />
+      <field column="PromotionActiveToWhen" guid="fb428099-9edc-4822-b30e-d8aea0da75a0" enabled="" order="7" />
+      <field column="PromotionType" guid="8ac9828a-9999-4730-8d9c-f751dd076cc8" enabled="" order="8" />
+      <field column="PromotionRuleIdentifier" guid="64ad0f50-f11b-45af-bfc9-c99825ba0230" enabled="" order="9" />
+      <field column="PromotionRuleConfiguration" guid="8419163c-7f62-47f3-8c5f-fd034bef93b1" enabled="" order="10" />
+      <category name="General" order="11">
+        <properties>
+          <caption>
+            <![CDATA[{$digitalcommerce.promotions.edit.general.headline$}]]>
+          </caption>
+          <visible>true</visible>
+        </properties>
+      </category>
+      <field column="PromotionDisplayName" enabled="true" guid="8ae46dc2-c55c-4cc7-baca-0cce24a23240" visible="true" order="12">
+        <settings>
+          <controlname>Kentico.Administration.TextInput</controlname>
+        </settings>
+        <properties>
+          <explanationtextashtml>False</explanationtextashtml>
+          <fieldcaption>
+            <![CDATA[{$digitalcommerce.promotions.edit.displayname.caption$}]]>
+          </fieldcaption>
+          <fielddescriptionashtml>False</fielddescriptionashtml>
+        </properties>
+      </field>
+      <field column="PromotionName" enabled="true" guid="c1f9efa9-1109-4618-b221-be668bd8dfa0" visible="true" order="13">
+        <settings>
+          <controlname>Kentico.Administration.CodeName</controlname>
+          <HasAutomaticCodeNameGenerationOption>True</HasAutomaticCodeNameGenerationOption>
+          <IsCollapsed>True</IsCollapsed>
+        </settings>
+        <properties>
+          <explanationtextashtml>False</explanationtextashtml>
+          <fieldcaption>
+            <![CDATA[{$digitalcommerce.promotioninfo.edit.name.caption$}]]>
+          </fieldcaption>
+          <fielddescriptionashtml>False</fielddescriptionashtml>
+        </properties>
+      </field>
+      <field column="PromotionDescription" enabled="true" guid="f6ffb212-fb11-476e-958a-66e75a3625d7" visible="true" order="14">
+        <settings>
+          <controlname>Kentico.Administration.TextArea</controlname>
+          <CopyButtonVisible>False</CopyButtonVisible>
+          <MaxRowsNumber>5</MaxRowsNumber>
+          <MinRowsNumber>3</MinRowsNumber>
+        </settings>
+        <properties>
+          <explanationtextashtml>False</explanationtextashtml>
+          <fieldcaption>
+            <![CDATA[{$digitalcommerce.promotions.edit.description.caption$}]]>
+          </fieldcaption>
+          <fielddescriptionashtml>False</fielddescriptionashtml>
+        </properties>
+      </field>
+    </form>
+  </FormDefinition>
+  <FormDisplayName>Edit promotion</FormDisplayName>
+  <FormGUID>b17e8726-ced6-44c3-89f5-a7c3e07a7eec</FormGUID>
+  <FormIsCustom>False</FormIsCustom>
+  <FormName>edit</FormName>
+</cms.alternativeform>

--- a/src/Goldfinch.Web/App_Data/CIRepository/@global/cms.alternativeform/cms.class_commerce.promotion/propertiesreadonly.xml
+++ b/src/Goldfinch.Web/App_Data/CIRepository/@global/cms.alternativeform/cms.class_commerce.promotion/propertiesreadonly.xml
@@ -1,0 +1,123 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<cms.alternativeform>
+  <FormClassID>
+    <CodeName>Commerce.Promotion</CodeName>
+    <GUID>ab59f73e-52f1-43ec-b9cb-edbc91b011fa</GUID>
+    <ObjectType>cms.class</ObjectType>
+  </FormClassID>
+  <FormCustomizedColumns />
+  <FormDefinition>
+    <form>
+      <field column="PromotionID" guid="eab0124a-706e-4788-b112-b3e01e3f316b" enabled="" />
+      <field column="PromotionName" guid="c1f9efa9-1109-4618-b221-be668bd8dfa0" enabled="" order="1" />
+      <field column="PromotionGUID" guid="8e08153e-ce43-4a33-a54d-1546d3882d20" enabled="" order="2" />
+      <field column="PromotionDescription" guid="f6ffb212-fb11-476e-958a-66e75a3625d7" enabled="" order="3" />
+      <field column="PromotionEnabled" guid="bf4f4d86-0641-4578-a411-691eaab47819" order="4" />
+      <field column="PromotionCreatedByUserID" guid="cf2648d2-4fee-4636-99f2-2c5e2f4b669a" enabled="" order="5" />
+      <field column="PromotionModifiedByUserID" guid="e8be80b6-50f0-4add-a4e5-511778b50ce1" enabled="" order="6" />
+      <field column="PromotionType" guid="8ac9828a-9999-4730-8d9c-f751dd076cc8" enabled="" order="7" />
+      <field column="PromotionRuleIdentifier" guid="64ad0f50-f11b-45af-bfc9-c99825ba0230" enabled="" order="8" />
+      <field column="PromotionRuleConfiguration" guid="8419163c-7f62-47f3-8c5f-fd034bef93b1" enabled="" order="9" />
+      <field column="PromotionDisplayName" enabled="true" guid="8ae46dc2-c55c-4cc7-baca-0cce24a23240" visible="true" order="10">
+        <settings>
+          <controlname>Kentico.Administration.TextWithLabel</controlname>
+        </settings>
+        <properties>
+          <explanationtextashtml>False</explanationtextashtml>
+          <fieldcaption>
+            <![CDATA[{$digitalcommerce.promotions.edit.properties.displayname$}]]>
+          </fieldcaption>
+          <fielddescriptionashtml>False</fielddescriptionashtml>
+        </properties>
+      </field>
+      <field column="PromotionStatus" columnprecision="0" columnsize="200" columntype="text" dummy="altform" enabled="true" guid="d80a13e0-2dc3-4daa-945f-28de6cf2ee5a" system="true" visible="true" order="11">
+        <properties>
+          <explanationtextashtml>False</explanationtextashtml>
+          <fieldcaption>
+            <![CDATA[{$digitalcommerce.promotions.edit.properties.status$}]]>
+          </fieldcaption>
+          <fielddescriptionashtml>False</fielddescriptionashtml>
+        </properties>
+        <settings>
+          <controlname>Kentico.Administration.TextWithLabel</controlname>
+        </settings>
+      </field>
+      <field column="PromotionActiveFromWhen" enabled="true" guid="b0cb650c-4ac0-4477-866b-832897990847" visible="true" order="12">
+        <settings>
+          <controlname>Kentico.Administration.DateTimeString</controlname>
+        </settings>
+        <properties>
+          <explanationtextashtml>False</explanationtextashtml>
+          <fieldcaption>
+            <![CDATA[{$digitalcommerce.promotions.edit.properties.activefrom$}]]>
+          </fieldcaption>
+          <fielddescriptionashtml>False</fielddescriptionashtml>
+        </properties>
+      </field>
+      <field column="PromotionActiveToWhen" enabled="true" guid="fb428099-9edc-4822-b30e-d8aea0da75a0" visible="true" order="13">
+        <settings>
+          <controlname>Kentico.Administration.DateTimeString</controlname>
+        </settings>
+        <properties>
+          <explanationtextashtml>False</explanationtextashtml>
+          <fieldcaption>
+            <![CDATA[{$digitalcommerce.promotions.edit.properties.activeto$}]]>
+          </fieldcaption>
+          <fielddescriptionashtml>False</fielddescriptionashtml>
+        </properties>
+      </field>
+      <field column="PromotionCreatedWhen" enabled="true" guid="1972decf-2692-46c5-b250-54940857d779" visible="true" order="14">
+        <settings>
+          <controlname>Kentico.Administration.DateTimeString</controlname>
+        </settings>
+        <properties>
+          <explanationtextashtml>False</explanationtextashtml>
+          <fieldcaption>
+            <![CDATA[{$digitalcommerce.promotions.edit.properties.created$}]]>
+          </fieldcaption>
+          <fielddescriptionashtml>False</fielddescriptionashtml>
+        </properties>
+      </field>
+      <field column="PromotionCreatedBy" columnprecision="0" columnsize="200" columntype="text" dummy="altform" enabled="true" guid="f6acfa6b-43a6-4c9b-b358-1f18641ed9ba" system="true" visible="true" order="15">
+        <properties>
+          <explanationtextashtml>False</explanationtextashtml>
+          <fieldcaption>
+            <![CDATA[{$digitalcommerce.promotions.edit.properties.createdby$}]]>
+          </fieldcaption>
+          <fielddescriptionashtml>False</fielddescriptionashtml>
+        </properties>
+        <settings>
+          <controlname>Kentico.Administration.TextWithLabel</controlname>
+        </settings>
+      </field>
+      <field column="PromotionModifiedWhen" enabled="true" guid="cdf9102f-8f1c-497d-afbb-8d6ab51d5d0d" visible="true" order="16">
+        <settings>
+          <controlname>Kentico.Administration.DateTimeString</controlname>
+        </settings>
+        <properties>
+          <explanationtextashtml>False</explanationtextashtml>
+          <fieldcaption>
+            <![CDATA[{$digitalcommerce.promotions.edit.properties.modified$}]]>
+          </fieldcaption>
+          <fielddescriptionashtml>False</fielddescriptionashtml>
+        </properties>
+      </field>
+      <field allowempty="true" column="PromotionModifiedBy" columnprecision="0" columnsize="200" columntype="text" dummy="altform" enabled="true" guid="cd5bc893-481e-46d3-a151-22973397de62" system="true" visible="true" order="17">
+        <properties>
+          <explanationtextashtml>False</explanationtextashtml>
+          <fieldcaption>
+            <![CDATA[{$digitalcommerce.promotions.edit.properties.modifiedby$}]]>
+          </fieldcaption>
+          <fielddescriptionashtml>False</fielddescriptionashtml>
+        </properties>
+        <settings>
+          <controlname>Kentico.Administration.TextWithLabel</controlname>
+        </settings>
+      </field>
+    </form>
+  </FormDefinition>
+  <FormDisplayName>Properties</FormDisplayName>
+  <FormGUID>0446f5af-dd5c-4413-8fbb-c9d45a37170f</FormGUID>
+  <FormIsCustom>False</FormIsCustom>
+  <FormName>PropertiesReadOnly</FormName>
+</cms.alternativeform>

--- a/src/Goldfinch.Web/App_Data/CIRepository/@global/cms.alternativeform/cms.systemtable_commerce.order/orderdetailreadonly.xml
+++ b/src/Goldfinch.Web/App_Data/CIRepository/@global/cms.alternativeform/cms.systemtable_commerce.order/orderdetailreadonly.xml
@@ -38,8 +38,7 @@
           <controlname>Kentico.Administration.TextWithLabel</controlname>
         </settings>
       </field>
-      <field column="OrderShippingMethodID" guid="a0795994-0938-46e6-b2f5-af61aeacc43b" enabled="" order="12" />
-      <field column="CustomerDetail" columnprecision="0" columnsize="200" columntype="text" dummy="altform" enabled="true" guid="8f2126a6-65db-471f-a2b5-946155703487" system="true" visible="true" order="13">
+      <field column="CustomerDetail" columnprecision="0" columnsize="200" columntype="text" dummy="altform" enabled="true" guid="8f2126a6-65db-471f-a2b5-946155703487" system="true" visible="true" order="12">
         <properties>
           <explanationtextashtml>False</explanationtextashtml>
           <fieldcaption>
@@ -52,7 +51,7 @@
           <OpenInNewTab>True</OpenInNewTab>
         </settings>
       </field>
-      <field column="CustomerIsMember" columnprecision="0" columnsize="200" columntype="text" dummy="altform" enabled="true" guid="e95d661b-96b0-4b39-a5d0-7c1a039e028f" system="true" visible="true" order="14">
+      <field column="CustomerIsMember" columnprecision="0" columnsize="200" columntype="text" dummy="altform" enabled="true" guid="e95d661b-96b0-4b39-a5d0-7c1a039e028f" system="true" visible="true" order="13">
         <properties>
           <explanationtextashtml>False</explanationtextashtml>
           <fieldcaption>
@@ -64,10 +63,11 @@
           <controlname>Kentico.Administration.TextWithLabel</controlname>
         </settings>
       </field>
-      <field column="OrderPaymentMethodDisplayName" guid="63d2da12-19f5-4a7f-9039-8c25954cf8c4" enabled="" order="15" />
-      <field column="OrderShippingMethodDisplayName" guid="692816cc-abb8-44ba-b7e5-6ca70ff517fd" enabled="" order="16" />
-      <field column="OrderShippingMethodPrice" guid="aba81771-ba51-43f2-bcd2-102de1d0f3c8" enabled="" order="17" />
-      <field column="OrderPaymentMethodID" guid="dad82dbd-a987-420e-9b00-79efb7c5ba7c" enabled="" order="18" />
+      <field column="OrderPaymentMethodDisplayName" guid="63d2da12-19f5-4a7f-9039-8c25954cf8c4" enabled="" order="14" />
+      <field column="OrderShippingMethodDisplayName" guid="692816cc-abb8-44ba-b7e5-6ca70ff517fd" enabled="" order="15" />
+      <field column="OrderShippingMethodPrice" guid="aba81771-ba51-43f2-bcd2-102de1d0f3c8" enabled="" order="16" />
+      <field column="OrderPaymentMethodID" guid="dad82dbd-a987-420e-9b00-79efb7c5ba7c" enabled="" order="17" />
+      <field column="OrderShippingMethodID" guid="a0795994-0938-46e6-b2f5-af61aeacc43b" enabled="" order="18" />
     </form>
   </FormDefinition>
   <FormDisplayName>Order detail</FormDisplayName>

--- a/src/Goldfinch.Web/App_Data/CIRepository/@global/cms.alternativeform/cms.systemtable_commerce.order/ordertotalsreadonly.xml
+++ b/src/Goldfinch.Web/App_Data/CIRepository/@global/cms.alternativeform/cms.systemtable_commerce.order/ordertotalsreadonly.xml
@@ -29,7 +29,19 @@
           <controlname>Kentico.Administration.TextWithLabel</controlname>
         </settings>
       </field>
-      <field column="OrderTotalShippingText" columnprecision="0" columnsize="200" columntype="text" dummy="altform" enabled="true" guid="7b925825-9953-42f2-aeea-31a9428fe35f" system="true" visible="true" order="11">
+      <field column="OrderDiscountText" columnprecision="0" columnsize="200" columntype="text" dummy="altform" enabled="true" guid="ca043326-b721-446c-abc4-dbc1dc5a48e8" system="true" visible="true" order="11">
+        <properties>
+          <explanationtextashtml>False</explanationtextashtml>
+          <fieldcaption>
+            <![CDATA[{$digitalcommerce.order.ordertotals.orderdiscount$}]]>
+          </fieldcaption>
+          <fielddescriptionashtml>False</fielddescriptionashtml>
+        </properties>
+        <settings>
+          <controlname>Kentico.Administration.TextWithLabel</controlname>
+        </settings>
+      </field>
+      <field column="OrderTotalShippingText" columnprecision="0" columnsize="200" columntype="text" dummy="altform" enabled="true" guid="7b925825-9953-42f2-aeea-31a9428fe35f" system="true" visible="true" order="12">
         <properties>
           <explanationtextashtml>False</explanationtextashtml>
           <fieldcaption>{$digitalcommerce.order.ordertotals.shipping$}</fieldcaption>
@@ -39,7 +51,7 @@
           <controlname>Kentico.Administration.TextWithLabel</controlname>
         </settings>
       </field>
-      <field column="OrderTotalTaxText" columnprecision="0" columnsize="200" columntype="text" dummy="altform" enabled="true" guid="7e6a6cff-1948-45de-b7d4-3fbc4b059249" system="true" visible="true" order="12">
+      <field column="OrderTotalTaxText" columnprecision="0" columnsize="200" columntype="text" dummy="altform" enabled="true" guid="7e6a6cff-1948-45de-b7d4-3fbc4b059249" system="true" visible="true" order="13">
         <properties>
           <explanationtextashtml>False</explanationtextashtml>
           <fieldcaption>{$digitalcommerce.order.ordertotals.tax$}</fieldcaption>
@@ -49,7 +61,7 @@
           <controlname>Kentico.Administration.TextWithLabel</controlname>
         </settings>
       </field>
-      <field column="OrderGrandTotalText" columnprecision="0" columnsize="200" columntype="text" dummy="altform" enabled="true" guid="9c66a6ed-3f35-406c-85ac-f246936cfdb2" system="true" visible="true" order="13">
+      <field column="OrderGrandTotalText" columnprecision="0" columnsize="200" columntype="text" dummy="altform" enabled="true" guid="9c66a6ed-3f35-406c-85ac-f246936cfdb2" system="true" visible="true" order="14">
         <properties>
           <explanationtextashtml>False</explanationtextashtml>
           <fieldcaption>{$digitalcommerce.order.ordertotals.total$}</fieldcaption>
@@ -59,12 +71,12 @@
           <controlname>Kentico.Administration.TextWithLabel</controlname>
         </settings>
       </field>
-      <field column="OrderOrderStatusID" guid="dbf0718d-a704-4c2b-a559-6616b8802d0c" enabled="" order="14" />
-      <field column="OrderPaymentMethodDisplayName" guid="63d2da12-19f5-4a7f-9039-8c25954cf8c4" enabled="" order="15" />
-      <field column="OrderShippingMethodDisplayName" guid="692816cc-abb8-44ba-b7e5-6ca70ff517fd" enabled="" order="16" />
-      <field column="OrderShippingMethodPrice" guid="aba81771-ba51-43f2-bcd2-102de1d0f3c8" enabled="" order="17" />
-      <field column="OrderPaymentMethodID" guid="dad82dbd-a987-420e-9b00-79efb7c5ba7c" enabled="" order="18" />
-      <field column="OrderShippingMethodID" guid="a0795994-0938-46e6-b2f5-af61aeacc43b" enabled="" order="19" />
+      <field column="OrderOrderStatusID" guid="dbf0718d-a704-4c2b-a559-6616b8802d0c" enabled="" order="15" />
+      <field column="OrderPaymentMethodDisplayName" guid="63d2da12-19f5-4a7f-9039-8c25954cf8c4" enabled="" order="16" />
+      <field column="OrderShippingMethodDisplayName" guid="692816cc-abb8-44ba-b7e5-6ca70ff517fd" enabled="" order="17" />
+      <field column="OrderShippingMethodPrice" guid="aba81771-ba51-43f2-bcd2-102de1d0f3c8" enabled="" order="18" />
+      <field column="OrderPaymentMethodID" guid="dad82dbd-a987-420e-9b00-79efb7c5ba7c" enabled="" order="19" />
+      <field column="OrderShippingMethodID" guid="a0795994-0938-46e6-b2f5-af61aeacc43b" enabled="" order="20" />
     </form>
   </FormDefinition>
   <FormDisplayName>Order totals</FormDisplayName>

--- a/src/Goldfinch.Web/App_Data/CIRepository/@global/cms.alternativeform/cms.systemtable_om.contact/contactedit.xml
+++ b/src/Goldfinch.Web/App_Data/CIRepository/@global/cms.alternativeform/cms.systemtable_om.contact/contactedit.xml
@@ -44,7 +44,6 @@
           <controlname>Kentico.Administration.DateTimeInput</controlname>
         </settings>
         <properties>
-          <explanationtext>{$base.forms.datetimeinput.explanation$}</explanationtext>
           <explanationtextashtml>False</explanationtextashtml>
           <fieldcaption>{$digitalmarketing.contact.birthday$}</fieldcaption>
           <fielddescriptionashtml>False</fielddescriptionashtml>

--- a/src/Goldfinch.Web/App_Data/CIRepository/@global/cms.alternativeform/cms.systemtable_om.contact/setcontactfieldvalueautomationstep.xml
+++ b/src/Goldfinch.Web/App_Data/CIRepository/@global/cms.alternativeform/cms.systemtable_om.contact/setcontactfieldvalueautomationstep.xml
@@ -61,7 +61,6 @@
           <controlname>Kentico.Administration.DateTimeInput</controlname>
         </settings>
         <properties>
-          <explanationtext>{$base.forms.datetimeinput.explanation$}</explanationtext>
           <explanationtextashtml>False</explanationtextashtml>
           <fieldcaption>{$digitalmarketing.contact.birthday$}</fieldcaption>
           <fielddescriptionashtml>False</fielddescriptionashtml>

--- a/src/Goldfinch.Web/App_Data/CIRepository/@global/cms.class/cms.contentitemlanguagemetadata.xml
+++ b/src/Goldfinch.Web/App_Data/CIRepository/@global/cms.class/cms.contentitemlanguagemetadata.xml
@@ -25,6 +25,7 @@
       <field allowempty="true" column="ContentItemLanguageMetadataContentWorkflowStepID" columnprecision="0" columntype="integer" enabled="true" guid="ad9637bd-85d3-4194-a29e-894e68ee76c5" refobjtype="cms.contentworkflowstep" reftype="NotRequired" system="true" />
       <field allowempty="true" column="ContentItemLanguageMetadataScheduledPublishWhen" columnprecision="7" columntype="datetime" enabled="true" guid="3a89fc79-bcdf-4b48-8c7b-fcc9192b8e70" system="true" />
       <field allowempty="true" column="ContentItemLanguageMetadataScheduledUnpublishWhen" columnprecision="7" columntype="datetime" enabled="true" guid="eecec463-c5c0-4062-8424-60711d2fd67c" system="true" />
+      <field allowempty="true" column="ContentItemLanguageMetadataShareablePreviewGUID" columnprecision="0" columntype="guid" enabled="true" guid="2cd89aeb-1207-4f80-89e2-732b6c541971" system="true" />
     </form>
   </ClassFormDefinition>
   <ClassGUID>b80834cb-b865-483f-87d3-e1725a66bd37</ClassGUID>

--- a/src/Goldfinch.Web/App_Data/CIRepository/@global/cms.class/commerce.orderpromotion.xml
+++ b/src/Goldfinch.Web/App_Data/CIRepository/@global/cms.class/commerce.orderpromotion.xml
@@ -1,0 +1,29 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<cms.class>
+  <ClassDisplayName>Order promotion</ClassDisplayName>
+  <ClassFormDefinition>
+    <form>
+      <field column="OrderPromotionID" columntype="integer" enabled="true" guid="ee1cf65b-05b9-4921-995c-beb83ae10f5d" isPK="true" system="true" />
+      <field allowempty="true" column="OrderPromotionPromotionID" columnprecision="0" columntype="integer" enabled="true" guid="c7d00b11-cf56-4d17-8e03-6d5e6e443869" refobjtype="commerce.promotion" reftype="NotRequired" system="true" />
+      <field column="OrderPromotionOrderID" columnprecision="0" columntype="integer" enabled="true" guid="d1d1d3dc-c6a1-4b63-9929-43a347545f8a" refobjtype="commerce.order" reftype="Required" system="true" />
+      <field allowempty="true" column="OrderPromotionOrderItemID" columnprecision="0" columntype="integer" enabled="true" guid="267e1c41-be75-4f99-ac65-07ae0d093e65" refobjtype="commerce.orderitem" reftype="Required" system="true" />
+      <field column="OrderPromotionPromotionDisplayName" columnprecision="0" columnsize="200" columntype="text" enabled="true" guid="e7abfdfc-65a0-46de-9168-9634f5e8ffd4" system="true" />
+      <field column="OrderPromotionDiscountAmount" columnprecision="4" columnsize="19" columntype="decimal" enabled="true" guid="0ec45993-cb89-43b2-8a33-acf71d7ccfd3" system="true">
+        <properties>
+          <defaultvalue>0</defaultvalue>
+        </properties>
+      </field>
+      <field column="OrderPromotionPromotionType" columnprecision="0" columnsize="50" columntype="text" enabled="true" guid="a30f9d2e-ffdf-4249-80d7-9bafd96d00a3" system="true" />
+    </form>
+  </ClassFormDefinition>
+  <ClassGUID>e5af20e2-61c8-4d37-be94-e38b0c217de8</ClassGUID>
+  <ClassHasUnmanagedDbSchema>False</ClassHasUnmanagedDbSchema>
+  <ClassName>Commerce.OrderPromotion</ClassName>
+  <ClassResourceID>
+    <CodeName>CMS.Commerce</CodeName>
+    <GUID>4975d347-eb67-4a9c-a5d6-76997340b8ac</GUID>
+    <ObjectType>cms.resource</ObjectType>
+  </ClassResourceID>
+  <ClassTableName>Commerce_OrderPromotion</ClassTableName>
+  <ClassType>Other</ClassType>
+</cms.class>

--- a/src/Goldfinch.Web/App_Data/CIRepository/@global/cms.class/commerce.promotion.xml
+++ b/src/Goldfinch.Web/App_Data/CIRepository/@global/cms.class/commerce.promotion.xml
@@ -1,0 +1,32 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<cms.class>
+  <ClassDisplayName>Promotion</ClassDisplayName>
+  <ClassFormDefinition>
+    <form>
+      <field column="PromotionID" columntype="integer" enabled="true" guid="eab0124a-706e-4788-b112-b3e01e3f316b" isPK="true" system="true" />
+      <field column="PromotionDisplayName" columnprecision="0" columnsize="200" columntype="text" enabled="true" guid="8ae46dc2-c55c-4cc7-baca-0cce24a23240" system="true" />
+      <field column="PromotionName" columnprecision="0" columnsize="200" columntype="text" enabled="true" guid="c1f9efa9-1109-4618-b221-be668bd8dfa0" system="true" />
+      <field column="PromotionGUID" columnprecision="0" columntype="guid" enabled="true" guid="8e08153e-ce43-4a33-a54d-1546d3882d20" system="true" />
+      <field allowempty="true" column="PromotionDescription" columnprecision="0" columntype="longtext" enabled="true" guid="f6ffb212-fb11-476e-958a-66e75a3625d7" system="true" />
+      <field column="PromotionCreatedWhen" columnprecision="7" columntype="datetime" enabled="true" guid="1972decf-2692-46c5-b250-54940857d779" system="true" />
+      <field allowempty="true" column="PromotionCreatedByUserID" columnprecision="0" columntype="integer" enabled="true" guid="cf2648d2-4fee-4636-99f2-2c5e2f4b669a" refobjtype="cms.user" reftype="NotRequired" system="true" />
+      <field column="PromotionModifiedWhen" columnprecision="7" columntype="datetime" enabled="true" guid="cdf9102f-8f1c-497d-afbb-8d6ab51d5d0d" system="true" />
+      <field allowempty="true" column="PromotionModifiedByUserID" columnprecision="0" columntype="integer" enabled="true" guid="e8be80b6-50f0-4add-a4e5-511778b50ce1" refobjtype="cms.user" reftype="NotRequired" system="true" />
+      <field allowempty="true" column="PromotionActiveFromWhen" columnprecision="7" columntype="datetime" enabled="true" guid="b0cb650c-4ac0-4477-866b-832897990847" system="true" />
+      <field allowempty="true" column="PromotionActiveToWhen" columnprecision="7" columntype="datetime" enabled="true" guid="fb428099-9edc-4822-b30e-d8aea0da75a0" system="true" />
+      <field column="PromotionType" columnprecision="0" columnsize="50" columntype="text" enabled="true" guid="8ac9828a-9999-4730-8d9c-f751dd076cc8" system="true" />
+      <field column="PromotionRuleIdentifier" columnprecision="0" columnsize="200" columntype="text" enabled="true" guid="64ad0f50-f11b-45af-bfc9-c99825ba0230" system="true" />
+      <field column="PromotionRuleConfiguration" columnprecision="0" columntype="longtext" enabled="true" guid="8419163c-7f62-47f3-8c5f-fd034bef93b1" system="true" />
+    </form>
+  </ClassFormDefinition>
+  <ClassGUID>ab59f73e-52f1-43ec-b9cb-edbc91b011fa</ClassGUID>
+  <ClassHasUnmanagedDbSchema>False</ClassHasUnmanagedDbSchema>
+  <ClassName>Commerce.Promotion</ClassName>
+  <ClassResourceID>
+    <CodeName>CMS.Commerce</CodeName>
+    <GUID>4975d347-eb67-4a9c-a5d6-76997340b8ac</GUID>
+    <ObjectType>cms.resource</ObjectType>
+  </ClassResourceID>
+  <ClassTableName>Commerce_Promotion</ClassTableName>
+  <ClassType>Other</ClassType>
+</cms.class>

--- a/src/Goldfinch.Web/App_Data/CIRepository/@global/cms.class/om.activitytype.xml
+++ b/src/Goldfinch.Web/App_Data/CIRepository/@global/cms.class/om.activitytype.xml
@@ -14,21 +14,11 @@
           <defaultvalue>true</defaultvalue>
         </properties>
       </field>
-      <field allowempty="true" column="ActivityTypeManualCreationAllowed" columntype="boolean" guid="cd4f230d-ddfc-4fc8-9772-99740c13dec2" system="true">
-        <properties>
-          <defaultvalue>false</defaultvalue>
-        </properties>
-      </field>
       <field allowempty="true" column="ActivityTypeEnabled" columntype="boolean" guid="9b57bc43-521f-478f-867b-83b5e381240f" system="true">
         <properties>
           <defaultvalue>true</defaultvalue>
         </properties>
       </field>
-      <field allowempty="true" column="ActivityTypeColor" columnsize="7" columntype="text" guid="8a9c7f23-05a0-4e0f-a987-306e3840b0d1" system="true" />
-      <field allowempty="true" column="ActivityTypeMainFormControl" columnsize="200" columntype="text" guid="b8e414ba-b56d-4191-8692-7dcbd990e758" system="true" />
-      <field allowempty="true" column="ActivityTypeItemObjectType" columnsize="200" columntype="text" guid="271a3ee0-26bf-492b-b2e3-fcf104631503" system="true" />
-      <field allowempty="true" column="ActivityTypeDetailFormControl" columnsize="200" columntype="text" guid="632db9b8-7929-473e-9e38-9b2d43a76024" system="true" />
-      <field allowempty="true" column="ActivityTypeItemDetailObjectType" columnsize="200" columntype="text" guid="e0796f9b-7948-4b6b-85a3-3dfc2951f018" system="true" />
     </form>
   </ClassFormDefinition>
   <ClassGUID>e1c6d908-d1f7-4495-a06b-c070ead822a9</ClassGUID>

--- a/src/Goldfinch.Web/App_Data/CIRepository/@global/cms.contenttype/goldfinch.blogpost.xml
+++ b/src/Goldfinch.Web/App_Data/CIRepository/@global/cms.contenttype/goldfinch.blogpost.xml
@@ -13,7 +13,6 @@
       </schema>
       <field column="BlogPostDate" columnprecision="0" columntype="date" enabled="true" guid="5297ab96-9ac0-4a56-a398-646ee2249bd4" visible="true">
         <properties>
-          <explanationtext>{$base.forms.dateinput.explanation$}</explanationtext>
           <explanationtextashtml>False</explanationtextashtml>
           <fieldcaption>Post Date</fieldcaption>
           <fielddescriptionashtml>False</fielddescriptionashtml>

--- a/src/Goldfinch.Web/App_Data/CIRepository/@global/cms.contenttype/goldfinch.speakingengagement.xml
+++ b/src/Goldfinch.Web/App_Data/CIRepository/@global/cms.contenttype/goldfinch.speakingengagement.xml
@@ -42,7 +42,6 @@
       </field>
       <field column="EventDate" columnprecision="0" columntype="date" enabled="true" guid="c98633a2-b2ed-4705-a542-15a226d1b6a9" visible="true">
         <properties>
-          <explanationtext>{$base.forms.dateinput.explanation$}</explanationtext>
           <explanationtextashtml>False</explanationtextashtml>
           <fieldcaption>Event Date</fieldcaption>
           <fielddescriptionashtml>False</fielddescriptionashtml>

--- a/src/Goldfinch.Web/App_Data/CIRepository/@global/cms.macrorule/cmscontacthasclickedonspecificemailurl.xml
+++ b/src/Goldfinch.Web/App_Data/CIRepository/@global/cms.macrorule/cmscontacthasclickedonspecificemailurl.xml
@@ -3,7 +3,9 @@
   <MacroRuleCondition>
     <![CDATA[Contact.ClickedOnSpecificLinkInEmail("{email}", "{op}", "{value}")]]>
   </MacroRuleCondition>
-  <MacroRuleDisplayName>Contact has clicked on email with specific URL</MacroRuleDisplayName>
+  <MacroRuleDisplayName>
+    <![CDATA[Contact has clicked an email link with specific URL]]>
+  </MacroRuleDisplayName>
   <MacroRuleEnabled>True</MacroRuleEnabled>
   <MacroRuleGUID>b2041a65-a82e-4a44-8ed5-df2e88d4f7a0</MacroRuleGUID>
   <MacroRuleIsCustom>False</MacroRuleIsCustom>

--- a/src/Goldfinch.Web/App_Data/CIRepository/@global/cms.settingscategory/cms.urls.shareablepreview.xml
+++ b/src/Goldfinch.Web/App_Data/CIRepository/@global/cms.settingscategory/cms.urls.shareablepreview.xml
@@ -1,0 +1,20 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<cms.settingscategory>
+  <CategoryDisplayName>
+    <![CDATA[{$base.settings.settingscategory.urls.shareablepreview$}]]>
+  </CategoryDisplayName>
+  <CategoryIconPath />
+  <CategoryIsCustom>False</CategoryIsCustom>
+  <CategoryIsGroup>True</CategoryIsGroup>
+  <CategoryName>CMS.URLs.ShareablePreview</CategoryName>
+  <CategoryOrder>5</CategoryOrder>
+  <CategoryParentID>
+    <CodeName>CMS.URLs</CodeName>
+    <ObjectType>cms.settingscategory</ObjectType>
+  </CategoryParentID>
+  <CategoryResourceID>
+    <CodeName>CMS</CodeName>
+    <GUID>ce1a65a0-80dc-4c53-b0e7-bdecf0aa8c02</GUID>
+    <ObjectType>cms.resource</ObjectType>
+  </CategoryResourceID>
+</cms.settingscategory>

--- a/src/Goldfinch.Web/App_Data/CIRepository/@global/cms.systemtable/commerce.orderitem.xml
+++ b/src/Goldfinch.Web/App_Data/CIRepository/@global/cms.systemtable/commerce.orderitem.xml
@@ -15,6 +15,16 @@
       <field allowempty="true" column="OrderItemQuantity" columnprecision="4" columnsize="19" columntype="decimal" enabled="true" guid="1f2ead4d-9a88-43fe-8eda-8759687934ba" system="true" />
       <field allowempty="true" column="OrderItemUnitPrice" columnprecision="4" columnsize="19" columntype="decimal" enabled="true" guid="aa9fad72-d252-4d7c-badb-ab08e55de7a1" system="true" />
       <field allowempty="true" column="OrderItemTotalPrice" columnprecision="4" columnsize="19" columntype="decimal" enabled="true" guid="13cd4ffa-61c4-4d63-8c80-4bf7583dc65c" system="true" />
+      <field column="OrderItemTotalTax" columnprecision="4" columnsize="19" columntype="decimal" enabled="true" guid="0d785149-57b9-4597-bc28-4214a4035473" system="true">
+        <properties>
+          <defaultvalue>0</defaultvalue>
+        </properties>
+      </field>
+      <field column="OrderItemTaxRate" columnprecision="4" columnsize="19" columntype="decimal" enabled="true" guid="604c33a0-56c0-4561-9cd7-ef9aee23c725" system="true">
+        <properties>
+          <defaultvalue>0</defaultvalue>
+        </properties>
+      </field>
     </form>
   </ClassFormDefinition>
   <ClassGUID>d3c43d67-7f6e-4c87-9c54-57606538d1d8</ClassGUID>

--- a/src/Goldfinch.Web/App_Data/CIRepository/@global/om.activitytype/bizformsubmit.xml
+++ b/src/Goldfinch.Web/App_Data/CIRepository/@global/om.activitytype/bizformsubmit.xml
@@ -1,6 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <om.activitytype>
-  <ActivityTypeColor>#D7EBBF</ActivityTypeColor>
   <ActivityTypeDescription>
 <![CDATA[
 The visitor submitted an on-line form.
@@ -10,8 +9,5 @@ The visitor submitted an on-line form.
   <ActivityTypeDisplayName>Form submission</ActivityTypeDisplayName>
   <ActivityTypeEnabled>True</ActivityTypeEnabled>
   <ActivityTypeIsCustom>False</ActivityTypeIsCustom>
-  <ActivityTypeItemObjectType>cms.form</ActivityTypeItemObjectType>
-  <ActivityTypeMainFormControl>BizFormSelector</ActivityTypeMainFormControl>
-  <ActivityTypeManualCreationAllowed>False</ActivityTypeManualCreationAllowed>
   <ActivityTypeName>bizformsubmit</ActivityTypeName>
 </om.activitytype>

--- a/src/Goldfinch.Web/App_Data/CIRepository/@global/om.activitytype/click.xml
+++ b/src/Goldfinch.Web/App_Data/CIRepository/@global/om.activitytype/click.xml
@@ -6,6 +6,5 @@
   <ActivityTypeDisplayName>Click</ActivityTypeDisplayName>
   <ActivityTypeEnabled>True</ActivityTypeEnabled>
   <ActivityTypeIsCustom>False</ActivityTypeIsCustom>
-  <ActivityTypeManualCreationAllowed>False</ActivityTypeManualCreationAllowed>
   <ActivityTypeName>click</ActivityTypeName>
 </om.activitytype>

--- a/src/Goldfinch.Web/App_Data/CIRepository/@global/om.activitytype/customactivity.xml
+++ b/src/Goldfinch.Web/App_Data/CIRepository/@global/om.activitytype/customactivity.xml
@@ -1,11 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <om.activitytype>
   <ActivityTypeDescription>Custom activity.</ActivityTypeDescription>
-  <ActivityTypeDetailFormControl>##default##</ActivityTypeDetailFormControl>
   <ActivityTypeDisplayName>Custom activity</ActivityTypeDisplayName>
   <ActivityTypeEnabled>True</ActivityTypeEnabled>
   <ActivityTypeIsCustom>True</ActivityTypeIsCustom>
-  <ActivityTypeMainFormControl>##default##</ActivityTypeMainFormControl>
-  <ActivityTypeManualCreationAllowed>True</ActivityTypeManualCreationAllowed>
   <ActivityTypeName>customactivity</ActivityTypeName>
 </om.activitytype>

--- a/src/Goldfinch.Web/App_Data/CIRepository/@global/om.activitytype/datainput.xml
+++ b/src/Goldfinch.Web/App_Data/CIRepository/@global/om.activitytype/datainput.xml
@@ -6,6 +6,5 @@
   <ActivityTypeDisplayName>Data input</ActivityTypeDisplayName>
   <ActivityTypeEnabled>True</ActivityTypeEnabled>
   <ActivityTypeIsCustom>False</ActivityTypeIsCustom>
-  <ActivityTypeManualCreationAllowed>False</ActivityTypeManualCreationAllowed>
   <ActivityTypeName>DataInput</ActivityTypeName>
 </om.activitytype>

--- a/src/Goldfinch.Web/App_Data/CIRepository/@global/om.activitytype/emailclick.xml
+++ b/src/Goldfinch.Web/App_Data/CIRepository/@global/om.activitytype/emailclick.xml
@@ -6,6 +6,5 @@
   <ActivityTypeDisplayName>Email click</ActivityTypeDisplayName>
   <ActivityTypeEnabled>True</ActivityTypeEnabled>
   <ActivityTypeIsCustom>False</ActivityTypeIsCustom>
-  <ActivityTypeManualCreationAllowed>False</ActivityTypeManualCreationAllowed>
   <ActivityTypeName>emailclick</ActivityTypeName>
 </om.activitytype>

--- a/src/Goldfinch.Web/App_Data/CIRepository/@global/om.activitytype/landingpage.xml
+++ b/src/Goldfinch.Web/App_Data/CIRepository/@global/om.activitytype/landingpage.xml
@@ -6,6 +6,5 @@
   <ActivityTypeDisplayName>Landing page</ActivityTypeDisplayName>
   <ActivityTypeEnabled>True</ActivityTypeEnabled>
   <ActivityTypeIsCustom>False</ActivityTypeIsCustom>
-  <ActivityTypeManualCreationAllowed>False</ActivityTypeManualCreationAllowed>
   <ActivityTypeName>landingpage</ActivityTypeName>
 </om.activitytype>

--- a/src/Goldfinch.Web/App_Data/CIRepository/@global/om.activitytype/memberregistration.xml
+++ b/src/Goldfinch.Web/App_Data/CIRepository/@global/om.activitytype/memberregistration.xml
@@ -4,6 +4,5 @@
   <ActivityTypeDisplayName>Member registration</ActivityTypeDisplayName>
   <ActivityTypeEnabled>True</ActivityTypeEnabled>
   <ActivityTypeIsCustom>False</ActivityTypeIsCustom>
-  <ActivityTypeManualCreationAllowed>False</ActivityTypeManualCreationAllowed>
   <ActivityTypeName>memberregistration</ActivityTypeName>
 </om.activitytype>

--- a/src/Goldfinch.Web/App_Data/CIRepository/@global/om.activitytype/pagevisit.xml
+++ b/src/Goldfinch.Web/App_Data/CIRepository/@global/om.activitytype/pagevisit.xml
@@ -4,6 +4,5 @@
   <ActivityTypeDisplayName>Page visit</ActivityTypeDisplayName>
   <ActivityTypeEnabled>True</ActivityTypeEnabled>
   <ActivityTypeIsCustom>False</ActivityTypeIsCustom>
-  <ActivityTypeManualCreationAllowed>False</ActivityTypeManualCreationAllowed>
   <ActivityTypeName>pagevisit</ActivityTypeName>
 </om.activitytype>

--- a/src/Goldfinch.Web/packages.lock.json
+++ b/src/Goldfinch.Web/packages.lock.json
@@ -4,14 +4,14 @@
     "net9.0": {
       "Kentico.Xperience.Admin": {
         "type": "Direct",
-        "requested": "[30.12.0, )",
-        "resolved": "30.12.0",
-        "contentHash": "10ibuKjLc9dZIsb/lHR639UHihFeMKDDdxUp8wO3CsdXPuZH+GX1cgoaAMEkU+Z44p2Gj5zwQAZNcBsmMtWmbA==",
+        "requested": "[31.0.0, )",
+        "resolved": "31.0.0",
+        "contentHash": "8IC208QUcTv5RuCOxkr7D65UHaLeqpQ9ekw9kZ7RiNosi690iv24p6/5mS/Vb+s1nmoXIzsTyq334pOPxv+SdQ==",
         "dependencies": {
-          "Kentico.Aira.Client": "3.6.1",
-          "Kentico.Xperience.WebApp": "[30.12.0]",
-          "Microsoft.AspNetCore.SpaServices.Extensions": "8.0.21",
-          "Microsoft.Extensions.FileProviders.Embedded": "8.0.21",
+          "Kentico.Aira.Client": "4.0.0",
+          "Kentico.Xperience.WebApp": "[31.0.0]",
+          "Microsoft.AspNetCore.SpaServices.Extensions": "8.0.22",
+          "Microsoft.Extensions.FileProviders.Embedded": "8.0.22",
           "Microsoft.SemanticKernel": "1.67.1",
           "Microsoft.SemanticKernel.Agents.Core": "1.67.1",
           "Microsoft.SemanticKernel.Connectors.AzureOpenAI": "1.67.1"
@@ -19,14 +19,14 @@
       },
       "Kentico.Xperience.AzureStorage": {
         "type": "Direct",
-        "requested": "[30.12.0, )",
-        "resolved": "30.12.0",
-        "contentHash": "teK0E3gp0XvXeXkjQ37n9fh4e7y2cVd7e3Q5zYJ4HEWmnzMobmwtJMlsQsRdLS8+h48f3lLbfchrKcpIEX1V5g==",
+        "requested": "[31.0.0, )",
+        "resolved": "31.0.0",
+        "contentHash": "IZkEtIbQWEB/8xX1JMGjeuMlyiDaOi/nmw8KzMnaIRRsZGCMkbedyZKJce2K2FBjCfm76nklBZetqHWf1GHe/Q==",
         "dependencies": {
           "Azure.Storage.Blobs": "12.26.0",
-          "Kentico.Xperience.Core": "30.12.0",
+          "Kentico.Xperience.Core": "31.0.0",
           "Newtonsoft.Json": "13.0.3",
-          "System.IO.Hashing": "9.0.10"
+          "System.IO.Hashing": "9.0.11"
         }
       },
       "Kentico.Xperience.MiniProfiler": {
@@ -42,18 +42,18 @@
       },
       "Kentico.Xperience.WebApp": {
         "type": "Direct",
-        "requested": "[30.12.0, )",
-        "resolved": "30.12.0",
-        "contentHash": "ztw9185n0rQ54Vd/unMXdd419C+Ju5/6NOZuO+uhgyCQXxL0rTHMYenEuUI9wLPgnafCd53xGXQFOyrgqI8JcA==",
+        "requested": "[31.0.0, )",
+        "resolved": "31.0.0",
+        "contentHash": "2BEEcrQRc37BFBstUngGbUYtnb3PD2m/Go1zwYH2/YTve0tY85EnAsoLT2NFuoFzivhMp17zmtIZFDr1yaeybA==",
         "dependencies": {
           "CommandLineParser": "2.9.1",
           "HotChocolate.AspNetCore": "15.0.3",
           "HotChocolate.Data": "15.0.3",
-          "HtmlSanitizer": "9.0.886",
-          "Kentico.Xperience.Core": "[30.12.0]",
-          "Microsoft.AspNetCore.Components": "8.0.21",
+          "HtmlSanitizer": "9.0.889",
+          "Kentico.Xperience.Core": "[31.0.0]",
+          "Microsoft.AspNetCore.Components": "8.0.22",
           "Microsoft.Extensions.Caching.Memory": "8.0.1",
-          "Microsoft.Extensions.FileProviders.Embedded": "8.0.21"
+          "Microsoft.Extensions.FileProviders.Embedded": "8.0.22"
         }
       },
       "Schema.NET": {
@@ -514,8 +514,8 @@
       },
       "HtmlSanitizer": {
         "type": "Transitive",
-        "resolved": "9.0.886",
-        "contentHash": "qw87Q+bffcs2Fw/Rd3VXWg/QK+K9eIxeE9QidQLz3C/ffgUGuOB0X4MWUuuolUnnBvoD/u6FqXhsqIA67nL4kg==",
+        "resolved": "9.0.889",
+        "contentHash": "gYEkdYFozRH28YvwekP2Ha5NONbpullgsrruBmJvtlAVDIP4NPvD7ma1P90J24c9nPXMaDxOTWJX8c6Jd6IdjQ==",
         "dependencies": {
           "AngleSharp": "[0.17.1]",
           "AngleSharp.Css": "[0.17.0]"
@@ -523,25 +523,25 @@
       },
       "Kentico.Aira.Client": {
         "type": "Transitive",
-        "resolved": "3.6.1",
-        "contentHash": "KwDjaB7JkuyVsqChevFJK+UnZq0oXQP3zgXIf6uhuYvdgEsjADtflFJIi3kTg3mOHRxP6Z/8taQONdLNFQF00A==",
+        "resolved": "4.0.0",
+        "contentHash": "cBW7qahkfmUJfrDI2Cmnjj8RpbwLLpiZDz5j+CFy+vpYUoQNhrsdIKGbTnLAtp+d+N7SHT3MHcwKLOdZKBDi5g==",
         "dependencies": {
           "Azure.Core": "1.47.1",
           "Microsoft.Extensions.DependencyInjection": "8.0.1",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "9.0.7",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "9.0.8",
           "Microsoft.Extensions.Http": "8.0.1",
-          "Microsoft.Extensions.Options": "8.0.2",
+          "Microsoft.Extensions.Options": "9.0.8",
           "Microsoft.Extensions.Options.ConfigurationExtensions": "8.0.0",
-          "Microsoft.IdentityModel.JsonWebTokens": "7.6.2"
+          "Microsoft.IdentityModel.JsonWebTokens": "8.14.0"
         }
       },
       "Kentico.Xperience.Core": {
         "type": "Transitive",
-        "resolved": "30.12.0",
-        "contentHash": "rDbplli6ar9sG3ulgCVXEtJqYnPzbXBct49whpswu1OtBs279pn4s6CyzHGo1JYmiFveFMYp1/wITS+iK9TXvg==",
+        "resolved": "31.0.0",
+        "contentHash": "j/8Uni3hy1R15CpjFPckAGk5svnbFsHXrMm5dG62xiL1HsWZTR3V9QKbTVs654pO8siDKySWMEgKPoYJPTZlPQ==",
         "dependencies": {
           "AngleSharp": "0.17.1",
-          "Kentico.Aira.Client": "3.6.1",
+          "Kentico.Aira.Client": "4.0.0",
           "Magick.NET-Q8-AnyCPU": "14.9.1",
           "MailKit": "4.14.1",
           "Microsoft.Data.SqlClient": "5.2.3",
@@ -550,13 +550,13 @@
           "Microsoft.Extensions.DependencyInjection": "8.0.1",
           "Microsoft.Extensions.FileProviders.Physical": "8.0.0",
           "Microsoft.Extensions.Hosting.Abstractions": "8.0.1",
-          "Microsoft.Extensions.Localization": "8.0.21",
+          "Microsoft.Extensions.Localization": "8.0.22",
           "Microsoft.Extensions.Logging": "8.0.1",
           "Microsoft.Extensions.Options.ConfigurationExtensions": "8.0.0",
           "Mono.Cecil": "0.11.6",
           "Newtonsoft.Json": "13.0.3",
           "System.CodeDom": "8.0.0",
-          "System.IO.Hashing": "9.0.10"
+          "System.IO.Hashing": "9.0.11"
         }
       },
       "Magick.NET-Q8-AnyCPU": {
@@ -593,37 +593,37 @@
       },
       "Microsoft.AspNetCore.Authorization": {
         "type": "Transitive",
-        "resolved": "8.0.21",
-        "contentHash": "ckniZ/HilMC311SNZM0Tb5+4f4IWmNniEy893pAmjVsN0veXIyegl9yDp6vn2iBooJB9qfxy4kVkFjEKEOFrng==",
+        "resolved": "8.0.22",
+        "contentHash": "D7GY8e30UCkjQO9z2cQ1XT/+T1CSAae+KxojcI5SRb8iKmhVjMrAyspdslGMVhS5zOnPgObUp1666BriQmzv3g==",
         "dependencies": {
-          "Microsoft.AspNetCore.Metadata": "8.0.21",
+          "Microsoft.AspNetCore.Metadata": "8.0.22",
           "Microsoft.Extensions.Logging.Abstractions": "8.0.3",
           "Microsoft.Extensions.Options": "8.0.2"
         }
       },
       "Microsoft.AspNetCore.Components": {
         "type": "Transitive",
-        "resolved": "8.0.21",
-        "contentHash": "O1UE1JgTFQKz0easeZ9rMg8sdsMC3Qois3oc4NNubLP7S4v25C602mCvnLjv1pF6mgXWEeGLpRQYQAqKx3ZcqQ==",
+        "resolved": "8.0.22",
+        "contentHash": "qlW2tz9umukb/XTA+D7p+OiOz6l10rtn0jwh2A46LN8VwikutX5HbCE3pdc1x7eG2LdSKb2OLOTpdhaDp4NB3g==",
         "dependencies": {
-          "Microsoft.AspNetCore.Authorization": "8.0.21",
-          "Microsoft.AspNetCore.Components.Analyzers": "8.0.21"
+          "Microsoft.AspNetCore.Authorization": "8.0.22",
+          "Microsoft.AspNetCore.Components.Analyzers": "8.0.22"
         }
       },
       "Microsoft.AspNetCore.Components.Analyzers": {
         "type": "Transitive",
-        "resolved": "8.0.21",
-        "contentHash": "rYzZWBgSBCtJSsqZTrXtSUY+vhJTRCL4+5fLZayPrXQjphQUUOpIyDT1hp3b8q5ytWwP0lUMCZH7lSBQ8C5tTw=="
+        "resolved": "8.0.22",
+        "contentHash": "Xf/+WuHI1obDwkxUb8w5P+JnaQJEau6r/fDkTvikUvTsMJOwsMAlaG67mJBx31z21jv2SGSPiOWLysBcLagcIQ=="
       },
       "Microsoft.AspNetCore.Metadata": {
         "type": "Transitive",
-        "resolved": "8.0.21",
-        "contentHash": "3C7OfvuSY+ODBe/uOrX/S/7cjVGQSzduXamkpoFv1GTcHMoPttK7VmUXTNSiVWerC14v/OtT52zL6+U+T3gx4A=="
+        "resolved": "8.0.22",
+        "contentHash": "Ha5M7eC//ZyBzJTc7CmUs0RJkqfBRXc38xzewR8VqZov8jURWuyaSv2XNiokjt7H77cZjQ7sLL0I/RD5JnQ/nA=="
       },
       "Microsoft.AspNetCore.SpaServices.Extensions": {
         "type": "Transitive",
-        "resolved": "8.0.21",
-        "contentHash": "UUOK6JldBc41XJGPMG5UrlnPkbFxWdWHq+W3I4b2noSoQDBnwiNTaRLG6mfcJkCsmEyypLY/PbX6RXzWsOneNg==",
+        "resolved": "8.0.22",
+        "contentHash": "Wz53AWozQhgtte+WtWfqSGnL9FF/YiEonf5PZTQYj3xYZWoXTZziWCo/ON0ni9AVXvEZ5SwsXK/WSGUXTrWaDQ==",
         "dependencies": {
           "Microsoft.Extensions.FileProviders.Physical": "8.0.0"
         }
@@ -781,8 +781,8 @@
       },
       "Microsoft.Extensions.FileProviders.Embedded": {
         "type": "Transitive",
-        "resolved": "8.0.21",
-        "contentHash": "JmAFU1Iuw84BbgPoHRPeEdlmyZHpTh3xdcM3+mYyNLm2OADHTvDMjoHnMLsxE7Qb5C18aWZror8Qr0+dsf0kcw==",
+        "resolved": "8.0.22",
+        "contentHash": "5Hrl2EyoqmSN/0YKfuYp4qRP8+RU4xguUVMg0J/5J+nDYobiBM4VgCTUN4oaCpIk9063hTsd/WoheKMlZBkVjA==",
         "dependencies": {
           "Microsoft.Extensions.FileProviders.Abstractions": "8.0.0"
         }
@@ -829,19 +829,19 @@
       },
       "Microsoft.Extensions.Localization": {
         "type": "Transitive",
-        "resolved": "8.0.21",
-        "contentHash": "pD4ypbFCTxDJuCKLw0F1lmK/z0wZBPgaNRRjHZlpkFWW9cNUq+9SiWGzf6DPd7tXCGSyhrs/CPv6qJBr21nzhg==",
+        "resolved": "8.0.22",
+        "contentHash": "qJtpGMta4v1yqj04c9DCqFC6cqtioEi5TBXml2O7I8p6SrfMan2Twj2AmCG/IcepXiS9wKgJwcMnAKriQoyo5w==",
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection.Abstractions": "8.0.2",
-          "Microsoft.Extensions.Localization.Abstractions": "8.0.21",
+          "Microsoft.Extensions.Localization.Abstractions": "8.0.22",
           "Microsoft.Extensions.Logging.Abstractions": "8.0.3",
           "Microsoft.Extensions.Options": "8.0.2"
         }
       },
       "Microsoft.Extensions.Localization.Abstractions": {
         "type": "Transitive",
-        "resolved": "8.0.21",
-        "contentHash": "+i3LqUjP+qG8xRaTHIHCRKfuZWm54MigfZFXGyTxEScwAgRCHvRrcwWDLRJpsvmue6c/VTJnprHCtLs+8nJdVw=="
+        "resolved": "8.0.22",
+        "contentHash": "8cpr20qkP74aNODW+78wcPmAg/RbMR+So1mGcLkJTrLGCJ7LJPOF6nngvUg6VOS050op7FruMFJm/9PuxWm9oQ=="
       },
       "Microsoft.Extensions.Logging": {
         "type": "Transitive",
@@ -921,23 +921,23 @@
       },
       "Microsoft.IdentityModel.Abstractions": {
         "type": "Transitive",
-        "resolved": "7.6.2",
-        "contentHash": "ULeyJwfYTMHOAArrBZorjPyM/BL5PFfwRzDtxlOxawO9vB/wVmHmbzZnOyHCOLJjel7XiVNmVnAs3H0jh4/9jQ=="
+        "resolved": "8.14.0",
+        "contentHash": "iwbCpSjD3ehfTwBhtSNEtKPK0ICun6ov7Ibx6ISNA9bfwIyzI2Siwyi9eJFCJBwxowK9xcA1mj+jBWiigeqgcQ=="
       },
       "Microsoft.IdentityModel.JsonWebTokens": {
         "type": "Transitive",
-        "resolved": "7.6.2",
-        "contentHash": "ySbY72MsWw7BnSZw0fCsmp/oMou8ntJkfuZUBcplV3ncXMzxcXCn3fK6Gg2YLnTT6F2G9JXl9zc2lwfVfGOWEA==",
+        "resolved": "8.14.0",
+        "contentHash": "4jOpiA4THdtpLyMdAb24dtj7+6GmvhOhxf5XHLYWmPKF8ApEnApal1UnJsKO4HxUWRXDA6C4WQVfYyqsRhpNpQ==",
         "dependencies": {
-          "Microsoft.IdentityModel.Tokens": "7.6.2"
+          "Microsoft.IdentityModel.Tokens": "8.14.0"
         }
       },
       "Microsoft.IdentityModel.Logging": {
         "type": "Transitive",
-        "resolved": "7.6.2",
-        "contentHash": "0brV311MYxGz7Numa+pbVsxbz5tfe2nbAig1b5tQb3h/L1y5lkoPyOgD0qAfI0iX1njbwr8l9NdxIT1cDbzWKA==",
+        "resolved": "8.14.0",
+        "contentHash": "eqqnemdW38CKZEHS6diA50BV94QICozDZEvSrsvN3SJXUFwVB9gy+/oz76gldP7nZliA16IglXjXTCTdmU/Ejg==",
         "dependencies": {
-          "Microsoft.IdentityModel.Abstractions": "7.6.2"
+          "Microsoft.IdentityModel.Abstractions": "8.14.0"
         }
       },
       "Microsoft.IdentityModel.Protocols": {
@@ -960,10 +960,11 @@
       },
       "Microsoft.IdentityModel.Tokens": {
         "type": "Transitive",
-        "resolved": "7.6.2",
-        "contentHash": "pLnhCq9UNKWkn83zutkObYuzA+sOzx6VZpPI8hB8gD/vAXVt14D0SJ0sKPftwufvAbYGSNRda1vw/IFLbkjxNg==",
+        "resolved": "8.14.0",
+        "contentHash": "lKIZiBiGd36k02TCdMHp1KlNWisyIvQxcYJvIkz7P4gSQ9zi8dgh6S5Grj8NNG7HWYIPfQymGyoZ6JB5d1Lo1g==",
         "dependencies": {
-          "Microsoft.IdentityModel.Logging": "7.6.2"
+          "Microsoft.Extensions.Logging.Abstractions": "8.0.0",
+          "Microsoft.IdentityModel.Logging": "8.14.0"
         }
       },
       "Microsoft.SemanticKernel": {
@@ -1152,8 +1153,8 @@
       },
       "System.IO.Hashing": {
         "type": "Transitive",
-        "resolved": "9.0.10",
-        "contentHash": "9gv5z71xaWWmcGEs4bXdreIhKp2kYLK2fvPK5gQkgnWMYvZ8ieaxKofDjxL3scZiEYfi/yW2nJTiKV2awcWEdA=="
+        "resolved": "9.0.11",
+        "contentHash": "c9tFngnvHiUsBPLW22QQBgcGe9xFvac9rg3QIRHxrY2gCUdy4s2M/gQHimH+Z4yR9Cj6xWTOsa8IYY5CIG8QFA=="
       },
       "System.IO.Pipelines": {
         "type": "Transitive",
@@ -1228,15 +1229,15 @@
         "type": "Project",
         "dependencies": {
           "Goldfinch.Core": "[1.0.0, )",
-          "Kentico.Xperience.Admin": "[30.12.0, )",
-          "Kentico.Xperience.WebApp": "[30.12.0, )"
+          "Kentico.Xperience.Admin": "[31.0.0, )",
+          "Kentico.Xperience.WebApp": "[31.0.0, )"
         }
       },
       "goldfinch.core": {
         "type": "Project",
         "dependencies": {
-          "Kentico.Xperience.Admin": "[30.12.0, )",
-          "Kentico.Xperience.WebApp": "[30.12.0, )",
+          "Kentico.Xperience.Admin": "[31.0.0, )",
+          "Kentico.Xperience.WebApp": "[31.0.0, )",
           "Sidio.Sitemap.AspNetCore": "[3.0.3, )"
         }
       }


### PR DESCRIPTION
## Summary

Updates Xperience by Kentico from version **30.12.0** to **31.0.0**.

### Changes Made

- ✅ Updated 3 Kentico.Xperience.* NuGet packages in Directory.Packages.props
- ✅ Updated 3 @kentico/* npm packages in admin client
- ✅ Applied database migrations successfully (no breaking changes)
- ✅ Stored updated CI objects to App_Data/CIRepository/
- ✅ Build passed with 0 warnings, 0 errors

### New in v31.0.0

- **Primary focus:** .NET 10 support
- **New features:**
  - Shareable preview URLs for collaboration
  - Content modeling MCP server
  - Catalog and order promotions for commerce
  - Clone headless items functionality
  - Full CRUD support in content type management API

### Breaking Changes

**None affecting this project.** The only breaking changes in v31.0.0 are:
- Removed unused columns from `OM_ActivityType` database table (doesn't affect application code)
- Digital commerce APIs no longer marked as experimental (additive change)

### Test Plan

- [x] Build solution successfully
- [ ] Test homepage loads correctly
- [ ] Test blog listing page works
- [ ] Test blog detail pages render with images
- [ ] Test navigation and header work
- [ ] Test admin interface is accessible at https://localhost:52623/admin
- [ ] Verify page builder widgets function correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)