### PR TITLE
Update speaking page URL and revise about/speaking content

### DIFF
--- a/src/Goldfinch.Web/App_Data/CIRepository/Goldfinch/cms.contentitemcommondata/about-7d046jbd@8f42f05f26/c0256ef3-6b7c-495c-8d32-c148249d6e39_en@efb9fa50f2.xml
+++ b/src/Goldfinch.Web/App_Data/CIRepository/Goldfinch/cms.contentitemcommondata/about-7d046jbd@8f42f05f26/c0256ef3-6b7c-495c-8d32-c148249d6e39_en@efb9fa50f2.xml
@@ -1,7 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <cms.contentitemcommondata>
   <BaseContentShortDescription />
-  <BaseContentTitle>About</BaseContentTitle>
+  <BaseContentTitle>
+    <![CDATA[Hello, I'm Liam.]]>
+  </BaseContentTitle>
   <ContentItemCommonDataContentItemID>
     <CodeName>About-7d046jbd</CodeName>
     <GUID>a967a64c-dd0f-497a-b6ae-51d5b2a5c1b5</GUID>
@@ -14,15 +16,15 @@
   </ContentItemCommonDataContentLanguageID>
   <ContentItemCommonDataGUID>c0256ef3-6b7c-495c-8d32-c148249d6e39</ContentItemCommonDataGUID>
   <ContentItemCommonDataIsLatest>True</ContentItemCommonDataIsLatest>
-  <ContentItemCommonDataLastPublishedWhen>2025-10-08 07:36:00Z</ContentItemCommonDataLastPublishedWhen>
+  <ContentItemCommonDataLastPublishedWhen>2026-04-19 20:40:41Z</ContentItemCommonDataLastPublishedWhen>
   <ContentItemCommonDataVersionStatus>2</ContentItemCommonDataVersionStatus>
   <ContentItemCommonDataVisualBuilderTemplateConfiguration>
     <![CDATA[{"identifier":"Goldfinch.InnerPage_Default","properties":{},"fieldIdentifiers":{}}]]>
   </ContentItemCommonDataVisualBuilderTemplateConfiguration>
   <ContentItemCommonDataVisualBuilderWidgets>
-    <![CDATA[{"editableAreas":[{"identifier":"InnerPage","sections":[{"identifier":"c2337389-ffa8-41b7-9b96-4071264992a1","type":"Kentico.DefaultSection","properties":null,"zones":[{"identifier":"479d03ee-3352-4344-896a-622504cae333","widgets":[{"identifier":"09fb35bf-849f-40e3-92cc-2d29c412adb4","type":"Kentico.Widget.RichText","variants":[{"identifier":"47384860-3df5-4a15-9e98-346d316540e1","properties":{"content":"<p>Hello, my name is Liam Goldfinch. 👋</p><p>I currently work as a Principal Systems Developer for the digital web agency <a href=\"https://www.idhlagency.com/\" rel=\"noopener noreferrer\" target=\"_blank\">IDHL</a>.</p><p>We specialise in building websites using <a href=\"https://www.kentico.com/\" rel=\"noopener noreferrer\" target=\"_blank\">Kentico</a> (Xperience by Kentico and Kentico Xperience 13) and <a href=\"https://umbraco.com/\" rel=\"noopener noreferrer\" target=\"_blank\">Umbraco</a> CMS platforms.</p><p>I have been honoured with the <a href=\"https://www.kentico.com/partners/mvp-program\" target=\"_blank\" rel=\"noopener noreferrer\">Kentico MVP</a> award consecutively since 2022, acknowledging my passion for their DXP offering and the substantial assistance I have provided to members of the community.</p><p>I am a certified developer and marketer for Kentico Xperience 13, and an active member of the Kentico open source community.</p><p>As a co-organiser of <a href=\"https://www.linkedin.com/groups/13057217/\" target=\"_blank\" rel=\"noopener noreferrer\" id=\"isPasted\">Kentico User Group UK</a>, I am proud to be part of a growing community that brings together Kentico users, developers, marketers and agencies to share knowledge and network.</p><p>This website has been built using the next generation of <a href=\"https://www.kentico.com/discover/blog/kentico-xperience-a-glance-into-the-future\" rel=\"noopener noreferrer\" target=\"_blank\">Xperience by Kentico</a>. &nbsp;The latest version of this cloud-native, flexible DXP has been fully rewritten using .NET Core (supporting .NET 6 and beyond), and uses one of the latest front-end development technologies ReactJS for the administration portal's user interface.</p><p>Thanks to <a href=\"https://www.idhlagency.com/\" rel=\"noopener noreferrer\" target=\"_blank\">IDHL</a> for hosting this blog website!</p>"},"fieldIdentifiers":{"content":"153c7b29-0aff-4b22-bf9f-23cc50301c5a"}}]}]}],"fieldIdentifiers":{}}]}]}]]>
+    <![CDATA[{"editableAreas":[{"identifier":"InnerPage","sections":[{"identifier":"c2337389-ffa8-41b7-9b96-4071264992a1","type":"Kentico.DefaultSection","properties":null,"zones":[{"identifier":"479d03ee-3352-4344-896a-622504cae333","widgets":[{"identifier":"09fb35bf-849f-40e3-92cc-2d29c412adb4","type":"Kentico.Widget.RichText","variants":[{"identifier":"47384860-3df5-4a15-9e98-346d316540e1","properties":{"content":"<p>I work as a Principal Systems Developer at <a href=\"https://www.idhlagency.com/\" rel=\"noopener noreferrer\" target=\"_blank\" data-pasted=\"true\">IDHL</a>, a digital agency that specialises in building websites on <a href=\"https://www.kentico.com/\" rel=\"noopener noreferrer\" target=\"_blank\" data-pasted=\"true\">Kentico</a> (Xperience by Kentico and Kentico Xperience 13) and <a href=\"https://umbraco.com/\" rel=\"noopener noreferrer\" target=\"_blank\" data-pasted=\"true\">Umbraco</a> CMS platforms.</p><p data-pasted=\"true\">I've been honoured with the <a href=\"https://community.kentico.com/community/programs\" target=\"_blank\" rel=\"noopener noreferrer\">Kentico MVP</a> award consecutively since 2022, recognising my passion for their DXP and the assistance I've given members of the community.</p><p data-pasted=\"true\">I'm a certified developer and marketer for Xperience by Kentico and an active member of the Kentico open-source community. As a co-organiser of <a href=\"https://www.linkedin.com/groups/13057217/\" target=\"_blank\" rel=\"noopener noreferrer\" data-pasted=\"true\">Kentico User Group UK</a> I'm proud to help bring together users, developers, marketers, and agencies to share knowledge.</p><p>This blog runs on Xperience by Kentico — the latest cloud-native, flexible DXP, rewritten from the ground up on .NET Core. The source is public at <a data-fr-linked=\"true\" href=\"//github.com/liamgold/goldfinch.me\">github.com/liamgold/goldfinch.me</a>.</p>"},"fieldIdentifiers":{"content":"153c7b29-0aff-4b22-bf9f-23cc50301c5a"}}]}]}],"fieldIdentifiers":{}}]}]}]]>
   </ContentItemCommonDataVisualBuilderWidgets>
   <SeoCanonicalUrl />
   <SeoShortDescription />
-  <SeoTitle />
+  <SeoTitle>About</SeoTitle>
 </cms.contentitemcommondata>

--- a/src/Goldfinch.Web/App_Data/CIRepository/Goldfinch/cms.contentitemcommondata/publicspeaking-qqc6wf1a@ed0b42b4b4/dd70937a-56b7-4129-b6ed-f5734b0f9f40_en@93345944fd.xml
+++ b/src/Goldfinch.Web/App_Data/CIRepository/Goldfinch/cms.contentitemcommondata/publicspeaking-qqc6wf1a@ed0b42b4b4/dd70937a-56b7-4129-b6ed-f5734b0f9f40_en@93345944fd.xml
@@ -1,6 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <cms.contentitemcommondata>
-  <BaseContentTitle>Public Speaking</BaseContentTitle>
+  <BaseContentShortDescription />
+  <BaseContentTitle>
+    <![CDATA[Talks & webinars]]>
+  </BaseContentTitle>
   <ContentItemCommonDataContentItemID>
     <CodeName>PublicSpeaking-qqc6wf1a</CodeName>
     <GUID>a94242a8-2b08-48bd-adc7-f9ddf7ca20ef</GUID>
@@ -14,12 +17,15 @@
   <ContentItemCommonDataFirstPublishedWhen>2024-11-10 23:30:21Z</ContentItemCommonDataFirstPublishedWhen>
   <ContentItemCommonDataGUID>dd70937a-56b7-4129-b6ed-f5734b0f9f40</ContentItemCommonDataGUID>
   <ContentItemCommonDataIsLatest>True</ContentItemCommonDataIsLatest>
-  <ContentItemCommonDataLastPublishedWhen>2025-09-12 22:35:03Z</ContentItemCommonDataLastPublishedWhen>
+  <ContentItemCommonDataLastPublishedWhen>2026-04-19 20:45:16Z</ContentItemCommonDataLastPublishedWhen>
   <ContentItemCommonDataVersionStatus>2</ContentItemCommonDataVersionStatus>
   <ContentItemCommonDataVisualBuilderTemplateConfiguration>
     <![CDATA[{"identifier":"Goldfinch.PublicSpeakingPage_Default","properties":{},"fieldIdentifiers":{}}]]>
   </ContentItemCommonDataVisualBuilderTemplateConfiguration>
   <ContentItemCommonDataVisualBuilderWidgets>
-    <![CDATA[{"editableAreas":[{"identifier":"PublicSpeaking","sections":[{"identifier":"0d1fc2a2-4b1f-4fae-8f48-65cfc5b1f754","type":"Kentico.DefaultSection","properties":null,"zones":[{"identifier":"d6f66d1d-3f5a-459d-85e1-e1dff2a8780e","widgets":[{"identifier":"09d90240-a95b-431f-a6d5-9e830c7b9a71","type":"Kentico.Widget.RichText","variants":[{"identifier":"715104fb-8dff-443d-832f-01963e97df55","properties":{"content":"<p id=\"isPasted\">Over the years, I have had the privilege of sharing my knowledge and experiences with audiences at industry conferences, meetups, and user groups. From Kentico's annual conferences to local tech meetups, I focus on topics that help developers and teams build better digital experiences.</p><p>Below is a list of my recent speaking engagements.</p>"},"fieldIdentifiers":{"content":"d2aed4af-8bfe-4f8b-9d16-84f5b15cd075"}}]}]}],"fieldIdentifiers":{}}]}]}]]>
+    <![CDATA[{"editableAreas":[{"identifier":"PublicSpeaking","sections":[{"identifier":"0d1fc2a2-4b1f-4fae-8f48-65cfc5b1f754","type":"Kentico.DefaultSection","properties":null,"zones":[{"identifier":"d6f66d1d-3f5a-459d-85e1-e1dff2a8780e","widgets":[{"identifier":"09d90240-a95b-431f-a6d5-9e830c7b9a71","type":"Kentico.Widget.RichText","variants":[{"identifier":"715104fb-8dff-443d-832f-01963e97df55","properties":{"content":"<p data-pasted=\"true\">I've had the privilege of speaking at industry conferences, meetups, and user groups — from Kentico's annual conferences to local tech meetups. I focus on topics that help developers and teams build better digital experiences.</p>"},"fieldIdentifiers":{"content":"d2aed4af-8bfe-4f8b-9d16-84f5b15cd075"}}]}]}],"fieldIdentifiers":{}}]}]}]]>
   </ContentItemCommonDataVisualBuilderWidgets>
+  <SeoCanonicalUrl />
+  <SeoShortDescription />
+  <SeoTitle />
 </cms.contentitemcommondata>

--- a/src/Goldfinch.Web/App_Data/CIRepository/Goldfinch/cms.contentitemlanguagemetadata/publicspeaking-qqc6wf1a@ed0b42b4b4/d5a407eb-6d65-4b11-b607-a3656de6b0b5_en@983a004ca0.xml
+++ b/src/Goldfinch.Web/App_Data/CIRepository/Goldfinch/cms.contentitemlanguagemetadata/publicspeaking-qqc6wf1a@ed0b42b4b4/d5a407eb-6d65-4b11-b607-a3656de6b0b5_en@983a004ca0.xml
@@ -16,7 +16,7 @@
     <ObjectType>cms.user</ObjectType>
   </ContentItemLanguageMetadataCreatedByUserID>
   <ContentItemLanguageMetadataCreatedWhen>2024-11-10 23:30:18Z</ContentItemLanguageMetadataCreatedWhen>
-  <ContentItemLanguageMetadataDisplayName>Public Speaking</ContentItemLanguageMetadataDisplayName>
+  <ContentItemLanguageMetadataDisplayName>Speaking</ContentItemLanguageMetadataDisplayName>
   <ContentItemLanguageMetadataGUID>d5a407eb-6d65-4b11-b607-a3656de6b0b5</ContentItemLanguageMetadataGUID>
   <ContentItemLanguageMetadataHasImageAsset>False</ContentItemLanguageMetadataHasImageAsset>
   <ContentItemLanguageMetadataLatestVersionStatus>2</ContentItemLanguageMetadataLatestVersionStatus>

--- a/src/Goldfinch.Web/App_Data/CIRepository/Goldfinch/cms.webpageformerurlpath/public_speaking@49bfb42496/public-speaking_en@311cf3da0c.xml
+++ b/src/Goldfinch.Web/App_Data/CIRepository/Goldfinch/cms.webpageformerurlpath/public_speaking@49bfb42496/public-speaking_en@311cf3da0c.xml
@@ -1,0 +1,29 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<cms.webpageformerurlpath>
+  <WebPageFormerUrlPath>Public-Speaking</WebPageFormerUrlPath>
+  <WebPageFormerUrlPathContentLanguageID>
+    <CodeName>en</CodeName>
+    <GUID>22960170-5c33-4d4e-a01b-fd4c8fcbd13d</GUID>
+    <ObjectType>cms.contentlanguage</ObjectType>
+  </WebPageFormerUrlPathContentLanguageID>
+  <WebPageFormerUrlPathGUID>957142f8-ad30-42ce-92d1-622ee2475b28</WebPageFormerUrlPathGUID>
+  <WebPageFormerUrlPathHash>
+    <![CDATA[BB92629F6EA0F82F37962089268E8E769FFBA368232072FE498D3BB4FFDD6B9D]]>
+  </WebPageFormerUrlPathHash>
+  <WebPageFormerUrlPathIsRedirect>False</WebPageFormerUrlPathIsRedirect>
+  <WebPageFormerUrlPathIsRedirectScheduled>False</WebPageFormerUrlPathIsRedirectScheduled>
+  <WebPageFormerUrlPathWebPageItemID>
+    <CodeName>PublicSpeaking-qqc6wf1a</CodeName>
+    <GUID>89b2871b-773b-4a77-bec9-91db31e2c681</GUID>
+    <ObjectType>cms.webpageitem</ObjectType>
+  </WebPageFormerUrlPathWebPageItemID>
+  <WebPageFormerUrlPathWebsiteChannelID>
+    <GUID>b3f8d8a7-ead7-433c-b0fb-225567a185c3</GUID>
+    <ObjectType>cms.websitechannel</ObjectType>
+    <Parent>
+      <CodeName>Goldfinch</CodeName>
+      <GUID>8d6b2e28-87c3-4ea4-8a3d-dfff7c209710</GUID>
+      <ObjectType>cms.channel</ObjectType>
+    </Parent>
+  </WebPageFormerUrlPathWebsiteChannelID>
+</cms.webpageformerurlpath>

--- a/src/Goldfinch.Web/App_Data/CIRepository/Goldfinch/cms.webpageurlpath/public_speaking@49bfb42496/speaking_en@2831533487.xml
+++ b/src/Goldfinch.Web/App_Data/CIRepository/Goldfinch/cms.webpageurlpath/public_speaking@49bfb42496/speaking_en@2831533487.xml
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <cms.webpageurlpath>
-  <WebPageUrlPath>Public-Speaking</WebPageUrlPath>
+  <WebPageUrlPath>speaking</WebPageUrlPath>
   <WebPageUrlPathContentLanguageID>
     <CodeName>en</CodeName>
     <GUID>22960170-5c33-4d4e-a01b-fd4c8fcbd13d</GUID>
@@ -8,7 +8,7 @@
   </WebPageUrlPathContentLanguageID>
   <WebPageUrlPathGUID>47258072-7696-43dd-8b79-823c28340cf4</WebPageUrlPathGUID>
   <WebPageUrlPathHash>
-    <![CDATA[BB92629F6EA0F82F37962089268E8E769FFBA368232072FE498D3BB4FFDD6B9D]]>
+    <![CDATA[8BF9ADA7866E2C5CAC3C622953CBE9255602971F417CB16D8090C000361B6927]]>
   </WebPageUrlPathHash>
   <WebPageUrlPathIsCanonical>True</WebPageUrlPathIsCanonical>
   <WebPageUrlPathIsDraft>False</WebPageUrlPathIsDraft>

--- a/src/Goldfinch.Web/Components/ViewComponents/Header/HeaderViewComponent.cs
+++ b/src/Goldfinch.Web/Components/ViewComponents/Header/HeaderViewComponent.cs
@@ -23,7 +23,7 @@ public class HeaderViewComponent : ViewComponent
             new() { Label = "home",     FileLabel = "index.md",    Url = "/",                Icon = "house", IsActive = IsHome(path) },
             new() { Label = "blog",     FileLabel = "blog.md",     Url = "/blog",            Icon = "book",  IsActive = path.StartsWith("/blog",            System.StringComparison.OrdinalIgnoreCase) },
             new() { Label = "about",    FileLabel = "about.md",    Url = "/about",           Icon = "user",  IsActive = path.StartsWith("/about",           System.StringComparison.OrdinalIgnoreCase) },
-            new() { Label = "speaking", FileLabel = "speaking.md", Url = "/public-speaking", Icon = "mic",   IsActive = path.StartsWith("/public-speaking", System.StringComparison.OrdinalIgnoreCase) },
+            new() { Label = "speaking", FileLabel = "speaking.md", Url = "/speaking", Icon = "mic",   IsActive = path.StartsWith("/speaking", System.StringComparison.OrdinalIgnoreCase) },
         };
 
         return View("~/Components/ViewComponents/Header/Header.cshtml", new HeaderViewModel { NavigationItems = items });

--- a/src/Goldfinch.Web/Features/BlogDetail/BlogDetail.cshtml
+++ b/src/Goldfinch.Web/Features/BlogDetail/BlogDetail.cshtml
@@ -1,4 +1,5 @@
 @using Goldfinch.Web.Features.BlogDetail
+@using Goldfinch.Core.Extensions
 @model BlogPostViewModel
 
 @section schema {
@@ -78,7 +79,7 @@
                 </dl>
             </div>
             @{
-                var pageUrl = $"https://www.goldfinch.me{Model.Url}";
+                var pageUrl = $"https://www.goldfinch.me{Model.Url.ToAbsolutePath()}";
                 var shareTitle = Uri.EscapeDataString(Model.Title);
                 var shareUrl = Uri.EscapeDataString(pageUrl);
             }

--- a/src/Goldfinch.Web/Features/Home/Components/HomePage.cshtml
+++ b/src/Goldfinch.Web/Features/Home/Components/HomePage.cshtml
@@ -70,7 +70,7 @@
                 <div class="hero-buttons">
                     <a class="btn btn--primary" href="/blog"><icon name="book" size="15" /> <span>Read the blog</span></a>
                     <a class="btn" href="/about"><icon name="user" size="15" /> <span>About me</span></a>
-                    <a class="btn" href="/public-speaking"><icon name="mic" size="15" /> <span>Speaking</span></a>
+                    <a class="btn" href="/speaking"><icon name="mic" size="15" /> <span>Speaking</span></a>
                 </div>
 
                 <div class="hero-stats">

--- a/src/Goldfinch.Web/Features/InnerPage/Components/InnerPage.cshtml
+++ b/src/Goldfinch.Web/Features/InnerPage/Components/InnerPage.cshtml
@@ -81,7 +81,7 @@
 
             <div class="about-cta-row">
                 <a class="btn btn--primary" href="/blog"><icon name="book" size="15" /> <span>Read the blog</span></a>
-                <a class="btn" href="/public-speaking"><icon name="mic" size="15" /> <span>Talks</span></a>
+                <a class="btn" href="/speaking"><icon name="mic" size="15" /> <span>Talks</span></a>
             </div>
             *@
         </div>

--- a/src/Goldfinch.Web/Views/Shared/PartialViews/Footer.cshtml
+++ b/src/Goldfinch.Web/Views/Shared/PartialViews/Footer.cshtml
@@ -12,7 +12,7 @@
             <a class="footer-link" href="/">Home /</a>
             <a class="footer-link" href="/blog">Blog /</a>
             <a class="footer-link" href="/about">About /</a>
-            <a class="footer-link" href="/public-speaking">Speaking /</a>
+            <a class="footer-link" href="/speaking">Speaking /</a>
         </div>
         <div class="footer-col">
             <div class="footer-col__head">Subscribe</div>

--- a/src/Goldfinch.Web/Views/Shared/PartialViews/MobileDrawer.cshtml
+++ b/src/Goldfinch.Web/Views/Shared/PartialViews/MobileDrawer.cshtml
@@ -6,7 +6,7 @@
         ("home",     "index.md",    "/",                "house"),
         ("blog",     "blog.md",     "/blog",            "book"),
         ("about",    "about.md",    "/about",           "user"),
-        ("speaking", "speaking.md", "/public-speaking", "mic"),
+        ("speaking", "speaking.md", "/speaking", "mic"),
     };
 
     var path = Context.Request.Path.Value ?? "/";

--- a/src/Goldfinch.Web/wwwroot/sitefiles/src/scripts/command-palette.js
+++ b/src/Goldfinch.Web/wwwroot/sitefiles/src/scripts/command-palette.js
@@ -28,7 +28,7 @@
     { kind: 'page', url: '/', title: 'Go to Home' },
     { kind: 'page', url: '/blog', title: 'Go to Blog' },
     { kind: 'page', url: '/about', title: 'Go to About' },
-    { kind: 'page', url: '/public-speaking', title: 'Go to Speaking' },
+    { kind: 'page', url: '/speaking', title: 'Go to Speaking' },
   ];
 
   // ------- rendering -------


### PR DESCRIPTION
Changed "Public Speaking" URL to /speaking across codebase, updated navigation and internal links, and added former URL tracking. Revised About and Speaking page content and titles for clarity. Set About page SEO title and updated BlogDetail to use absolute URLs.