### PR TITLE
Refactor SVG styles to CSS classes and restore height on motif

### DIFF
--- a/src/Goldfinch.Web/Features/Home/Components/HomePage.cshtml
+++ b/src/Goldfinch.Web/Features/Home/Components/HomePage.cshtml
@@ -142,17 +142,9 @@
             </header>
 
             @{
-                // Decorative code-editor motif. Row widths use a tiny palette cycled per line.
-                // Keep in sync with the mock (docs/design-handoff/mock.html, PostCard featured branch).
-                var codeCols = new[]
-                {
-                    (Width: 24, Color: "var(--magenta)"),
-                    (Width: 46, Color: "var(--fg-muted)"),
-                    (Width: 70, Color: "var(--cyan)"),
-                    (Width: 90, Color: "var(--fg-dim)"),
-                    (Width: 30, Color: "var(--accent)"),
-                    (Width: 60, Color: "var(--fg-muted)"),
-                };
+                // Decorative code-editor motif. Row widths cycle through a fixed palette.
+                // Colors live in global.css (.motif-col-N) to avoid CSP inline-style violations.
+                var codeColWidths = new[] { 24, 46, 70, 90, 30, 60 };
             }
 
             <a class="featured-card" href="@Model.FeaturedPost.Url">
@@ -163,19 +155,18 @@
                         <circle cx="12" cy="11" r="4" fill="#f87171" opacity=".7" />
                         <circle cx="28" cy="11" r="4" fill="#fbbf24" opacity=".7" />
                         <circle cx="44" cy="11" r="4" fill="#86efac" opacity=".7" />
-                        <text x="64" y="15" style="fill:var(--fg-dim); font-family:var(--font-mono); font-size:9px;">@Model.FeaturedPost.Filename</text>
+                        <text x="64" y="15" class="motif-filename">@Model.FeaturedPost.Filename</text>
                         @for (var i = 0; i < 9; i++)
                         {
                             var lineY = 44 + i * 17;
                             var take = 2 + (i % 3);
                             var x = 12;
                             <g>
-                                <text x="4" y="@lineY" style="fill:var(--fg-dimmer); font-family:var(--font-mono); font-size:9px;">@((i + 1).ToString("00"))</text>
+                                <text x="4" y="@lineY" class="motif-linenum">@((i + 1).ToString("00"))</text>
                                 @for (var k = 0; k < take; k++)
                                 {
-                                    var col = codeCols[k];
-                                    <rect x="@(20 + x)" y="@(lineY - 7)" width="@col.Width" height="8" style="fill:@col.Color;" opacity=".35" />
-                                    x += col.Width + 6;
+                                    <rect x="@(20 + x)" y="@(lineY - 7)" width="@codeColWidths[k]" height="8" class="motif-col-@k" opacity=".35" />
+                                    x += codeColWidths[k] + 6;
                                 }
                             </g>
                         }

--- a/src/Goldfinch.Web/wwwroot/sitefiles/src/global.css
+++ b/src/Goldfinch.Web/wwwroot/sitefiles/src/global.css
@@ -920,6 +920,7 @@ h1.hero-h1 {
 }
 .featured-card__motif {
   width: 85%;
+  height: 80%;
   opacity: 0.9;
 }
 .motif-filename {

--- a/src/Goldfinch.Web/wwwroot/sitefiles/src/global.css
+++ b/src/Goldfinch.Web/wwwroot/sitefiles/src/global.css
@@ -920,9 +920,24 @@ h1.hero-h1 {
 }
 .featured-card__motif {
   width: 85%;
-  height: 80%;
   opacity: 0.9;
 }
+.motif-filename {
+  fill: var(--fg-dim);
+  font-family: var(--font-mono);
+  font-size: 9px;
+}
+.motif-linenum {
+  fill: var(--fg-dimmer);
+  font-family: var(--font-mono);
+  font-size: 9px;
+}
+.motif-col-0 { fill: var(--magenta); }
+.motif-col-1 { fill: var(--fg-muted); }
+.motif-col-2 { fill: var(--cyan); }
+.motif-col-3 { fill: var(--fg-dim); }
+.motif-col-4 { fill: var(--accent); }
+.motif-col-5 { fill: var(--fg-muted); }
 .featured-card__pin {
   position: absolute;
   top: 16px;


### PR DESCRIPTION
This pull request refactors the decorative code-editor motif on the homepage to improve maintainability and ensure compliance with Content Security Policy (CSP) by moving inline styles to CSS classes. The changes also introduce new CSS classes for motif styling and update the Razor view to use these classes.

**Refactoring for CSP compliance and maintainability:**

* Moved motif color and font styling from inline SVG styles in `HomePage.cshtml` to new CSS classes (`.motif-filename`, `.motif-linenum`, `.motif-col-N`) defined in `global.css`, avoiding CSP inline-style violations and centralizing style definitions. [[1]](diffhunk://#diff-3393ba8d9e8877aa993e470c17e704c117b5c2801edc670c60832737258b2bd0L145-R147) [[2]](diffhunk://#diff-3393ba8d9e8877aa993e470c17e704c117b5c2801edc670c60832737258b2bd0L166-R169) [[3]](diffhunk://#diff-4c998eff9e0fcf601baba346865519d9907cf50bbff3b8383be7a5da45f1e824R926-R941)
* Updated the Razor view logic to use a simple array of column widths (`codeColWidths`) and apply the new CSS classes instead of inline color values. [[1]](diffhunk://#diff-3393ba8d9e8877aa993e470c17e704c117b5c2801edc670c60832737258b2bd0L145-R147) [[2]](diffhunk://#diff-3393ba8d9e8877aa993e470c17e704c117b5c2801edc670c60832737258b2bd0L166-R169)

**Styling improvements:**

* Added new CSS classes in `global.css` for motif filename, line numbers, and each motif column color, ensuring consistent styling and easier future changes.