### PR TITLE
feat(blog): show tag chips on home and latest-posts cards

### DIFF
--- a/src/Goldfinch.Web/Components/ViewComponents/LatestBlogPosts/LatestBlogPostsViewComponent.cs
+++ b/src/Goldfinch.Web/Components/ViewComponents/LatestBlogPosts/LatestBlogPostsViewComponent.cs
@@ -1,7 +1,9 @@
 ﻿using CMS.Websites;
 using Goldfinch.Core.BlogPosts;
 using Goldfinch.Web.Features.BlogDetail;
+using Goldfinch.Web.Features.BlogList;
 using Kentico.Content.Web.Mvc;
+using Kentico.Content.Web.Mvc.Routing;
 using Microsoft.AspNetCore.Mvc;
 using System.Collections.Generic;
 using System.Linq;
@@ -14,15 +16,21 @@ public class LatestBlogPostsViewComponent : ViewComponent
     private readonly IWebPageUrlRetriever _pageUrlRetriever;
     private readonly IBlogPostService _blogPostService;
     private readonly IWebPageDataContextRetriever _pageDataContextRetriever;
+    private readonly IBlogTagService _blogTagService;
+    private readonly IPreferredLanguageRetriever _preferredLanguageRetriever;
 
     public LatestBlogPostsViewComponent(
         IWebPageUrlRetriever pageUrlRetriever,
         IBlogPostService blogPostService,
-        IWebPageDataContextRetriever pageDataContextRetriever)
+        IWebPageDataContextRetriever pageDataContextRetriever,
+        IBlogTagService blogTagService,
+        IPreferredLanguageRetriever preferredLanguageRetriever)
     {
         _pageUrlRetriever = pageUrlRetriever;
         _blogPostService = blogPostService;
         _pageDataContextRetriever = pageDataContextRetriever;
+        _blogTagService = blogTagService;
+        _preferredLanguageRetriever = preferredLanguageRetriever;
     }
 
     public async Task<IViewComponentResult> InvokeAsync(string title)
@@ -33,6 +41,7 @@ public class LatestBlogPostsViewComponent : ViewComponent
         }
 
         var page = data.WebPage;
+        var languageName = _preferredLanguageRetriever.Get();
 
         var blogPosts = (await _blogPostService.GetLatestBlogPosts())
             .Where(x => x.SystemFields.WebPageItemID != page.WebPageItemID)
@@ -43,6 +52,13 @@ public class LatestBlogPostsViewComponent : ViewComponent
         foreach (var blogPost in blogPosts)
         {
             var blogPostViewModel = await BlogPostViewModel.GetViewModelAsync(blogPost, _pageUrlRetriever);
+
+            if (blogPost.BlogPostTags?.Any() == true)
+            {
+                var tagGuids = blogPost.BlogPostTags.Select(t => t.Identifier).ToList();
+                var resolvedTags = await _blogTagService.GetTagsByGuids(tagGuids, languageName);
+                blogPostViewModel.Tags = resolvedTags.Select(t => new BlogTagViewModel(t.Name, t.Title, 0)).ToList();
+            }
 
             blogPostViewModels.Add(blogPostViewModel);
         }

--- a/src/Goldfinch.Web/Features/Home/Components/HomePage.cshtml
+++ b/src/Goldfinch.Web/Features/Home/Components/HomePage.cshtml
@@ -181,6 +181,15 @@
                     </div>
                     <h3 class="featured-card__title">@Model.FeaturedPost.Title</h3>
                     <p class="featured-card__summary">@Model.FeaturedPost.Summary</p>
+                    @if (Model.FeaturedPost.Tags.Count > 0)
+                    {
+                        <div class="post-card__tags">
+                            @foreach (var tag in Model.FeaturedPost.Tags)
+                            {
+                                <span class="tag-chip tag-chip--small mono"><span class="tag-chip__hash">#</span><span>@tag.Label</span></span>
+                            }
+                        </div>
+                    }
                     <div class="featured-card__cta">
                         <span>Read the post</span>
                         <icon name="arrowR" size="15" />
@@ -219,6 +228,15 @@
                             </div>
                             <h3 class="post-card__title">@post.Title</h3>
                             <p class="post-card__summary">@post.Summary</p>
+                            @if (post.Tags.Count > 0)
+                            {
+                                <div class="post-card__tags">
+                                    @foreach (var tag in post.Tags)
+                                    {
+                                        <span class="tag-chip tag-chip--small mono"><span class="tag-chip__hash">#</span><span>@tag.Label</span></span>
+                                    }
+                                </div>
+                            }
                         </div>
                     </a>
                 }

--- a/src/Goldfinch.Web/Features/Home/Components/HomePageViewComponent.cs
+++ b/src/Goldfinch.Web/Features/Home/Components/HomePageViewComponent.cs
@@ -5,7 +5,9 @@ using CMS.Websites;
 using Goldfinch.Core.BlogPosts;
 using Goldfinch.Core.SiteStats;
 using Goldfinch.Web.Features.BlogDetail;
+using Goldfinch.Web.Features.BlogList;
 using Kentico.Content.Web.Mvc;
+using Kentico.Content.Web.Mvc.Routing;
 using Microsoft.AspNetCore.Mvc;
 
 namespace Goldfinch.Web.Features.Home;
@@ -22,20 +24,27 @@ public class HomePageViewComponent : ViewComponent
     private readonly IContentRetriever _contentRetriever;
     private readonly IBlogPostService _blogPostService;
     private readonly IWebPageUrlRetriever _urlRetriever;
