### PR TITLE
Potential fix for code scanning alert no. 5: DOM text reinterpreted as HTML

### DIFF
--- a/src/Goldfinch.Web/wwwroot/sitefiles/src/scripts/toc-scrollspy.js
+++ b/src/Goldfinch.Web/wwwroot/sitefiles/src/scripts/toc-scrollspy.js
@@ -20,8 +20,12 @@
     headings.forEach((h, i) => {
       const li = document.createElement('li');
       const a = document.createElement('a');
+      const idx = document.createElement('span');
       a.href = `#${h.id}`;
-      a.innerHTML = `<span class="idx">${String(i + 1).padStart(2, '0')}</span>${h.textContent}`;
+      idx.className = 'idx';
+      idx.textContent = String(i + 1).padStart(2, '0');
+      a.appendChild(idx);
+      a.appendChild(document.createTextNode(h.textContent || ''));
       li.appendChild(a);
       ul.appendChild(li);
     });


### PR DESCRIPTION
Potential fix for [https://github.com/liamgold/goldfinch.me/security/code-scanning/5](https://github.com/liamgold/goldfinch.me/security/code-scanning/5)

Use DOM APIs instead of `innerHTML` to build the anchor content:

- Keep the index `<span class="idx">…</span>` as an actual element.
- Put heading text into a text node (or `textContent`) so it is never interpreted as HTML.

Best single fix in `src/Goldfinch.Web/wwwroot/sitefiles/src/scripts/toc-scrollspy.js`:
- Replace line 24’s `a.innerHTML = ...` with element construction:
  - create `span`
  - set `span.className = 'idx'`
  - set `span.textContent` to the zero-padded index
  - append `span` to `a`
  - append a text node for `h.textContent`

No new imports or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
