### PR TITLE
build(sln): update to Xperience v31.5.1

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -7,11 +7,11 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="coverlet.collector" Version="10.0.1" />
-    <PackageVersion Include="Kentico.Xperience.Admin" Version="31.5.0" />
-    <PackageVersion Include="Kentico.Xperience.AzureStorage" Version="31.5.0" />
-    <PackageVersion Include="Kentico.Xperience.ManagementApi" Version="31.5.0-preview" />
+    <PackageVersion Include="Kentico.Xperience.Admin" Version="31.5.1" />
+    <PackageVersion Include="Kentico.Xperience.AzureStorage" Version="31.5.1" />
+    <PackageVersion Include="Kentico.Xperience.ManagementApi" Version="31.5.1-preview" />
     <PackageVersion Include="Kentico.Xperience.MiniProfiler" Version="3.0.0" />
-    <PackageVersion Include="Kentico.Xperience.WebApp" Version="31.5.0" />
+    <PackageVersion Include="Kentico.Xperience.WebApp" Version="31.5.1" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
     <PackageVersion Include="Microsoft.Playwright" Version="1.59.0" />
     <PackageVersion Include="Schema.NET" Version="13.0.0" />

--- a/scripts/Update-Xperience.ps1
+++ b/scripts/Update-Xperience.ps1
@@ -227,11 +227,13 @@ function Update-DirectoryPackagesProps {
 
         $updatedCount = 0
 
-        $packagesProps.Project.ItemGroup.PackageVersion | Where-Object {
+        $packagesToUpdate = $packagesProps.Project.ItemGroup.PackageVersion | Where-Object {
             $_.Include -like "Kentico.Xperience.*" -and $preservePackages -notcontains $_.Include
-        } | ForEach-Object {
-            $packageName = $_.Include
-            $oldVersion = $_.Version
+        }
+
+        foreach ($package in $packagesToUpdate) {
+            $packageName = $package.Include
+            $oldVersion = $package.Version
 
             # Always query NuGet to resolve the actual version to use
             Write-Host "  Querying NuGet for $packageName..." -ForegroundColor Gray
@@ -239,7 +241,7 @@ function Update-DirectoryPackagesProps {
 
             if ($nugetResponse.versions.Count -eq 0) {
                 Write-Warning "No versions found for $packageName on NuGet. Skipping."
-                return
+                continue
             }
 
             $resolvedVersion = if ($Version -eq "latest") {
@@ -258,7 +260,7 @@ function Update-DirectoryPackagesProps {
                 }
             }
 
-            $_.Version = $resolvedVersion
+            $package.Version = $resolvedVersion
             $script:updatedVersion = $resolvedVersion
 
             Write-Host "  Updated $packageName : $oldVersion -> $resolvedVersion" -ForegroundColor Green

--- a/scripts/Update-Xperience.ps1
+++ b/scripts/Update-Xperience.ps1
@@ -233,25 +233,35 @@ function Update-DirectoryPackagesProps {
             $packageName = $_.Include
             $oldVersion = $_.Version
 
-            if ($Version -eq "latest") {
-                # Query NuGet for latest version
-                Write-Host "  Querying NuGet for latest version of $packageName..." -ForegroundColor Gray
-                $nugetResponse = Invoke-RestMethod -Uri "https://api.nuget.org/v3-flatcontainer/$($packageName.ToLower())/index.json"
+            # Always query NuGet to resolve the actual version to use
+            Write-Host "  Querying NuGet for $packageName..." -ForegroundColor Gray
+            $nugetResponse = Invoke-RestMethod -Uri "https://api.nuget.org/v3-flatcontainer/$($packageName.ToLower())/index.json"
 
-                if ($nugetResponse.versions.Count -gt 0) {
-                    $latestVersion = $nugetResponse.versions[-1]
-                    $_.Version = $latestVersion
-                    $script:updatedVersion = $latestVersion
-                } else {
-                    Write-Warning "No versions found for $packageName on NuGet. Skipping update for this package."
-                    return
-                }
-            } else {
-                $_.Version = $Version
-                $script:updatedVersion = $Version
+            if ($nugetResponse.versions.Count -eq 0) {
+                Write-Warning "No versions found for $packageName on NuGet. Skipping."
+                return
             }
 
-            Write-Host "  Updated $packageName : $oldVersion -> $($_.Version)" -ForegroundColor Green
+            $resolvedVersion = if ($Version -eq "latest") {
+                $nugetResponse.versions[-1]
+            } elseif ($nugetResponse.versions -contains $Version) {
+                $Version
+            } else {
+                # Exact version not found — try preview variant, then fall back to latest
+                $previewVariant = "$Version-preview"
+                if ($nugetResponse.versions -contains $previewVariant) {
+                    Write-Warning "$packageName $Version not found; using $previewVariant"
+                    $previewVariant
+                } else {
+                    Write-Warning "$packageName $Version not found and no preview variant exists; using latest ($($nugetResponse.versions[-1]))"
+                    $nugetResponse.versions[-1]
+                }
+            }
+
+            $_.Version = $resolvedVersion
+            $script:updatedVersion = $resolvedVersion
+
+            Write-Host "  Updated $packageName : $oldVersion -> $resolvedVersion" -ForegroundColor Green
             $updatedCount++
         }
 

--- a/scripts/Update-Xperience.ps1
+++ b/scripts/Update-Xperience.ps1
@@ -23,6 +23,7 @@ param(
 $ErrorActionPreference = "Stop"
 $script:hasErrors = $false
 $script:updatedVersion = $null
+$script:resolvedVersions = @{}
 $script:ciWasEnabled = $false
 
 #region Helper Functions
@@ -261,13 +262,21 @@ function Update-DirectoryPackagesProps {
             }
 
             $package.Version = $resolvedVersion
-            $script:updatedVersion = $resolvedVersion
+            $script:resolvedVersions[$packageName] = $resolvedVersion
 
             Write-Host "  Updated $packageName : $oldVersion -> $resolvedVersion" -ForegroundColor Green
             $updatedCount++
         }
 
         if ($updatedCount -gt 0) {
+            # Use the requested target version for the summary/commit hint; fall back to
+            # the resolved version only when the target was "latest" (no explicit request).
+            $script:updatedVersion = if ($Version -eq "latest") {
+                $script:resolvedVersions.Values | Select-Object -First 1
+            } else {
+                $Version
+            }
+
             $packagesProps.Save((Resolve-Path "Directory.Packages.props"))
             Write-Success "Updated $updatedCount Kentico packages in Directory.Packages.props"
 
@@ -569,6 +578,15 @@ function Show-Summary {
 
         if ($script:updatedVersion) {
             Write-Host "`nUpdated to Xperience version: $script:updatedVersion" -ForegroundColor Cyan
+
+            # Highlight any packages that resolved to a different version than requested
+            $overrides = $script:resolvedVersions.GetEnumerator() | Where-Object { $_.Value -ne $script:updatedVersion }
+            if ($overrides) {
+                Write-Host "`nNote: the following packages resolved to a different version:" -ForegroundColor Yellow
+                foreach ($entry in $overrides) {
+                    Write-Host "  $($entry.Key): $($entry.Value)" -ForegroundColor Yellow
+                }
+            }
         }
 
         Write-Host "`nNext steps:" -ForegroundColor White

--- a/src/Goldfinch.Admin/Client/package-lock.json
+++ b/src/Goldfinch.Admin/Client/package-lock.json
@@ -8,8 +8,8 @@
       "name": "goldfinch-web-admin",
       "version": "1.0.0",
       "dependencies": {
-        "@kentico/xperience-admin-base": "^31.5.0",
-        "@kentico/xperience-admin-components": "^31.5.0",
+        "@kentico/xperience-admin-base": "^31.5.1",
+        "@kentico/xperience-admin-components": "^31.5.1",
         "react": "^19.1.1",
         "react-dom": "^19.1.1"
       },
@@ -19,7 +19,7 @@
         "@babel/preset-env": "^7.29.5",
         "@babel/preset-react": "^7.28.5",
         "@babel/preset-typescript": "^7.28.5",
-        "@kentico/xperience-webpack-config": "^31.5.0",
+        "@kentico/xperience-webpack-config": "^31.5.1",
         "@types/react": "^19.1.16",
         "@types/react-dom": "^19.1.9",
         "babel-loader": "^10.0.0",
@@ -2405,13 +2405,13 @@
       "license": "Apache-2.0"
     },
     "node_modules/@kentico/xperience-admin-base": {
-      "version": "31.5.0",
-      "resolved": "https://registry.npmjs.org/@kentico/xperience-admin-base/-/xperience-admin-base-31.5.0.tgz",
-      "integrity": "sha512-w932kdw9S8NOOsGwtzTTffxEL/SKgIMTLlsSr4JD1BkO+ncua7uVvRyd3ENzZ1lyproEHAy/6LwJjjEnmVPBiw==",
+      "version": "31.5.1",
+      "resolved": "https://registry.npmjs.org/@kentico/xperience-admin-base/-/xperience-admin-base-31.5.1.tgz",
+      "integrity": "sha512-WcbyNExjPm8FEnGXs3uA65M9scbVIy7f54iUCBzeklCsSXBwZp72Z/6zvk7RJI9reku/5c9eqDR5SfVIOzIxOA==",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "^18.0.1",
-        "@kentico/xperience-admin-components": "31.5.0",
+        "@kentico/xperience-admin-components": "31.5.1",
         "@react-aria/focus": "^3.22.0",
         "@react-aria/i18n": "^3.13.0",
         "@react-aria/visually-hidden": "^3.9.0",
@@ -2438,9 +2438,9 @@
       }
     },
     "node_modules/@kentico/xperience-admin-components": {
-      "version": "31.5.0",
-      "resolved": "https://registry.npmjs.org/@kentico/xperience-admin-components/-/xperience-admin-components-31.5.0.tgz",
-      "integrity": "sha512-g1fOzJuERq6xioM0tKdxRfMGGOTkAXkBCKinD7sQ/kQ+yE5aQAemYbQWY5Iloqw/dOxvuFG5aakAoZzxaItiQQ==",
+      "version": "31.5.1",
+      "resolved": "https://registry.npmjs.org/@kentico/xperience-admin-components/-/xperience-admin-components-31.5.1.tgz",
+      "integrity": "sha512-f7AGotztXMhuGTfzpvOvKCZW2uaPvL20gKCk2/cqCw9HYG924sW6sMe4tqKEG7nCCbwKuyzy1Fd3QJu33+gmdw==",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@amcharts/amcharts5": "5.17.2",
@@ -2480,9 +2480,9 @@
       }
     },
     "node_modules/@kentico/xperience-webpack-config": {
-      "version": "31.5.0",
-      "resolved": "https://registry.npmjs.org/@kentico/xperience-webpack-config/-/xperience-webpack-config-31.5.0.tgz",
-      "integrity": "sha512-zsR69LTuyQQoUS8Emn+tLURYJqInfF0huFGCz0D3GnhsNYKNw2Q4HnBLtjC0bLT6t8+BmgZlCuATcYhE+jz42Q==",
+      "version": "31.5.1",
+      "resolved": "https://registry.npmjs.org/@kentico/xperience-webpack-config/-/xperience-webpack-config-31.5.1.tgz",
+      "integrity": "sha512-QWIwh9lDY/TWGSijvLD4tfMpw8HzlPwTbqEs16RI3+L7PznmKwBgngdLlFkKq5GS2FeHHuQPxRC4o7DqXuJ+og==",
       "dev": true,
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
@@ -10723,10 +10723,11 @@
       "license": "MIT"
     },
     "node_modules/ws": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
-      "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
+      "version": "8.20.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
+      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
       },

--- a/src/Goldfinch.Admin/Client/package.json
+++ b/src/Goldfinch.Admin/Client/package.json
@@ -11,8 +11,8 @@
     "build": "webpack --mode=production"
   },
   "dependencies": {
-    "@kentico/xperience-admin-base": "^31.5.0",
-    "@kentico/xperience-admin-components": "^31.5.0",
+    "@kentico/xperience-admin-base": "^31.5.1",
+    "@kentico/xperience-admin-components": "^31.5.1",
     "react": "^19.1.1",
     "react-dom": "^19.1.1"
   },
@@ -22,7 +22,7 @@
     "@babel/preset-env": "^7.29.5",
     "@babel/preset-react": "^7.28.5",
     "@babel/preset-typescript": "^7.28.5",
-    "@kentico/xperience-webpack-config": "^31.5.0",
+    "@kentico/xperience-webpack-config": "^31.5.1",
     "@types/react": "^19.1.16",
     "@types/react-dom": "^19.1.9",
     "babel-loader": "^10.0.0",

--- a/src/Goldfinch.Admin/packages.lock.json
+++ b/src/Goldfinch.Admin/packages.lock.json
@@ -4,12 +4,12 @@
     "net10.0": {
       "Kentico.Xperience.Admin": {
         "type": "Direct",
-        "requested": "[31.5.0, )",
-        "resolved": "31.5.0",
-        "contentHash": "JOCdhKhmsdU/0fdVWJlqiG+nd6eaomefBts4Soi30TkUsxf1iZ4vnLYY4wj5S2NAYfvvinriu2BqHBxqynaRRw==",
+        "requested": "[31.5.1, )",
+        "resolved": "31.5.1",
+        "contentHash": "kKbNYnUnTpDTqgrrsOFPp436/7SwwPC0bn/0+gfU5htADEtLzObAn2vags3183GYgbu+DD0nruGHgPvo+XYTAQ==",
         "dependencies": {
           "Kentico.Aira.Client": "6.1.0",
-          "Kentico.Xperience.WebApp": "[31.5.0]",
+          "Kentico.Xperience.WebApp": "[31.5.1]",
           "Microsoft.AspNetCore.SpaServices.Extensions": "8.0.26",
           "Microsoft.Extensions.FileProviders.Embedded": "8.0.26",
           "Microsoft.SemanticKernel": "1.75.0",
@@ -20,15 +20,15 @@
       },
       "Kentico.Xperience.WebApp": {
         "type": "Direct",
-        "requested": "[31.5.0, )",
-        "resolved": "31.5.0",
-        "contentHash": "A0WXW05ExXF95+CxcZKbSzqqiAX2SDmqupkCp8G97RSO3m3AaLHQxXAqvT29SHwNGlJAlUA480L8hqD6o+Jepw==",
+        "requested": "[31.5.1, )",
+        "resolved": "31.5.1",
+        "contentHash": "EY6UVqB+PGzkG9FyiY3Eile2ziJEGqSk6KlkTRwrTNYLC++ck3sq1F4fGH2IURnaDH262YWh8N/4DCSuaNz0Pg==",
         "dependencies": {
           "CommandLineParser": "2.9.1",
           "HotChocolate.AspNetCore": "15.1.16",
           "HotChocolate.Data": "15.1.16",
           "HtmlSanitizer": "9.0.892",
-          "Kentico.Xperience.Core": "[31.5.0]",
+          "Kentico.Xperience.Core": "[31.5.1]",
           "Microsoft.Extensions.FileProviders.Embedded": "8.0.26"
         }
       },
@@ -420,8 +420,8 @@
       },
       "Kentico.Xperience.Core": {
         "type": "Transitive",
-        "resolved": "31.5.0",
-        "contentHash": "IKV1CkJDkfIbM2hE+5M1xOkQZotvZMhy/Y+v/wHASWGiVPhbpZ+deLLLjoaB9KzZgE7/71QRH3IwUQ4GeLiyww==",
+        "resolved": "31.5.1",
+        "contentHash": "B+syZSMPr9MbLTk1RRvgJz4bR6kt6zddCQu10pM8p65u11te6cNn/d/RRCsgKo6iEIVYooaoSvOD36nwGLmZSw==",
         "dependencies": {
           "AngleSharp": "0.17.1",
           "Kentico.Aira.Client": "6.1.0",
@@ -802,8 +802,8 @@
       "goldfinch.core": {
         "type": "Project",
         "dependencies": {
-          "Kentico.Xperience.Admin": "[31.5.0, )",
-          "Kentico.Xperience.WebApp": "[31.5.0, )",
+          "Kentico.Xperience.Admin": "[31.5.1, )",
+          "Kentico.Xperience.WebApp": "[31.5.1, )",
           "Sidio.Sitemap.AspNetCore": "[3.1.1, )"
         }
       },

--- a/src/Goldfinch.Core/packages.lock.json
+++ b/src/Goldfinch.Core/packages.lock.json
@@ -4,12 +4,12 @@
     "net10.0": {
       "Kentico.Xperience.Admin": {
         "type": "Direct",
-        "requested": "[31.5.0, )",
-        "resolved": "31.5.0",
-        "contentHash": "JOCdhKhmsdU/0fdVWJlqiG+nd6eaomefBts4Soi30TkUsxf1iZ4vnLYY4wj5S2NAYfvvinriu2BqHBxqynaRRw==",
+        "requested": "[31.5.1, )",
+        "resolved": "31.5.1",
+        "contentHash": "kKbNYnUnTpDTqgrrsOFPp436/7SwwPC0bn/0+gfU5htADEtLzObAn2vags3183GYgbu+DD0nruGHgPvo+XYTAQ==",
         "dependencies": {
           "Kentico.Aira.Client": "6.1.0",
-          "Kentico.Xperience.WebApp": "[31.5.0]",
+          "Kentico.Xperience.WebApp": "[31.5.1]",
           "Microsoft.AspNetCore.SpaServices.Extensions": "8.0.26",
           "Microsoft.Extensions.FileProviders.Embedded": "8.0.26",
           "Microsoft.SemanticKernel": "1.75.0",
@@ -20,17 +20,17 @@
       },
       "Kentico.Xperience.WebApp": {
         "type": "Direct",
-        "requested": "[31.5.0, )",
-        "resolved": "31.5.0",
-        "contentHash": "A0WXW05ExXF95+CxcZKbSzqqiAX2SDmqupkCp8G97RSO3m3AaLHQxXAqvT29SHwNGlJAlUA480L8hqD6o+Jepw==",
+        "requested": "[31.5.1, )",
+        "resolved": "31.5.1",
+        "contentHash": "EY6UVqB+PGzkG9FyiY3Eile2ziJEGqSk6KlkTRwrTNYLC++ck3sq1F4fGH2IURnaDH262YWh8N/4DCSuaNz0Pg==",
         "dependencies": {
           "CommandLineParser": "2.9.1",
           "HotChocolate.AspNetCore": "15.1.16",
           "HotChocolate.Data": "15.1.16",
           "HtmlSanitizer": "9.0.892",
-          "Kentico.Xperience.Core": "[31.5.0]",
+          "Kentico.Xperience.Core": "[31.5.1]",
           "Microsoft.AspNetCore.Components": "8.0.26",
-          "Microsoft.Extensions.Caching.Memory": "8.0.1",
+          "Microsoft.Extensions.Caching.Memory": "9.0.13",
           "Microsoft.Extensions.FileProviders.Embedded": "8.0.26"
         }
       },
@@ -455,15 +455,15 @@
       },
       "Kentico.Xperience.Core": {
         "type": "Transitive",
-        "resolved": "31.5.0",
-        "contentHash": "IKV1CkJDkfIbM2hE+5M1xOkQZotvZMhy/Y+v/wHASWGiVPhbpZ+deLLLjoaB9KzZgE7/71QRH3IwUQ4GeLiyww==",
+        "resolved": "31.5.1",
+        "contentHash": "B+syZSMPr9MbLTk1RRvgJz4bR6kt6zddCQu10pM8p65u11te6cNn/d/RRCsgKo6iEIVYooaoSvOD36nwGLmZSw==",
         "dependencies": {
           "AngleSharp": "0.17.1",
           "Kentico.Aira.Client": "6.1.0",
           "Magick.NET-Q8-AnyCPU": "14.13.0",
           "MailKit": "4.16.0",
           "Microsoft.Data.SqlClient": "7.0.0",
-          "Microsoft.Extensions.Caching.Memory": "8.0.1",
+          "Microsoft.Extensions.Caching.Memory": "9.0.13",
           "Microsoft.Extensions.Configuration": "8.0.0",
           "Microsoft.Extensions.DependencyInjection": "8.0.1",
           "Microsoft.Extensions.FileProviders.Physical": "8.0.0",

--- a/src/Goldfinch.Web/packages.lock.json
+++ b/src/Goldfinch.Web/packages.lock.json
@@ -4,12 +4,12 @@
     "net10.0": {
       "Kentico.Xperience.Admin": {
         "type": "Direct",
-        "requested": "[31.5.0, )",
-        "resolved": "31.5.0",
-        "contentHash": "JOCdhKhmsdU/0fdVWJlqiG+nd6eaomefBts4Soi30TkUsxf1iZ4vnLYY4wj5S2NAYfvvinriu2BqHBxqynaRRw==",
+        "requested": "[31.5.1, )",
+        "resolved": "31.5.1",
+        "contentHash": "kKbNYnUnTpDTqgrrsOFPp436/7SwwPC0bn/0+gfU5htADEtLzObAn2vags3183GYgbu+DD0nruGHgPvo+XYTAQ==",
         "dependencies": {
           "Kentico.Aira.Client": "6.1.0",
-          "Kentico.Xperience.WebApp": "[31.5.0]",
+          "Kentico.Xperience.WebApp": "[31.5.1]",
           "Microsoft.AspNetCore.SpaServices.Extensions": "8.0.26",
           "Microsoft.Extensions.FileProviders.Embedded": "8.0.26",
           "Microsoft.SemanticKernel": "1.75.0",
@@ -20,26 +20,26 @@
       },
       "Kentico.Xperience.AzureStorage": {
         "type": "Direct",
-        "requested": "[31.5.0, )",
-        "resolved": "31.5.0",
-        "contentHash": "2e34MTZ2Coq/tjUfqGljCZHFBk24ZvEjXXuc8Hev+mbyIc2t6zaHqFhxx/CmvNG0hcgOgiRE+iSUuhkpimN0tA==",
+        "requested": "[31.5.1, )",
+        "resolved": "31.5.1",
+        "contentHash": "OXY9ZoQ79iLSh8xOE2Ky5iipaKQJOpp0UIopShRKuKd6uFVa0DxBZtjtelfPmPS3lzaEDQsglT025R6zex0KKg==",
         "dependencies": {
           "Azure.Storage.Blobs": "12.27.0",
-          "Kentico.Xperience.Core": "31.5.0",
+          "Kentico.Xperience.Core": "31.5.1",
           "Newtonsoft.Json": "13.0.4",
           "System.IO.Hashing": "10.0.7"
         }
       },
       "Kentico.Xperience.ManagementApi": {
         "type": "Direct",
-        "requested": "[31.5.0-preview, )",
-        "resolved": "31.5.0-preview",
-        "contentHash": "bhZeNMXlpIjLKNzTXyKjjCvHhUfJoAvP/IUqmDIeKerQxKqeh7Vzs0OYJyH3HSbscmVEJOls6v5Y7abhSc0P9Q==",
+        "requested": "[31.5.1-preview, )",
+        "resolved": "31.5.1-preview",
+        "contentHash": "cmQs799IjymQ9SduKA11TfCy1RlRm//+PWL0yVFsRAp/Mxlrt3r3he3p6b4vjWAXFFzLIP0FnMTfzRgr8WQKVw==",
         "dependencies": {
           "Asp.Versioning.Mvc": "8.1.1",
           "Asp.Versioning.Mvc.ApiExplorer": "8.1.1",
-          "Kentico.Xperience.Admin": "31.5.0",
-          "Kentico.Xperience.Core": "31.5.0",
+          "Kentico.Xperience.Admin": "31.5.1",
+          "Kentico.Xperience.Core": "31.5.1",
           "NJsonSchema": "11.6.1",
           "Swashbuckle.AspNetCore": "9.0.6"
         }
@@ -57,15 +57,15 @@
       },
       "Kentico.Xperience.WebApp": {
         "type": "Direct",
-        "requested": "[31.5.0, )",
-        "resolved": "31.5.0",
-        "contentHash": "A0WXW05ExXF95+CxcZKbSzqqiAX2SDmqupkCp8G97RSO3m3AaLHQxXAqvT29SHwNGlJAlUA480L8hqD6o+Jepw==",
+        "requested": "[31.5.1, )",
+        "resolved": "31.5.1",
+        "contentHash": "EY6UVqB+PGzkG9FyiY3Eile2ziJEGqSk6KlkTRwrTNYLC++ck3sq1F4fGH2IURnaDH262YWh8N/4DCSuaNz0Pg==",
         "dependencies": {
           "CommandLineParser": "2.9.1",
           "HotChocolate.AspNetCore": "15.1.16",
           "HotChocolate.Data": "15.1.16",
           "HtmlSanitizer": "9.0.892",
-          "Kentico.Xperience.Core": "[31.5.0]",
+          "Kentico.Xperience.Core": "[31.5.1]",
           "Microsoft.Extensions.FileProviders.Embedded": "8.0.26"
         }
       },
@@ -535,8 +535,8 @@
       },
       "Kentico.Xperience.Core": {
         "type": "Transitive",
-        "resolved": "31.5.0",
-        "contentHash": "IKV1CkJDkfIbM2hE+5M1xOkQZotvZMhy/Y+v/wHASWGiVPhbpZ+deLLLjoaB9KzZgE7/71QRH3IwUQ4GeLiyww==",
+        "resolved": "31.5.1",
+        "contentHash": "B+syZSMPr9MbLTk1RRvgJz4bR6kt6zddCQu10pM8p65u11te6cNn/d/RRCsgKo6iEIVYooaoSvOD36nwGLmZSw==",
         "dependencies": {
           "AngleSharp": "0.17.1",
           "Kentico.Aira.Client": "6.1.0",
@@ -981,15 +981,15 @@
         "type": "Project",
         "dependencies": {
           "Goldfinch.Core": "[1.0.0, )",
-          "Kentico.Xperience.Admin": "[31.5.0, )",
-          "Kentico.Xperience.WebApp": "[31.5.0, )"
+          "Kentico.Xperience.Admin": "[31.5.1, )",
+          "Kentico.Xperience.WebApp": "[31.5.1, )"
         }
       },
       "goldfinch.core": {
         "type": "Project",
         "dependencies": {
-          "Kentico.Xperience.Admin": "[31.5.0, )",
-          "Kentico.Xperience.WebApp": "[31.5.0, )",
+          "Kentico.Xperience.Admin": "[31.5.1, )",
+          "Kentico.Xperience.WebApp": "[31.5.1, )",
           "Sidio.Sitemap.AspNetCore": "[3.1.1, )"
         }
       }


### PR DESCRIPTION
## Summary

- Updated `Kentico.Xperience.Admin`, `Kentico.Xperience.AzureStorage`, and `Kentico.Xperience.WebApp` from **31.5.0 → 31.5.1**
- Updated `Kentico.Xperience.ManagementApi` from **31.5.0-preview → 31.5.1-preview** (no stable 31.5.1 release exists for this package)
- Updated `@kentico/*` npm packages in admin client to **31.5.1**
- Applied database migrations via `--kxp-update`
- Also fixed `scripts/Update-Xperience.ps1` to gracefully handle packages where the stable target version does not exist — it now queries NuGet and automatically falls back to the preview variant

## Test plan

- [ ] Homepage loads correctly at https://localhost:52623
- [ ] Blog listing page works (pagination, filters)
- [ ] Blog detail pages render with images and code blocks
- [ ] Navigation and header scroll behaviour works
- [ ] Admin interface accessible at https://localhost:52623/admin

🤖 Generated with [Claude Code](https://claude.com/claude-code)