### PR TITLE
fix: correct job title to Principal Systems Engineer

### DIFF
--- a/src/Goldfinch.Web/Components/ViewComponents/SEO/SEOViewComponent.cs
+++ b/src/Goldfinch.Web/Components/ViewComponents/SEO/SEOViewComponent.cs
@@ -82,7 +82,7 @@ public class SEOViewComponent : ViewComponent
             },
             HasOccupation = new Occupation
             {
-                Name = "Principal Systems Developer",
+                Name = "Principal Systems Engineer",
                 OccupationLocation = new City
                 {
                     Name = "Leeds, UK"

--- a/src/Goldfinch.Web/Features/BlogDetail/BlogDetail.cshtml
+++ b/src/Goldfinch.Web/Features/BlogDetail/BlogDetail.cshtml
@@ -60,7 +60,7 @@
                 <div class="post-author-card__avatar" aria-hidden="true">LG</div>
                 <div class="post-author-card__text">
                     <div class="post-author-card__title mono">Liam Goldfinch <span class="sep">·</span> Kentico MVP</div>
-                    <p class="post-author-card__bio">Principal Systems Developer at IDHL. Writing about Xperience by Kentico, .NET, and the tooling I use to ship.</p>
+                    <p class="post-author-card__bio">Principal Systems Engineer at IDHL. Writing about Xperience by Kentico, .NET, and the tooling I use to ship.</p>
                 </div>
                 <a class="btn btn--small" href="/rss.xml"><icon name="rss" size="14" /> <span>Subscribe</span></a>
             </div>

--- a/src/Goldfinch.Web/Features/BlogDetail/BlogDetailController.cs
+++ b/src/Goldfinch.Web/Features/BlogDetail/BlogDetailController.cs
@@ -70,7 +70,7 @@ public class BlogDetailController : Controller
             },
             HasOccupation = new Occupation
             {
-                Name = "Principal Systems Developer",
+                Name = "Principal Systems Engineer",
                 OccupationLocation = new City
                 {
                     Name = "Leeds, UK"

--- a/src/Goldfinch.Web/Features/Home/Components/HomePage.cshtml
+++ b/src/Goldfinch.Web/Features/Home/Components/HomePage.cshtml
@@ -63,7 +63,7 @@
                     }
                     else
                     {
-                        <p>Principal Systems Developer at <a href="/about">IDHL</a>, Kentico MVP since 2022. Long-form notes on Xperience by Kentico, the .NET ecosystem, and the tooling I use to ship.</p>
+                        <p>Principal Systems Engineer at <a href="/about">IDHL</a>, Kentico MVP since 2022. Long-form notes on Xperience by Kentico, the .NET ecosystem, and the tooling I use to ship.</p>
                     }
                 </div>
 

--- a/src/Goldfinch.Web/Features/InnerPage/Components/InnerPage.cshtml
+++ b/src/Goldfinch.Web/Features/InnerPage/Components/InnerPage.cshtml
@@ -18,7 +18,7 @@
     @* Timeline hidden for launch — revisit once the narrative is finalised.
     (string Year, string Text)[] timelineRows = new[]
     {
-        ("2026", "Principal Systems Developer at IDHL"),
+        ("2026", "Principal Systems Engineer at IDHL"),
         ("2025", "Kentico MVP — 4th consecutive year"),
         ("2023", "Kentico Connection speaker · Brno"),
         ("2022", "First Kentico MVP award"),

--- a/src/Goldfinch.Web/Views/Shared/PartialViews/Footer.cshtml
+++ b/src/Goldfinch.Web/Views/Shared/PartialViews/Footer.cshtml
@@ -4,7 +4,7 @@
             <div class="footer-title mono">liam<span class="at">@@</span>goldfinch</div>
             <p class="footer-lede">
                 Long-form notes on Xperience by Kentico, .NET, and the tooling I use to ship.
-                Written by Liam Goldfinch — Principal Systems Developer at IDHL.
+                Written by Liam Goldfinch — Principal Systems Engineer at IDHL.
             </p>
         </div>
         <div class="footer-col">


### PR DESCRIPTION
This pull request updates all references to the job title "Principal Systems Developer" and changes them to "Principal Systems Engineer" throughout the application. This ensures consistency in job title presentation across the site, including schema data, author bios, timelines, and footers.

**Job Title Update:**

* Updated all instances of "Principal Systems Developer" to "Principal Systems Engineer" in schema generation logic for both web page and blog post schema data (`SEOViewComponent.cs`, `BlogDetailController.cs`). [[1]](diffhunk://#diff-ac55a115fd6cc89eeb0bad5160c4c962e79135fc90e752a61c6862c08cfb0de9L85-R85) [[2]](diffhunk://#diff-01438c80d61868fa40bd5d8b87306934daef3124ab9d9dc4d48fe1745ef5b339L73-R73)

**Content/Bio Updates:**

* Changed the job title in the blog post author bio and homepage introduction to "Principal Systems Engineer" (`BlogDetail.cshtml`, `HomePage.cshtml`). [[1]](diffhunk://#diff-06b6b8a6242cc75bb55d80e82c8cbeb7d5c4bcc4758a334c183f5a8020d3a047L63-R63) [[2]](diffhunk://#diff-3393ba8d9e8877aa993e470c17e704c117b5c2801edc670c60832737258b2bd0L66-R66)
* Updated the timeline entry for 2026 in the inner page component to reflect the new job title (`InnerPage.cshtml`).
* Modified the footer author line to use "Principal Systems Engineer" (`Footer.cshtml`).