### PR TITLE
Increase cache lifetime

### DIFF
--- a/src/Goldfinch.Web/Infrastructure/StaticFiles/CustomStaticFilesConfiguration.cs
+++ b/src/Goldfinch.Web/Infrastructure/StaticFiles/CustomStaticFilesConfiguration.cs
@@ -1,0 +1,58 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.StaticFiles;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using System;
+using System.Collections.Generic;
+
+namespace Goldfinch.Web.Infrastructure.StaticFiles;
+
+public static class CustomStaticFilesConfiguration
+{
+    private static readonly IReadOnlyCollection<string> _staticPaths =
+    [
+        "/sitefiles/dist/assets",
+        "/fonts",
+    ];
+
+    /// <summary>
+    ///     Configures the <see cref="StaticFileOptions"/> to allow custom MIME types and add 'Cache-Control' headers
+    ///     for hash-busted asset bundles and self-hosted fonts.
+    /// </summary>
+    /// <param name="serviceCollection">The service collection to configure the options within.</param>
+    /// <param name="configuration">The application configuration.</param>
+    public static IServiceCollection AddCustomStaticFilesConfiguration(this IServiceCollection serviceCollection, IConfiguration configuration)
+    {
+        var cacheOptions = configuration
+            .GetSection(StaticFilesCacheOptions.SectionName)
+            .Get<StaticFilesCacheOptions>() ?? new StaticFilesCacheOptions();
+
+        var provider = new FileExtensionContentTypeProvider();
+        provider.Mappings[".webmanifest"] = "application/manifest+json";
+
+        var cacheControl = cacheOptions.Immutable
+            ? $"public, max-age={cacheOptions.CacheDurationSeconds}, immutable"
+            : $"public, max-age={cacheOptions.CacheDurationSeconds}";
+
+        return serviceCollection.Configure<StaticFileOptions>(options =>
+        {
+            options.ContentTypeProvider = provider;
+            options.OnPrepareResponse = context =>
+            {
+                if (!cacheOptions.Enabled)
+                {
+                    return;
+                }
+
+                foreach (var path in _staticPaths)
+                {
+                    if (context.Context.Request.Path.StartsWithSegments(path, StringComparison.OrdinalIgnoreCase))
+                    {
+                        context.Context.Response.Headers.CacheControl = cacheControl;
+                        return;
+                    }
+                }
+            };
+        });
+    }
+}

--- a/src/Goldfinch.Web/Infrastructure/StaticFiles/StaticFilesCacheOptions.cs
+++ b/src/Goldfinch.Web/Infrastructure/StaticFiles/StaticFilesCacheOptions.cs
@@ -1,0 +1,12 @@
+namespace Goldfinch.Web.Infrastructure.StaticFiles;
+
+public class StaticFilesCacheOptions
+{
+    public const string SectionName = "StaticFiles:Cache";
+
+    public bool Enabled { get; set; } = true;
+
+    public int CacheDurationSeconds { get; set; } = 31536000;
+
+    public bool Immutable { get; set; } = true;
+}

--- a/src/Goldfinch.Web/Program.cs
+++ b/src/Goldfinch.Web/Program.cs
@@ -1,5 +1,6 @@
 using Goldfinch.Core;
 using Goldfinch.Core.ContentTypes;
+using Goldfinch.Web.Infrastructure.StaticFiles;
 using Goldfinch.Web.Middleware;
 using Kentico.Content.Web.Mvc.Routing;
 using Kentico.Membership;
@@ -99,6 +100,8 @@ builder.Services
     .AddDefaultSitemapServices<HttpContextBaseUrlProvider>();
 
 builder.Services.AddTrailingSlash(builder.Configuration);
+
+builder.Services.AddCustomStaticFilesConfiguration(builder.Configuration);
 
 var app = builder.Build();
 


### PR DESCRIPTION
This pull request introduces a configurable and centralized approach for handling static file caching and MIME types in the web application. The main focus is on improving how static files (such as asset bundles and fonts) are served, allowing for custom cache control headers and support for additional MIME types. The configuration is now driven by application settings, making it easier to manage and update cache policies.

**Static file configuration and caching improvements:**

* Added a new `StaticFilesCacheOptions` class to encapsulate cache-related settings for static files, including whether caching is enabled, the cache duration, and the use of the `immutable` directive. (`StaticFilesCacheOptions.cs`)
* Introduced the `CustomStaticFilesConfiguration` static class with an extension method `AddCustomStaticFilesConfiguration` to configure `StaticFileOptions`. This sets up custom MIME types (e.g., `.webmanifest`) and applies cache control headers to specific static file paths based on configuration. (`CustomStaticFilesConfiguration.cs`)
* Registered the new static files configuration in the application startup by calling `AddCustomStaticFilesConfiguration` in `Program.cs`.

**Dependency and namespace updates:**

* Updated `Program.cs` to include the necessary using statement for the new static files infrastructure namespace.