+    private readonly IBlogTagService _blogTagService;
+    private readonly IPreferredLanguageRetriever _preferredLanguageRetriever;
 
     public HomePageViewComponent(
         IContentRetriever contentRetriever,
         IBlogPostService blogPostService,
-        IWebPageUrlRetriever urlRetriever)
+        IWebPageUrlRetriever urlRetriever,
+        IBlogTagService blogTagService,
+        IPreferredLanguageRetriever preferredLanguageRetriever)
     {
         _contentRetriever = contentRetriever;
         _blogPostService = blogPostService;
         _urlRetriever = urlRetriever;
+        _blogTagService = blogTagService;
+        _preferredLanguageRetriever = preferredLanguageRetriever;
     }
 
     public async Task<IViewComponentResult> InvokeAsync(RoutedWebPage page, HomePageTemplateProperties props)
     {
         var home = await _contentRetriever.RetrieveCurrentPage<Core.ContentTypes.Home>();
+        var languageName = _preferredLanguageRetriever.Get();
 
         // Pull the full set — cheap on a small blog, lets us derive totals + first-year
         // for the hero stats without a second query.
@@ -51,24 +60,28 @@ public class HomePageViewComponent : ViewComponent
         {
             var top = allPosts[0];
             var topUrl = (await _urlRetriever.Retrieve(top)).RelativePath;
+            var topTags = await ResolveTags(top.BlogPostTags, languageName);
             featured = new HomeFeaturedPost(
                 Title: top.BaseContentTitle,
                 Summary: top.BaseContentShortDescription,
                 Url: topUrl,
                 Filename: BlogPostViewModel.FilenameFromUrl(topUrl),
                 PublishedOn: top.BlogPostDate,
-                ReadingMinutes: EstimateReadingMinutes(top.BaseContentShortDescription));
+                ReadingMinutes: EstimateReadingMinutes(top.BaseContentShortDescription),
+                Tags: topTags);
 
             foreach (var post in allPosts.Skip(1).Take(RecentPostCount))
             {
                 var url = (await _urlRetriever.Retrieve(post)).RelativePath;
+                var tags = await ResolveTags(post.BlogPostTags, languageName);
                 recent.Add(new HomeRecentPost(
                     Title: post.BaseContentTitle,
                     Summary: post.BaseContentShortDescription,
                     Url: url,
                     Filename: BlogPostViewModel.FilenameFromUrl(url),
                     PublishedOn: post.BlogPostDate,
-                    ReadingMinutes: EstimateReadingMinutes(post.BaseContentShortDescription)));
+                    ReadingMinutes: EstimateReadingMinutes(post.BaseContentShortDescription),
+                    Tags: tags));
             }
         }
 
@@ -97,6 +110,16 @@ public class HomePageViewComponent : ViewComponent
             years--;
         }
         return System.Math.Max(0, years);
+    }
+
+    private async System.Threading.Tasks.Task<IReadOnlyList<BlogTagViewModel>> ResolveTags(
+        System.Collections.Generic.IEnumerable<CMS.ContentEngine.TagReference>? tagRefs,
+        string languageName)
+    {
+        if (tagRefs == null || !tagRefs.Any()) return [];
+        var guids = tagRefs.Select(t => t.Identifier).ToList();
+        var tags = await _blogTagService.GetTagsByGuids(guids, languageName);
+        return tags.Select(t => new BlogTagViewModel(t.Name, t.Title, 0)).ToList();
     }
 
     /// <summary>

--- a/src/Goldfinch.Web/Features/Home/HomePageViewModel.cs
+++ b/src/Goldfinch.Web/Features/Home/HomePageViewModel.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using Goldfinch.Web.Features.BlogList;
 
 namespace Goldfinch.Web.Features.Home;
 
@@ -30,7 +31,8 @@ public record HomeFeaturedPost(
     string Url,
     string Filename,
     DateTime PublishedOn,
-    int ReadingMinutes);
+    int ReadingMinutes,
+    IReadOnlyList<BlogTagViewModel> Tags);
 
 public record HomeRecentPost(
     string Title,
@@ -38,4 +40,5 @@ public record HomeRecentPost(
     string Url,
     string Filename,
     DateTime PublishedOn,
-    int ReadingMinutes);
+    int ReadingMinutes,
+    IReadOnlyList<BlogTagViewModel> Tags);

--- a/src/Goldfinch.Web/Views/Shared/PartialViews/BlogPost.cshtml
+++ b/src/Goldfinch.Web/Views/Shared/PartialViews/BlogPost.cshtml
@@ -16,5 +16,14 @@
         </div>
         <h3 class="post-card__title">@Model.Title</h3>
         <p class="post-card__summary">@Model.Summary</p>
+        @if (Model.Tags.Count > 0)
+        {
+            <div class="post-card__tags">
+                @foreach (var tag in Model.Tags)
+                {
+                    <span class="tag-chip tag-chip--small mono"><span class="tag-chip__hash">#</span><span>@tag.Label</span></span>
+                }
+            </div>
+        }
     </div>
 </a>


### PR DESCRIPTION
## Summary

- **`BlogPost.cshtml` partial** (used by the "Keep reading" section at the bottom of post detail): tags were already on `BlogPostViewModel` but never rendered — added the chips block
- **Home page featured card**: tags added to `HomeFeaturedPost` record and rendered beneath the summary
- **Home page recent post cards**: tags added to `HomeRecentPost` record and rendered on each card
- **`HomePageViewComponent`**: injects `IBlogTagService` + `IPreferredLanguageRetriever` to resolve tags using the same pattern as `BlogListController`

## Test plan

- [ ] Tags appear on the featured post card on the home page
- [ ] Tags appear on recent post cards on the home page
- [ ] Tags appear on cards in the "Keep reading" section at the bottom of a post detail page
- [ ] Posts with no tags show no tag row (empty state handled)

🤖 Generated with [Claude Code](https://claude.com/claude-code)