### PR TITLE
Implement Lucene-backed blog search (#202)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -374,6 +374,10 @@ src/Goldfinch.Web/wwwroot/SiteFiles/dist
 src/Goldfinch.Web/assets/contentitems/**/*
 src/Goldfinch.Web/App_Data/playwright
 
+# Lucene search index is runtime data — rebuilt locally / stored in Azure Blob in production
+src/Goldfinch.Web/App_Data/LuceneSearch
+src/Goldfinch.Web/$LuceneLocks
+
 # Continuous Deployment
 /src/Goldfinch.Web/$CDRepository
 DeploymentPackage.zip

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -9,9 +9,12 @@
     <PackageVersion Include="coverlet.collector" Version="10.0.1" />
     <PackageVersion Include="Kentico.Xperience.Admin" Version="31.5.3" />
     <PackageVersion Include="Kentico.Xperience.AzureStorage" Version="31.5.3" />
+    <PackageVersion Include="Kentico.Xperience.Lucene" Version="15.0.3" />
     <PackageVersion Include="Kentico.Xperience.ManagementApi" Version="31.5.3-preview" />
     <PackageVersion Include="Kentico.Xperience.MiniProfiler" Version="3.0.0" />
     <PackageVersion Include="Kentico.Xperience.WebApp" Version="31.5.3" />
+    <PackageVersion Include="Lucene.Net.Highlighter" Version="4.8.0-beta00017" />
+    <PackageVersion Include="AngleSharp" Version="0.17.1" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
     <PackageVersion Include="Microsoft.Playwright" Version="1.60.0" />
     <PackageVersion Include="Schema.NET" Version="13.0.0" />

--- a/src/Goldfinch.Admin/packages.lock.json
+++ b/src/Goldfinch.Admin/packages.lock.json
@@ -32,11 +32,6 @@
           "Microsoft.Extensions.FileProviders.Embedded": "8.0.26"
         }
       },
-      "AngleSharp": {
-        "type": "Transitive",
-        "resolved": "0.17.1",
-        "contentHash": "5MPI4bbixlwxb0W/smOMeIR+QlxMy5/5jD+WnIAw4pBC+7AhLPe5bS3cLgQMJyvd6q0A48sG+uYOt/ep406GLA=="
-      },
       "AngleSharp.Css": {
         "type": "Transitive",
         "resolved": "0.17.0",
@@ -409,6 +404,11 @@
           "AngleSharp.Css": "[0.17.0]"
         }
       },
+      "J2N": {
+        "type": "Transitive",
+        "resolved": "2.1.0",
+        "contentHash": "Vooz1wbnnqWuS+u93tADXK5Owxo8vLJhSrZ9Ac+KpgDF3GJq9TybXXTF1TFcWILgEtRThc8AOBENEzB0TQH1JA=="
+      },
       "Kentico.Aira.Client": {
         "type": "Transitive",
         "resolved": "6.1.0",
@@ -433,6 +433,84 @@
           "ReverseMarkdown": "5.3.0",
           "System.CodeDom": "8.0.0",
           "System.IO.Hashing": "10.0.7"
+        }
+      },
+      "Kentico.Xperience.Lucene.Admin": {
+        "type": "Transitive",
+        "resolved": "15.0.3",
+        "contentHash": "q2AyXL+nDnQMtlgDWhAc3pLbH5VpY2Z2+b71lu/wzA70wrNJka3vJ6/caj/UZKHgqfEtvgj6CsJ37AGz6P/jVw==",
+        "dependencies": {
+          "Kentico.Xperience.Admin": "31.0.0",
+          "Kentico.Xperience.Lucene.Core": "15.0.3"
+        }
+      },
+      "Kentico.Xperience.Lucene.Core": {
+        "type": "Transitive",
+        "resolved": "15.0.3",
+        "contentHash": "VGQ83QOfNwm9tJVDnUgJTFopx6SEzPTlxZ9ouNkziQpxEIjcy/tj//54H/vjTFsUGzXFOJSErOPqLTUGlE3Qww==",
+        "dependencies": {
+          "Kentico.Xperience.Core": "31.0.0",
+          "Lucene.Net": "4.8.0-beta00017",
+          "Lucene.Net.Analysis.Common": "4.8.0-beta00017",
+          "Lucene.Net.Facet": "4.8.0-beta00017"
+        }
+      },
+      "Lucene.Net": {
+        "type": "Transitive",
+        "resolved": "4.8.0-beta00017",
+        "contentHash": "7LLWS9nNwx01AyE/KXMh+qdAlzDkRANE8407AO/wEmLL1InzVKFwfsRdRmwg4ILOMFui4xZ1Y54eqvzo3Tf9Vw==",
+        "dependencies": {
+          "J2N": "[2.1.0, 3.0.0)"
+        }
+      },
+      "Lucene.Net.Analysis.Common": {
+        "type": "Transitive",
+        "resolved": "4.8.0-beta00017",
+        "contentHash": "rPpmww/HgwEwhvfvZgdWITxFsWRoCEpP3+WQBFgbGxTn4eLDr3U/oFoe8KS+8jUNAl2+5atErDrW5JOcFG+gcQ==",
+        "dependencies": {
+          "Lucene.Net": "4.8.0-beta00017"
+        }
+      },
+      "Lucene.Net.Facet": {
+        "type": "Transitive",
+        "resolved": "4.8.0-beta00017",
+        "contentHash": "LVxGwgRAVq9XdwvNfgCB8OH+ou40I0E1NYN53muPjQK5oUY+HpkgkFUhTFSHdajWWj7xFI1f+UFB23iweoVf2w==",
+        "dependencies": {
+          "Lucene.Net.Join": "4.8.0-beta00017",
+          "Lucene.Net.Queries": "4.8.0-beta00017"
+        }
+      },
+      "Lucene.Net.Grouping": {
+        "type": "Transitive",
+        "resolved": "4.8.0-beta00017",
+        "contentHash": "nzMGvz0b1cedS8KKOlglJQJpyz8fT0ojgXFkgSkLLhwPNbMPwVoBsR7RlZs1FrF60Oz369O3Pm1a+MIr52KcLQ==",
+        "dependencies": {
+          "Lucene.Net": "4.8.0-beta00017",
+          "Lucene.Net.Queries": "4.8.0-beta00017"
+        }
+      },
+      "Lucene.Net.Join": {
+        "type": "Transitive",
+        "resolved": "4.8.0-beta00017",
+        "contentHash": "WcJl4O6t3iXiXwXHnhmbVCO7C6ilPxabBCsdW/auQN0lrDpbVIcHorCxwd199fGBEQnk7wbl5pPnk8nw/VK4eQ==",
+        "dependencies": {
+          "Lucene.Net.Grouping": "4.8.0-beta00017"
+        }
+      },
+      "Lucene.Net.Memory": {
+        "type": "Transitive",
+        "resolved": "4.8.0-beta00017",
+        "contentHash": "T4uG0k1iGzXXRRlmsFTtRPhnc2Ef1wlh68TxO2dN8qLW7AXX9qsIjOuN64+IXAPUkysvvks8psoU6epi642MUw==",
+        "dependencies": {
+          "Lucene.Net": "4.8.0-beta00017"
+        }
+      },
+      "Lucene.Net.Queries": {
+        "type": "Transitive",
+        "resolved": "4.8.0-beta00017",
+        "contentHash": "RVpZCfa/7pgvytFw64zLqinvZPQt4TojvcFghdAA5vhnpSs5GTbtciPIxFH3wwH3f2dYJywiqYKo1h3JBCXRBA==",
+        "dependencies": {
+          "Lucene.Net": "4.8.0-beta00017"
         }
       },
       "Magick.NET-Q8-AnyCPU": {
@@ -802,9 +880,38 @@
       "goldfinch.core": {
         "type": "Project",
         "dependencies": {
+          "AngleSharp": "[0.17.1, )",
           "Kentico.Xperience.Admin": "[31.5.3, )",
+          "Kentico.Xperience.Lucene": "[15.0.3, )",
           "Kentico.Xperience.WebApp": "[31.5.3, )",
+          "Lucene.Net.Highlighter": "[4.8.0-beta00017, )",
           "Sidio.Sitemap.AspNetCore": "[3.1.1, )"
+        }
+      },
+      "AngleSharp": {
+        "type": "CentralTransitive",
+        "requested": "[0.17.1, )",
+        "resolved": "0.17.1",
+        "contentHash": "5MPI4bbixlwxb0W/smOMeIR+QlxMy5/5jD+WnIAw4pBC+7AhLPe5bS3cLgQMJyvd6q0A48sG+uYOt/ep406GLA=="
+      },
+      "Kentico.Xperience.Lucene": {
+        "type": "CentralTransitive",
+        "requested": "[15.0.3, )",
+        "resolved": "15.0.3",
+        "contentHash": "xihyGfQ59suos8OBXosEev/oIPHlcPd5CXuDE6a/mAAUyN9Vi3Mnw2qGYJ1czF6WaflvUpesnfpYSqDj079PsQ==",
+        "dependencies": {
+          "Kentico.Xperience.Lucene.Admin": "15.0.3",
+          "Kentico.Xperience.Lucene.Core": "15.0.3"
+        }
+      },
+      "Lucene.Net.Highlighter": {
+        "type": "CentralTransitive",
+        "requested": "[4.8.0-beta00017, )",
+        "resolved": "4.8.0-beta00017",
+        "contentHash": "Mqm+KlBHhNO+jhmSkC1xD88qSAWEcFu7vGt7utpoZZn9RGD5TVXavJHNLXYjvj9O5NQtDAjeKZ0T9toVCY0REw==",
+        "dependencies": {
+          "Lucene.Net.Memory": "4.8.0-beta00017",
+          "Lucene.Net.Queries": "4.8.0-beta00017"
         }
       },
       "Sidio.Sitemap.AspNetCore": {

--- a/src/Goldfinch.Core/Goldfinch.Core.csproj
+++ b/src/Goldfinch.Core/Goldfinch.Core.csproj
@@ -2,6 +2,9 @@
 	<ItemGroup>
 		<PackageReference Include="Kentico.Xperience.Admin" />
 		<PackageReference Include="Kentico.Xperience.WebApp" />
+		<PackageReference Include="Kentico.Xperience.Lucene" />
+		<PackageReference Include="Lucene.Net.Highlighter" />
+		<PackageReference Include="AngleSharp" />
 		<PackageReference Include="Sidio.Sitemap.AspNetCore" />
 	</ItemGroup>
 </Project>

--- a/src/Goldfinch.Core/Search/BlogPostSearchIndexingStrategy.cs
+++ b/src/Goldfinch.Core/Search/BlogPostSearchIndexingStrategy.cs
@@ -1,0 +1,132 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using CMS.ContentEngine;
+using CMS.Websites;
+using Goldfinch.Core.BlogPosts;
+using Goldfinch.Core.ContentTypes;
+using Goldfinch.Core.Extensions;
+using Kentico.Xperience.Lucene.Core;
+using Kentico.Xperience.Lucene.Core.Indexing;
+using Lucene.Net.Documents;
+
+namespace Goldfinch.Core.Search;
+
+/// <summary>
+/// Lucene indexing strategy for <see cref="BlogPost"/> web pages. Indexes the title, summary,
+/// resolved tag slugs, publish date, an estimated reading time, and the full rendered post body
+/// (crawled and sanitized to plain text, since the body lives in Page Builder editable areas).
+/// </summary>
+public class BlogPostSearchIndexingStrategy : DefaultLuceneIndexingStrategy
+{
+    private readonly IContentQueryExecutor _queryExecutor;
+    private readonly IWebPageUrlRetriever _urlRetriever;
+    private readonly IBlogTagService _blogTagService;
+    private readonly WebCrawlerService _webCrawler;
+    private readonly WebScraperHtmlSanitizer _htmlSanitizer;
+
+    public BlogPostSearchIndexingStrategy(
+        IContentQueryExecutor queryExecutor,
+        IWebPageUrlRetriever urlRetriever,
+        IBlogTagService blogTagService,
+        WebCrawlerService webCrawler,
+        WebScraperHtmlSanitizer htmlSanitizer)
+    {
+        _queryExecutor = queryExecutor;
+        _urlRetriever = urlRetriever;
+        _blogTagService = blogTagService;
+        _webCrawler = webCrawler;
+        _htmlSanitizer = htmlSanitizer;
+    }
+
+    public override async Task<Document?> MapToLuceneDocumentOrNull(IIndexEventItemModel item)
+    {
+        // Only index BlogPost web pages; ignore everything else (and secured items).
+        if (item is not IndexEventWebPageItemModel webPageItem ||
+            !string.Equals(item.ContentTypeName, BlogPost.CONTENT_TYPE_NAME, StringComparison.OrdinalIgnoreCase))
+        {
+            return null;
+        }
+
+        var page = await GetPage(webPageItem.ItemGuid, webPageItem.WebsiteChannelName, webPageItem.LanguageName);
+        if (page is null)
+        {
+            return null;
+        }
+
+        var title = page.BaseContentTitle ?? string.Empty;
+        var summary = page.BaseContentShortDescription ?? string.Empty;
+
+        // Resolve tag references to their code names (the ?tag= slugs).
+        var tagSlugs = Array.Empty<string>();
+        if (page.BlogPostTags?.Any() == true)
+        {
+            var tags = await _blogTagService.GetTagsByGuids(
+                page.BlogPostTags.Select(t => t.Identifier), webPageItem.LanguageName);
+            tagSlugs = tags.Select(t => t.Name).ToArray();
+        }
+
+        // Crawl the rendered page and reduce it to the post body text.
+        var rawHtml = await _webCrawler.CrawlWebPage(page);
+        var body = _htmlSanitizer.SanitizeHtmlDocument(rawHtml);
+
+        var readingMinutes = EstimateReadingMinutes(body);
+
+        var url = string.Empty;
+        try
+        {
+            url = (await _urlRetriever.Retrieve(page)).RelativePath.ToAbsolutePath();
+        }
+        catch (Exception)
+        {
+            // Retrieve can throw if the page was deleted before the queued task ran; index an empty URL.
+        }
+
+        var document = new Document
+        {
+            new TextField(BlogSearchConstants.FIELD_TITLE, title, Field.Store.YES),
+            new TextField(BlogSearchConstants.FIELD_SUMMARY, summary, Field.Store.YES),
+            // Body is indexed for matching but not stored (results never echo the full body).
+            new TextField(BlogSearchConstants.FIELD_CONTENT, body, Field.Store.NO),
+            new StringField(BlogSearchConstants.FIELD_DATE, page.BlogPostDate.ToString("yyyy-MM-dd"), Field.Store.YES),
+            new StoredField(BlogSearchConstants.FIELD_READING_MINUTES, readingMinutes),
+            new StringField(BaseDocumentProperties.URL, url, Field.Store.YES),
+        };
+
+        // Tag slugs: indexed as exact terms (for ?tag= scoping) and stored (for result rendering).
+        foreach (var slug in tagSlugs)
+        {
+            document.Add(new StringField(BlogSearchConstants.FIELD_TAGS, slug, Field.Store.YES));
+        }
+
+        return document;
+    }
+
+    private async Task<BlogPost?> GetPage(Guid itemGuid, string channelName, string languageName)
+    {
+        var builder = new ContentItemQueryBuilder()
+            .ForContentType(BlogPost.CONTENT_TYPE_NAME, config => config
+                .WithLinkedItems(1)
+                .ForWebsite(channelName)
+                .Where(where => where.WhereEquals(nameof(WebPageFields.WebPageItemGUID), itemGuid))
+                .TopN(1))
+            .InLanguage(languageName);
+
+        var result = await _queryExecutor.GetMappedWebPageResult<BlogPost>(builder);
+
+        return result.FirstOrDefault();
+    }
+
+    private static int EstimateReadingMinutes(string body)
+    {
+        if (string.IsNullOrWhiteSpace(body))
+        {
+            return 1;
+        }
+
+        var wordCount = body.Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries).Length;
+
+        return Math.Max(1, (int)Math.Ceiling((double)wordCount / BlogSearchConstants.WORDS_PER_MINUTE));
+    }
+}

--- a/src/Goldfinch.Core/Search/BlogSearchConstants.cs
+++ b/src/Goldfinch.Core/Search/BlogSearchConstants.cs
@@ -1,0 +1,24 @@
+namespace Goldfinch.Core.Search;
+
+/// <summary>
+/// Shared constants for the blog Lucene index — the index/strategy name (must match the index
+/// created in the admin Search application) and the Lucene document field names used by both the
+/// indexing strategy and the query service.
+/// </summary>
+public static class BlogSearchConstants
+{
+    /// <summary>
+    /// Code name of the index + registered strategy. Must match the index created in the admin UI.
+    /// </summary>
+    public const string INDEX_NAME = "BlogPosts";
+
+    public const string FIELD_TITLE = "Title";
+    public const string FIELD_SUMMARY = "Summary";
+    public const string FIELD_CONTENT = "Content";
+    public const string FIELD_TAGS = "Tags";
+    public const string FIELD_DATE = "Date";
+    public const string FIELD_READING_MINUTES = "ReadingMinutes";
+
+    /// <summary>Average adult reading speed (words per minute) used to estimate reading time.</summary>
+    public const int WORDS_PER_MINUTE = 200;
+}

--- a/src/Goldfinch.Core/Search/BlogSearchResult.cs
+++ b/src/Goldfinch.Core/Search/BlogSearchResult.cs
@@ -15,9 +15,9 @@ public class BlogSearchResult
     public string[] Tags { get; init; } = Array.Empty<string>();
     public int ReadingMinutes { get; init; }
 
-    /// <summary>Title with matched terms wrapped in <c>&lt;mark&gt;</c> (HTML-escaped); null if no match.</summary>
+    /// <summary>Raw title with matched terms wrapped in literal <c>&lt;mark&gt;</c> tags; null if no match. The client re-escapes everything except <c>&lt;mark&gt;</c>.</summary>
     public string? HighlightedTitle { get; init; }
 
-    /// <summary>Summary with matched terms wrapped in <c>&lt;mark&gt;</c> (HTML-escaped); null if no match.</summary>
+    /// <summary>Raw summary with matched terms wrapped in literal <c>&lt;mark&gt;</c> tags; null if no match. The client re-escapes everything except <c>&lt;mark&gt;</c>.</summary>
     public string? HighlightedSummary { get; init; }
 }

--- a/src/Goldfinch.Core/Search/BlogSearchResult.cs
+++ b/src/Goldfinch.Core/Search/BlogSearchResult.cs
@@ -1,0 +1,23 @@
+using System;
+
+namespace Goldfinch.Core.Search;
+
+/// <summary>
+/// A single blog post hit returned by <see cref="ILuceneBlogSearchService"/>.
+/// </summary>
+public class BlogSearchResult
+{
+    public required string Slug { get; init; }
+    public required string Title { get; init; }
+    public required string Summary { get; init; }
+    public required string Url { get; init; }
+    public required string Date { get; init; }
+    public string[] Tags { get; init; } = Array.Empty<string>();
+    public int ReadingMinutes { get; init; }
+
+    /// <summary>Title with matched terms wrapped in <c>&lt;mark&gt;</c> (HTML-escaped); null if no match.</summary>
+    public string? HighlightedTitle { get; init; }
+
+    /// <summary>Summary with matched terms wrapped in <c>&lt;mark&gt;</c> (HTML-escaped); null if no match.</summary>
+    public string? HighlightedSummary { get; init; }
+}

--- a/src/Goldfinch.Core/Search/ILuceneBlogSearchService.cs
+++ b/src/Goldfinch.Core/Search/ILuceneBlogSearchService.cs
@@ -1,0 +1,18 @@
+using System.Collections.Generic;
+
+namespace Goldfinch.Core.Search;
+
+/// <summary>
+/// Queries the <c>BlogPosts</c> Lucene index for the live search endpoint, ranking matches
+/// title &gt; summary &gt; body and generating <c>&lt;mark&gt;</c> highlights.
+/// </summary>
+public interface ILuceneBlogSearchService
+{
+    /// <summary>
+    /// Searches blog posts, optionally scoped to a single tag slug.
+    /// </summary>
+    /// <param name="query">The trimmed, non-empty search query.</param>
+    /// <param name="tag">Optional tag slug to scope results to.</param>
+    /// <param name="limit">Maximum number of post hits to return.</param>
+    IReadOnlyList<BlogSearchResult> SearchPosts(string query, string? tag, int limit);
+}

--- a/src/Goldfinch.Core/Search/LuceneBlogSearchService.cs
+++ b/src/Goldfinch.Core/Search/LuceneBlogSearchService.cs
@@ -1,0 +1,132 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using Kentico.Xperience.Lucene.Core;
+using Kentico.Xperience.Lucene.Core.Indexing;
+using Kentico.Xperience.Lucene.Core.Search;
+using Lucene.Net.Analysis;
+using Lucene.Net.Index;
+using Lucene.Net.Search;
+using Lucene.Net.Search.Highlight;
+using Lucene.Net.Util;
+
+namespace Goldfinch.Core.Search;
+
+public class LuceneBlogSearchService : ILuceneBlogSearchService
+{
+    // Relevance boosts encode the contract's ranking: title > summary > body.
+    private const float TITLE_BOOST = 5f;
+    private const float SUMMARY_BOOST = 2f;
+    private const float CONTENT_BOOST = 1f;
+
+    private readonly ILuceneSearchService _searchService;
+    private readonly ILuceneIndexManager _indexManager;
+
+    public LuceneBlogSearchService(
+        ILuceneSearchService searchService,
+        ILuceneIndexManager indexManager)
+    {
+        _searchService = searchService;
+        _indexManager = indexManager;
+    }
+
+    public IReadOnlyList<BlogSearchResult> SearchPosts(string query, string? tag, int limit)
+    {
+        var index = _indexManager.GetRequiredIndex(BlogSearchConstants.INDEX_NAME);
+        var analyzer = index.LuceneAnalyzer;
+
+        // Boosted text query across the indexed fields (title > summary > body).
+        var queryBuilder = new QueryBuilder(analyzer);
+        var textQuery = new BooleanQuery();
+        AddBoostedClause(textQuery, queryBuilder, BlogSearchConstants.FIELD_TITLE, query, TITLE_BOOST);
+        AddBoostedClause(textQuery, queryBuilder, BlogSearchConstants.FIELD_SUMMARY, query, SUMMARY_BOOST);
+        AddBoostedClause(textQuery, queryBuilder, BlogSearchConstants.FIELD_CONTENT, query, CONTENT_BOOST);
+
+        // No analyzable tokens (e.g. query was only stop words/punctuation) — nothing to match.
+        if (!textQuery.GetClauses().Any())
+        {
+            return [];
+        }
+
+        // Scope to a tag when provided (exact term on the stored tag slug).
+        Query finalQuery = textQuery;
+        if (!string.IsNullOrWhiteSpace(tag))
+        {
+            finalQuery = new BooleanQuery
+            {
+                { textQuery, Occur.MUST },
+                { new TermQuery(new Term(BlogSearchConstants.FIELD_TAGS, tag)), Occur.MUST },
+            };
+        }
+
+        return _searchService.UseSearcher(index, searcher =>
+        {
+            var topDocs = searcher.Search(finalQuery, limit);
+
+            // Highlight against the text query only (not the tag scope) and over the whole field.
+            var highlighter = new Highlighter(
+                new SimpleHTMLFormatter("<mark>", "</mark>"),
+                new QueryScorer(textQuery))
+            {
+                TextFragmenter = new NullFragmenter(),
+            };
+
+            var results = new List<BlogSearchResult>(topDocs.ScoreDocs.Length);
+            foreach (var scoreDoc in topDocs.ScoreDocs)
+            {
+                var doc = searcher.Doc(scoreDoc.Doc);
+
+                var title = doc.Get(BlogSearchConstants.FIELD_TITLE) ?? string.Empty;
+                var summary = doc.Get(BlogSearchConstants.FIELD_SUMMARY) ?? string.Empty;
+                var url = doc.Get(BaseDocumentProperties.URL) ?? string.Empty;
+
+                results.Add(new BlogSearchResult
+                {
+                    Slug = SlugFromUrl(url),
+                    Title = title,
+                    Summary = summary,
+                    Url = url,
+                    Date = doc.Get(BlogSearchConstants.FIELD_DATE) ?? string.Empty,
+                    Tags = doc.GetValues(BlogSearchConstants.FIELD_TAGS) ?? [],
+                    ReadingMinutes = doc.GetField(BlogSearchConstants.FIELD_READING_MINUTES)?.GetInt32Value() ?? 1,
+                    HighlightedTitle = Highlight(highlighter, analyzer, BlogSearchConstants.FIELD_TITLE, title),
+                    HighlightedSummary = Highlight(highlighter, analyzer, BlogSearchConstants.FIELD_SUMMARY, summary),
+                });
+            }
+
+            return (IReadOnlyList<BlogSearchResult>)results;
+        });
+    }
+
+    private static void AddBoostedClause(BooleanQuery target, QueryBuilder queryBuilder, string field, string query, float boost)
+    {
+        var clause = queryBuilder.CreateBooleanQuery(field, query, Occur.SHOULD);
+        if (clause is null)
+        {
+            return;
+        }
+
+        clause.Boost = boost;
+        target.Add(clause, Occur.SHOULD);
+    }
+
+    /// <summary>
+    /// Produces a highlighted fragment with matched terms wrapped in <c>&lt;mark&gt;</c>. The field
+    /// text is HTML-encoded first so <c>&lt;mark&gt;</c> is the only markup in the result (the client
+    /// renders this via innerHTML and trusts nothing else). Returns null when no term matched.
+    /// </summary>
+    private static string? Highlight(Highlighter highlighter, Analyzer analyzer, string field, string text)
+    {
+        if (string.IsNullOrEmpty(text))
+        {
+            return null;
+        }
+
+        var encoded = WebUtility.HtmlEncode(text);
+
+        return highlighter.GetBestFragment(analyzer, field, encoded);
+    }
+
+    private static string SlugFromUrl(string url) =>
+        url.TrimEnd('/').Split('/').LastOrDefault() ?? string.Empty;
+}

--- a/src/Goldfinch.Core/Search/LuceneBlogSearchService.cs
+++ b/src/Goldfinch.Core/Search/LuceneBlogSearchService.cs
@@ -1,6 +1,5 @@
 using System.Collections.Generic;
 using System.Linq;
-using System.Net;
 using Kentico.Xperience.Lucene.Core;
 using Kentico.Xperience.Lucene.Core.Indexing;
 using Kentico.Xperience.Lucene.Core.Search;
@@ -14,10 +13,17 @@ namespace Goldfinch.Core.Search;
 
 public class LuceneBlogSearchService : ILuceneBlogSearchService
 {
-    // Relevance boosts encode the contract's ranking: title > summary > body.
-    private const float TITLE_BOOST = 5f;
-    private const float SUMMARY_BOOST = 2f;
-    private const float CONTENT_BOOST = 1f;
+    // Relevance boosts encode the contract's ranking: title > summary > body, and within each
+    // field an exact/near-exact phrase match outranks scattered individual term matches.
+    private const float TITLE_PHRASE_BOOST = 10f;
+    private const float TITLE_TERM_BOOST = 5f;
+    private const float SUMMARY_PHRASE_BOOST = 4f;
+    private const float SUMMARY_TERM_BOOST = 2f;
+    private const float CONTENT_PHRASE_BOOST = 2f;
+    private const float CONTENT_TERM_BOOST = 1f;
+
+    // Allows a couple of intervening words so near-phrase matches still count as a phrase hit.
+    private const int PHRASE_SLOP = 2;
 
     private readonly ILuceneSearchService _searchService;
     private readonly ILuceneIndexManager _indexManager;
@@ -35,12 +41,14 @@ public class LuceneBlogSearchService : ILuceneBlogSearchService
         var index = _indexManager.GetRequiredIndex(BlogSearchConstants.INDEX_NAME);
         var analyzer = index.LuceneAnalyzer;
 
-        // Boosted text query across the indexed fields (title > summary > body).
+        // Boosted text query across the indexed fields. Each field contributes a high-boost phrase
+        // clause (exact/near-exact match) and a lower-boost term clause (any word), so a full-phrase
+        // hit ranks above scattered term hits, and title beats summary beats body.
         var queryBuilder = new QueryBuilder(analyzer);
         var textQuery = new BooleanQuery();
-        AddBoostedClause(textQuery, queryBuilder, BlogSearchConstants.FIELD_TITLE, query, TITLE_BOOST);
-        AddBoostedClause(textQuery, queryBuilder, BlogSearchConstants.FIELD_SUMMARY, query, SUMMARY_BOOST);
-        AddBoostedClause(textQuery, queryBuilder, BlogSearchConstants.FIELD_CONTENT, query, CONTENT_BOOST);
+        AddFieldClauses(textQuery, queryBuilder, BlogSearchConstants.FIELD_TITLE, query, TITLE_PHRASE_BOOST, TITLE_TERM_BOOST);
+        AddFieldClauses(textQuery, queryBuilder, BlogSearchConstants.FIELD_SUMMARY, query, SUMMARY_PHRASE_BOOST, SUMMARY_TERM_BOOST);
+        AddFieldClauses(textQuery, queryBuilder, BlogSearchConstants.FIELD_CONTENT, query, CONTENT_PHRASE_BOOST, CONTENT_TERM_BOOST);
 
         // No analyzable tokens (e.g. query was only stop words/punctuation) — nothing to match.
         if (!textQuery.GetClauses().Any())
@@ -98,22 +106,30 @@ public class LuceneBlogSearchService : ILuceneBlogSearchService
         });
     }
 
-    private static void AddBoostedClause(BooleanQuery target, QueryBuilder queryBuilder, string field, string query, float boost)
+    private static void AddFieldClauses(BooleanQuery target, QueryBuilder queryBuilder, string field, string query, float phraseBoost, float termBoost)
     {
-        var clause = queryBuilder.CreateBooleanQuery(field, query, Occur.SHOULD);
-        if (clause is null)
+        // Phrase clause: rewards an exact/near-exact match of the whole query in this field.
+        var phrase = queryBuilder.CreatePhraseQuery(field, query, PHRASE_SLOP);
+        if (phrase is not null)
         {
-            return;
+            phrase.Boost = phraseBoost;
+            target.Add(phrase, Occur.SHOULD);
         }
 
-        clause.Boost = boost;
-        target.Add(clause, Occur.SHOULD);
+        // Term clause: matches any of the query words, for recall.
+        var terms = queryBuilder.CreateBooleanQuery(field, query, Occur.SHOULD);
+        if (terms is not null)
+        {
+            terms.Boost = termBoost;
+            target.Add(terms, Occur.SHOULD);
+        }
     }
 
     /// <summary>
-    /// Produces a highlighted fragment with matched terms wrapped in <c>&lt;mark&gt;</c>. The field
-    /// text is HTML-encoded first so <c>&lt;mark&gt;</c> is the only markup in the result (the client
-    /// renders this via innerHTML and trusts nothing else). Returns null when no term matched.
+    /// Produces a highlighted fragment with matched terms wrapped in literal <c>&lt;mark&gt;</c> tags
+    /// over the raw field text. The client re-escapes everything except <c>&lt;mark&gt;</c> before
+    /// rendering, so encoding here would double-encode (e.g. an apostrophe would render as
+    /// <c>&amp;#39;</c>). Returns null when no term matched.
     /// </summary>
     private static string? Highlight(Highlighter highlighter, Analyzer analyzer, string field, string text)
     {
@@ -122,9 +138,7 @@ public class LuceneBlogSearchService : ILuceneBlogSearchService
             return null;
         }
 
-        var encoded = WebUtility.HtmlEncode(text);
-
-        return highlighter.GetBestFragment(analyzer, field, encoded);
+        return highlighter.GetBestFragment(analyzer, field, text);
     }
 
     private static string SlugFromUrl(string url) =>

--- a/src/Goldfinch.Core/Search/WebCrawlerService.cs
+++ b/src/Goldfinch.Core/Search/WebCrawlerService.cs
@@ -1,0 +1,84 @@
+using System;
+using System.Net.Http;
+using System.Threading.Tasks;
+using CMS.Core;
+using CMS.Websites;
+
+namespace Goldfinch.Core.Search;
+
+/// <summary>
+/// Fetches the rendered HTML of a web page so its Page Builder body can be extracted for indexing.
+/// The base URL is read from the <c>WebCrawlerBaseUrl</c> app setting and must match the website
+/// channel being indexed (localhost in development, the public URL in production).
+/// </summary>
+public class WebCrawlerService
+{
+    private readonly HttpClient _httpClient;
+    private readonly IEventLogService _log;
+    private readonly IWebPageUrlRetriever _urlRetriever;
+
+    public WebCrawlerService(
+        HttpClient httpClient,
+        IEventLogService log,
+        IWebPageUrlRetriever urlRetriever,
+        IAppSettingsService appSettingsService)
+    {
+        var baseUrl = appSettingsService["WebCrawlerBaseUrl"];
+
+        _httpClient = httpClient;
+        _httpClient.DefaultRequestHeaders.Add("User-Agent", "GoldfinchSearchCrawler");
+
+        if (!string.IsNullOrWhiteSpace(baseUrl))
+        {
+            _httpClient.BaseAddress = new Uri(baseUrl);
+        }
+
+        _log = log;
+        _urlRetriever = urlRetriever;
+    }
+
+    /// <summary>
+    /// Crawls the rendered HTML for a web page item. Returns an empty string on any failure
+    /// (logged to the event log) so indexing of other items is unaffected.
+    /// </summary>
+    public async Task<string> CrawlWebPage(IWebPageFieldsSource page)
+    {
+        try
+        {
+            var url = await _urlRetriever.Retrieve(page);
+            var path = url.RelativePath.TrimStart('~').TrimStart('/');
+
+            return await CrawlPage(path);
+        }
+        catch (Exception ex)
+        {
+            _log.LogException(
+                nameof(WebCrawlerService),
+                nameof(CrawlWebPage),
+                ex,
+                $"Tree Path: {page.SystemFields.WebPageItemTreePath}");
+        }
+
+        return string.Empty;
+    }
+
+    public async Task<string> CrawlPage(string url)
+    {
+        try
+        {
+            var response = await _httpClient.GetAsync(url);
+
+            return await response.Content.ReadAsStringAsync();
+        }
+        catch (Exception ex)
+        {
+            _log.LogException(
+                nameof(WebCrawlerService),
+                nameof(CrawlPage),
+                ex,
+                $"Url: {url}");
+        }
+
+        return string.Empty;
+    }
+}

--- a/src/Goldfinch.Core/Search/WebScraperHtmlSanitizer.cs
+++ b/src/Goldfinch.Core/Search/WebScraperHtmlSanitizer.cs
@@ -1,0 +1,46 @@
+using System.Linq;
+using System.Text.RegularExpressions;
+using AngleSharp.Html.Parser;
+
+namespace Goldfinch.Core.Search;
+
+/// <summary>
+/// Converts a rendered HTML page into clean, indexable plain text. Prefers the post body
+/// container (<c>.post-body</c>) and falls back to <c>&lt;main&gt;</c> then <c>&lt;body&gt;</c>,
+/// stripping scripts, styles, and anything marked <c>data-ktc-search-exclude</c>.
+/// </summary>
+public class WebScraperHtmlSanitizer
+{
+    private static readonly Regex WhitespaceRegex = new(@"\s+", RegexOptions.Compiled);
+
+    public virtual string SanitizeHtmlDocument(string htmlContent)
+    {
+        if (string.IsNullOrWhiteSpace(htmlContent))
+        {
+            return string.Empty;
+        }
+
+        var parser = new HtmlParser();
+        var doc = parser.ParseDocument(htmlContent);
+
+        var body = doc.Body;
+        if (body is null)
+        {
+            return string.Empty;
+        }
+
+        // Index the post body when present, otherwise the main content, otherwise the whole body.
+        var root = body.QuerySelector(".post-body")
+            ?? body.QuerySelector("main")
+            ?? body;
+
+        foreach (var element in root.QuerySelectorAll("script, style, [data-ktc-search-exclude]").ToList())
+        {
+            element.Remove();
+        }
+
+        var textContent = root.TextContent ?? string.Empty;
+
+        return WhitespaceRegex.Replace(textContent, " ").Trim();
+    }
+}

--- a/src/Goldfinch.Core/ServiceConfiguration.cs
+++ b/src/Goldfinch.Core/ServiceConfiguration.cs
@@ -1,6 +1,7 @@
 using Goldfinch.Core.BlogPosts;
 using Goldfinch.Core.ErrorPages;
 using Goldfinch.Core.PublicSpeaking;
+using Goldfinch.Core.Search;
 using Goldfinch.Core.SEO;
 using Goldfinch.Core.Sitemap;
 using Microsoft.Extensions.DependencyInjection;
@@ -11,12 +12,19 @@ public static class ServiceConfiguration
 {
     public static IServiceCollection AddCoreServices(this IServiceCollection services)
     {
-        return services
+        services
             .AddSingleton<IBreadcrumbService, BreadcrumbService>()
             .AddSingleton<IBlogPostService, BlogPostService>()
             .AddSingleton<IBlogTagService, BlogTagService>()
             .AddScoped<IErrorPageService, ErrorPageService>()
             .AddSingleton<IPublicSpeakingService, PublicSpeakingService>()
-            .AddSingleton<ISitemapService, SitemapService>();
+            .AddSingleton<ISitemapService, SitemapService>()
+            .AddSingleton<WebScraperHtmlSanitizer>()
+            .AddSingleton<ILuceneBlogSearchService, LuceneBlogSearchService>();
+
+        // Typed HttpClient used by the search indexing strategy to crawl rendered post bodies.
+        services.AddHttpClient<WebCrawlerService>();
+
+        return services;
     }
 }

--- a/src/Goldfinch.Core/packages.lock.json
+++ b/src/Goldfinch.Core/packages.lock.json
@@ -2,6 +2,12 @@
   "version": 2,
   "dependencies": {
     "net10.0": {
+      "AngleSharp": {
+        "type": "Direct",
+        "requested": "[0.17.1, )",
+        "resolved": "0.17.1",
+        "contentHash": "5MPI4bbixlwxb0W/smOMeIR+QlxMy5/5jD+WnIAw4pBC+7AhLPe5bS3cLgQMJyvd6q0A48sG+uYOt/ep406GLA=="
+      },
       "Kentico.Xperience.Admin": {
         "type": "Direct",
         "requested": "[31.5.3, )",
@@ -16,6 +22,16 @@
           "Microsoft.SemanticKernel.Agents.Core": "1.75.0",
           "Microsoft.SemanticKernel.Connectors.AzureOpenAI": "1.75.0",
           "NJsonSchema": "11.6.1"
+        }
+      },
+      "Kentico.Xperience.Lucene": {
+        "type": "Direct",
+        "requested": "[15.0.3, )",
+        "resolved": "15.0.3",
+        "contentHash": "xihyGfQ59suos8OBXosEev/oIPHlcPd5CXuDE6a/mAAUyN9Vi3Mnw2qGYJ1czF6WaflvUpesnfpYSqDj079PsQ==",
+        "dependencies": {
+          "Kentico.Xperience.Lucene.Admin": "15.0.3",
+          "Kentico.Xperience.Lucene.Core": "15.0.3"
         }
       },
       "Kentico.Xperience.WebApp": {
@@ -34,6 +50,16 @@
           "Microsoft.Extensions.FileProviders.Embedded": "8.0.26"
         }
       },
+      "Lucene.Net.Highlighter": {
+        "type": "Direct",
+        "requested": "[4.8.0-beta00017, )",
+        "resolved": "4.8.0-beta00017",
+        "contentHash": "Mqm+KlBHhNO+jhmSkC1xD88qSAWEcFu7vGt7utpoZZn9RGD5TVXavJHNLXYjvj9O5NQtDAjeKZ0T9toVCY0REw==",
+        "dependencies": {
+          "Lucene.Net.Memory": "4.8.0-beta00017",
+          "Lucene.Net.Queries": "4.8.0-beta00017"
+        }
+      },
       "Sidio.Sitemap.AspNetCore": {
         "type": "Direct",
         "requested": "[3.1.1, )",
@@ -43,11 +69,6 @@
           "Microsoft.Extensions.Caching.Hybrid": "10.5.0",
           "Sidio.Sitemap.Core": "2.8.1"
         }
-      },
-      "AngleSharp": {
-        "type": "Transitive",
-        "resolved": "0.17.1",
-        "contentHash": "5MPI4bbixlwxb0W/smOMeIR+QlxMy5/5jD+WnIAw4pBC+7AhLPe5bS3cLgQMJyvd6q0A48sG+uYOt/ep406GLA=="
       },
       "AngleSharp.Css": {
         "type": "Transitive",
@@ -439,6 +460,11 @@
           "AngleSharp.Css": "[0.17.0]"
         }
       },
+      "J2N": {
+        "type": "Transitive",
+        "resolved": "2.1.0",
+        "contentHash": "Vooz1wbnnqWuS+u93tADXK5Owxo8vLJhSrZ9Ac+KpgDF3GJq9TybXXTF1TFcWILgEtRThc8AOBENEzB0TQH1JA=="
+      },
       "Kentico.Aira.Client": {
         "type": "Transitive",
         "resolved": "6.1.0",
@@ -476,6 +502,85 @@
           "ReverseMarkdown": "5.3.0",
           "System.CodeDom": "8.0.0",
           "System.IO.Hashing": "10.0.7"
+        }
+      },
+      "Kentico.Xperience.Lucene.Admin": {
+        "type": "Transitive",
+        "resolved": "15.0.3",
+        "contentHash": "q2AyXL+nDnQMtlgDWhAc3pLbH5VpY2Z2+b71lu/wzA70wrNJka3vJ6/caj/UZKHgqfEtvgj6CsJ37AGz6P/jVw==",
+        "dependencies": {
+          "Kentico.Xperience.Admin": "31.0.0",
+          "Kentico.Xperience.Lucene.Core": "15.0.3"
+        }
+      },
+      "Kentico.Xperience.Lucene.Core": {
+        "type": "Transitive",
+        "resolved": "15.0.3",
+        "contentHash": "VGQ83QOfNwm9tJVDnUgJTFopx6SEzPTlxZ9ouNkziQpxEIjcy/tj//54H/vjTFsUGzXFOJSErOPqLTUGlE3Qww==",
+        "dependencies": {
+          "Kentico.Xperience.Core": "31.0.0",
+          "Lucene.Net": "4.8.0-beta00017",
+          "Lucene.Net.Analysis.Common": "4.8.0-beta00017",
+          "Lucene.Net.Facet": "4.8.0-beta00017"
+        }
+      },
+      "Lucene.Net": {
+        "type": "Transitive",
+        "resolved": "4.8.0-beta00017",
+        "contentHash": "7LLWS9nNwx01AyE/KXMh+qdAlzDkRANE8407AO/wEmLL1InzVKFwfsRdRmwg4ILOMFui4xZ1Y54eqvzo3Tf9Vw==",
+        "dependencies": {
+          "J2N": "[2.1.0, 3.0.0)",
+          "Microsoft.Extensions.Configuration.Abstractions": "8.0.0"
+        }
+      },
+      "Lucene.Net.Analysis.Common": {
+        "type": "Transitive",
+        "resolved": "4.8.0-beta00017",
+        "contentHash": "rPpmww/HgwEwhvfvZgdWITxFsWRoCEpP3+WQBFgbGxTn4eLDr3U/oFoe8KS+8jUNAl2+5atErDrW5JOcFG+gcQ==",
+        "dependencies": {
+          "Lucene.Net": "4.8.0-beta00017"
+        }
+      },
+      "Lucene.Net.Facet": {
+        "type": "Transitive",
+        "resolved": "4.8.0-beta00017",
+        "contentHash": "LVxGwgRAVq9XdwvNfgCB8OH+ou40I0E1NYN53muPjQK5oUY+HpkgkFUhTFSHdajWWj7xFI1f+UFB23iweoVf2w==",
+        "dependencies": {
+          "Lucene.Net.Join": "4.8.0-beta00017",
+          "Lucene.Net.Queries": "4.8.0-beta00017"
+        }
+      },
+      "Lucene.Net.Grouping": {
+        "type": "Transitive",
+        "resolved": "4.8.0-beta00017",
+        "contentHash": "nzMGvz0b1cedS8KKOlglJQJpyz8fT0ojgXFkgSkLLhwPNbMPwVoBsR7RlZs1FrF60Oz369O3Pm1a+MIr52KcLQ==",
+        "dependencies": {
+          "Lucene.Net": "4.8.0-beta00017",
+          "Lucene.Net.Queries": "4.8.0-beta00017"
+        }
+      },
+      "Lucene.Net.Join": {
+        "type": "Transitive",
+        "resolved": "4.8.0-beta00017",
+        "contentHash": "WcJl4O6t3iXiXwXHnhmbVCO7C6ilPxabBCsdW/auQN0lrDpbVIcHorCxwd199fGBEQnk7wbl5pPnk8nw/VK4eQ==",
+        "dependencies": {
+          "Lucene.Net.Grouping": "4.8.0-beta00017"
+        }
+      },
+      "Lucene.Net.Memory": {
+        "type": "Transitive",
+        "resolved": "4.8.0-beta00017",
+        "contentHash": "T4uG0k1iGzXXRRlmsFTtRPhnc2Ef1wlh68TxO2dN8qLW7AXX9qsIjOuN64+IXAPUkysvvks8psoU6epi642MUw==",
+        "dependencies": {
+          "Lucene.Net": "4.8.0-beta00017"
+        }
+      },
+      "Lucene.Net.Queries": {
+        "type": "Transitive",
+        "resolved": "4.8.0-beta00017",
+        "contentHash": "RVpZCfa/7pgvytFw64zLqinvZPQt4TojvcFghdAA5vhnpSs5GTbtciPIxFH3wwH3f2dYJywiqYKo1h3JBCXRBA==",
+        "dependencies": {
+          "Lucene.Net": "4.8.0-beta00017"
         }
       },
       "Magick.NET-Q8-AnyCPU": {

--- a/src/Goldfinch.Web/App_Data/CIRepository/@global/cms.class/kenticolucene.lucenecontenttypeitem.xml
+++ b/src/Goldfinch.Web/App_Data/CIRepository/@global/cms.class/kenticolucene.lucenecontenttypeitem.xml
@@ -1,0 +1,23 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<cms.class>
+  <ClassDisplayName>Lucene Type Item</ClassDisplayName>
+  <ClassFormDefinition>
+    <form>
+      <field column="LuceneContentTypeItemId" columntype="integer" enabled="true" guid="bcbfa821-f83c-442f-a1c5-63665626f439" isPK="true" />
+      <field column="LuceneContentTypeItemContentTypeName" columnprecision="0" columnsize="100" columntype="text" enabled="true" guid="8f389988-a927-4985-b591-aa1c779593ad" visible="true" />
+      <field column="LuceneContentTypeItemIncludedPathItemId" columnprecision="0" columntype="integer" enabled="true" guid="3f460b8f-2357-4ddf-973f-5ebe5a870abd" refobjtype="kenticolucene.luceneincludedpathitem" reftype="Required" visible="true" />
+      <field column="LuceneContentTypeItemGuid" columnprecision="0" columntype="guid" enabled="true" guid="9abc2916-e5b9-4087-886c-1a12cc02871d" visible="true" />
+      <field column="LuceneContentTypeItemIndexItemId" columnprecision="0" columntype="integer" enabled="true" guid="d76ae479-7220-4870-86a8-249d2d8b2751" refobjtype="kenticolucene.luceneindexitem" reftype="Required" visible="true" />
+    </form>
+  </ClassFormDefinition>
+  <ClassGUID>432ae548-706f-41ce-84ea-da7360a6ae6b</ClassGUID>
+  <ClassHasUnmanagedDbSchema>False</ClassHasUnmanagedDbSchema>
+  <ClassName>KenticoLucene.LuceneContentTypeItem</ClassName>
+  <ClassResourceID>
+    <CodeName>CMS.Integration.Lucene</CodeName>
+    <GUID>a4c59eb4-e549-426d-8f5a-925929a42e68</GUID>
+    <ObjectType>cms.resource</ObjectType>
+  </ClassResourceID>
+  <ClassTableName>KenticoLucene_LuceneContentTypeItem</ClassTableName>
+  <ClassType>Other</ClassType>
+</cms.class>

--- a/src/Goldfinch.Web/App_Data/CIRepository/@global/cms.class/kenticolucene.luceneincludedpathitem.xml
+++ b/src/Goldfinch.Web/App_Data/CIRepository/@global/cms.class/kenticolucene.luceneincludedpathitem.xml
@@ -1,0 +1,23 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<cms.class>
+  <ClassDisplayName>Lucene Path Item</ClassDisplayName>
+  <ClassFormDefinition>
+    <form>
+      <field column="LuceneIncludedPathItemId" columntype="integer" enabled="true" guid="aac9a2ec-1495-4d01-a1c6-5de99ccbdaf5" isPK="true" />
+      <field column="LuceneIncludedPathItemGuid" columnprecision="0" columntype="guid" enabled="true" guid="cbe0deb8-f91d-40d9-a599-ffb4a0d180b4" visible="true" />
+      <field column="LuceneIncludedPathItemAliasPath" columnprecision="0" columnsize="100" columntype="text" enabled="true" guid="d7fd85c4-c5cf-4ed4-9720-76c687718720" visible="true" />
+      <field column="LuceneIncludedPathItemChannelName" columnprecision="0" columnsize="100" columntype="text" enabled="true" guid="03c0d0d7-0b81-440f-8c8a-5cef945081b8" visible="true" />
+      <field column="LuceneIncludedPathItemIndexItemId" columnprecision="0" columntype="integer" enabled="true" guid="5789afd4-6c87-465c-a54a-f135e9b23b3c" refobjtype="kenticolucene.luceneindexitem" reftype="Required" visible="true" />
+    </form>
+  </ClassFormDefinition>
+  <ClassGUID>11aa4100-3a5c-45d4-912a-9e1588f05ff0</ClassGUID>
+  <ClassHasUnmanagedDbSchema>False</ClassHasUnmanagedDbSchema>
+  <ClassName>KenticoLucene.LuceneIncludedPathItem</ClassName>
+  <ClassResourceID>
+    <CodeName>CMS.Integration.Lucene</CodeName>
+    <GUID>a4c59eb4-e549-426d-8f5a-925929a42e68</GUID>
+    <ObjectType>cms.resource</ObjectType>
+  </ClassResourceID>
+  <ClassTableName>KenticoLucene_LuceneIncludedPathItem</ClassTableName>
+  <ClassType>Other</ClassType>
+</cms.class>

--- a/src/Goldfinch.Web/App_Data/CIRepository/@global/cms.class/kenticolucene.luceneindexassemblyversionitem.xml
+++ b/src/Goldfinch.Web/App_Data/CIRepository/@global/cms.class/kenticolucene.luceneindexassemblyversionitem.xml
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<cms.class>
+  <ClassDisplayName>Lucene Index Assembly Version Item</ClassDisplayName>
+  <ClassFormDefinition>
+    <form>
+      <field column="LuceneIndexAssemblyVersionItemID" columntype="integer" enabled="true" guid="76f9d8ae-f9e6-481c-bdcf-39e9cf64e4e1" isPK="true" />
+      <field column="LuceneIndexAssemblyVersionItemGuid" columnprecision="0" columntype="guid" enabled="true" guid="2d2ff9f2-a90d-4e6c-96b8-e35cd30354d3" visible="true" />
+      <field column="LuceneIndexAssemblyVersionItemAssemblyVersion" columnprecision="0" columnsize="100" columntype="text" enabled="true" guid="a0025a89-bcd8-4f42-a2a1-bcf6445be52e" visible="true" />
+      <field column="LuceneIndexAssemblyVersionItemIndexItemId" columnprecision="0" columntype="integer" enabled="true" guid="9de7d1d3-d6a2-43c0-bc6d-63034fe571d4" refobjtype="kenticolucene.luceneindexitem" reftype="Required" visible="true" />
+    </form>
+  </ClassFormDefinition>
+  <ClassGUID>9d0a8eab-b3cb-4645-92fc-0b55c721cb81</ClassGUID>
+  <ClassHasUnmanagedDbSchema>False</ClassHasUnmanagedDbSchema>
+  <ClassName>KenticoLucene.LuceneIndexAssemblyVersionItem</ClassName>
+  <ClassResourceID>
+    <CodeName>CMS.Integration.Lucene</CodeName>
+    <GUID>a4c59eb4-e549-426d-8f5a-925929a42e68</GUID>
+    <ObjectType>cms.resource</ObjectType>
+  </ClassResourceID>
+  <ClassTableName>KenticoLucene_LuceneIndexAssemblyVersionItem</ClassTableName>
+  <ClassType>Other</ClassType>
+</cms.class>

--- a/src/Goldfinch.Web/App_Data/CIRepository/@global/cms.class/kenticolucene.luceneindexitem.xml
+++ b/src/Goldfinch.Web/App_Data/CIRepository/@global/cms.class/kenticolucene.luceneindexitem.xml
@@ -1,0 +1,24 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<cms.class>
+  <ClassDisplayName>Lucene Index Item</ClassDisplayName>
+  <ClassFormDefinition>
+    <form>
+      <field column="LuceneIndexItemId" columntype="integer" enabled="true" guid="784c40f0-a51f-453e-a083-a96e03ce3439" isPK="true" />
+      <field column="LuceneIndexItemGuid" columnprecision="0" columntype="guid" enabled="true" guid="79062e30-1bff-4552-a1e5-d5ae0c9c495a" visible="true" />
+      <field column="LuceneIndexItemIndexName" columnprecision="0" columnsize="100" columntype="text" enabled="true" guid="fdaa7d7f-b21f-4034-8ac7-a5592594381e" visible="true" />
+      <field column="LuceneIndexItemStrategyName" columnprecision="0" columnsize="100" columntype="text" enabled="true" guid="74f2580a-e796-47b5-9136-729abcfe6a3c" visible="true" />
+      <field column="LuceneIndexItemAnalyzerName" columnprecision="0" columnsize="100" columntype="text" enabled="true" guid="4ed8e3a8-26af-4226-abaf-474db3456055" visible="true" />
+      <field allowempty="true" column="LuceneIndexItemRebuildHook" columnprecision="0" columnsize="100" columntype="text" enabled="true" guid="2c78e707-1490-41bf-a52e-2d0251c339b6" visible="true" />
+    </form>
+  </ClassFormDefinition>
+  <ClassGUID>ad662e39-3c8e-4b9b-8206-d963411ea296</ClassGUID>
+  <ClassHasUnmanagedDbSchema>False</ClassHasUnmanagedDbSchema>
+  <ClassName>KenticoLucene.LuceneIndexItem</ClassName>
+  <ClassResourceID>
+    <CodeName>CMS.Integration.Lucene</CodeName>
+    <GUID>a4c59eb4-e549-426d-8f5a-925929a42e68</GUID>
+    <ObjectType>cms.resource</ObjectType>
+  </ClassResourceID>
+  <ClassTableName>KenticoLucene_LuceneIndexItem</ClassTableName>
+  <ClassType>Other</ClassType>
+</cms.class>

--- a/src/Goldfinch.Web/App_Data/CIRepository/@global/cms.class/kenticolucene.luceneindexlanguageitem.xml
+++ b/src/Goldfinch.Web/App_Data/CIRepository/@global/cms.class/kenticolucene.luceneindexlanguageitem.xml
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<cms.class>
+  <ClassDisplayName>Lucene Indexed Language Item</ClassDisplayName>
+  <ClassFormDefinition>
+    <form>
+      <field column="LuceneIndexLanguageItemID" columntype="integer" enabled="true" guid="45d70737-bc62-44ab-a157-57755a136940" isPK="true" />
+      <field column="LuceneIndexLanguageItemName" columnprecision="0" columnsize="100" columntype="text" enabled="true" guid="2096e226-ea79-484f-9ce7-37905b5b67a0" visible="true" />
+      <field column="LuceneIndexLanguageItemGuid" columnprecision="0" columntype="guid" enabled="true" guid="5f9310fd-1473-4ebe-aea5-b480745e3469" visible="true" />
+      <field column="LuceneIndexLanguageItemIndexItemId" columnprecision="0" columntype="integer" enabled="true" guid="adfc8acd-01c0-4370-8710-5b2d57d98162" refobjtype="kenticolucene.luceneindexitem" reftype="Required" visible="true" />
+    </form>
+  </ClassFormDefinition>
+  <ClassGUID>deeb19da-ef41-457d-b08e-5949bb897742</ClassGUID>
+  <ClassHasUnmanagedDbSchema>False</ClassHasUnmanagedDbSchema>
+  <ClassName>KenticoLucene.LuceneIndexLanguageItem</ClassName>
+  <ClassResourceID>
+    <CodeName>CMS.Integration.Lucene</CodeName>
+    <GUID>a4c59eb4-e549-426d-8f5a-925929a42e68</GUID>
+    <ObjectType>cms.resource</ObjectType>
+  </ClassResourceID>
+  <ClassTableName>KenticoLucene_LuceneIndexLanguageItem</ClassTableName>
+  <ClassType>Other</ClassType>
+</cms.class>

--- a/src/Goldfinch.Web/App_Data/CIRepository/@global/cms.class/kenticolucene.lucenereusablecontenttypeitem.xml
+++ b/src/Goldfinch.Web/App_Data/CIRepository/@global/cms.class/kenticolucene.lucenereusablecontenttypeitem.xml
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<cms.class>
+  <ClassDisplayName>Lucene Reusable Content Type Item</ClassDisplayName>
+  <ClassFormDefinition>
+    <form>
+      <field column="LuceneReusableContentTypeItemId" columntype="integer" enabled="true" guid="6b6d86cb-7aa2-4325-ba1c-ec1932bb44af" isPK="true" />
+      <field column="LuceneReusableContentTypeItemContentTypeName" columnprecision="0" columnsize="100" columntype="text" enabled="true" guid="97fcae12-9a50-4932-afac-d0c4ea970a8a" visible="true" />
+      <field column="LuceneReusableContentTypeItemGuid" columnprecision="0" columntype="guid" enabled="true" guid="cad1e21c-c57e-47ae-aa45-f6a9d9df9953" visible="true" />
+      <field column="LuceneReusableContentTypeItemIndexItemId" columnprecision="0" columntype="integer" enabled="true" guid="9f6e2bef-8fc7-4071-ac9b-03207e5b4767" refobjtype="kenticolucene.luceneindexitem" reftype="Required" visible="true" />
+    </form>
+  </ClassFormDefinition>
+  <ClassGUID>da3c0fc5-2090-4a68-87b8-081b26b5bae5</ClassGUID>
+  <ClassHasUnmanagedDbSchema>False</ClassHasUnmanagedDbSchema>
+  <ClassName>KenticoLucene.LuceneReusableContentTypeItem</ClassName>
+  <ClassResourceID>
+    <CodeName>CMS.Integration.Lucene</CodeName>
+    <GUID>a4c59eb4-e549-426d-8f5a-925929a42e68</GUID>
+    <ObjectType>cms.resource</ObjectType>
+  </ClassResourceID>
+  <ClassTableName>KenticoLucene_LuceneReusableContentTypeItem</ClassTableName>
+  <ClassType>Other</ClassType>
+</cms.class>

--- a/src/Goldfinch.Web/App_Data/CIRepository/@global/cms.resource/cms.integration.lucene.xml
+++ b/src/Goldfinch.Web/App_Data/CIRepository/@global/cms.resource/cms.integration.lucene.xml
@@ -1,0 +1,8 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<cms.resource>
+  <ResourceDescription>Kentico Lucene custom data</ResourceDescription>
+  <ResourceDisplayName>Kentico Integration - Lucene</ResourceDisplayName>
+  <ResourceGUID>a4c59eb4-e549-426d-8f5a-925929a42e68</ResourceGUID>
+  <ResourceIsInDevelopment>False</ResourceIsInDevelopment>
+  <ResourceName>CMS.Integration.Lucene</ResourceName>
+</cms.resource>

--- a/src/Goldfinch.Web/App_Data/CIRepository/@global/kenticolucene.lucenecontenttypeitem/04da86b1-4d2f-4e2f-8305-b7f01898cd9e.xml
+++ b/src/Goldfinch.Web/App_Data/CIRepository/@global/kenticolucene.lucenecontenttypeitem/04da86b1-4d2f-4e2f-8305-b7f01898cd9e.xml
@@ -1,0 +1,14 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<kenticolucene.lucenecontenttypeitem>
+  <LuceneContentTypeItemContentTypeName>Goldfinch.BlogPost</LuceneContentTypeItemContentTypeName>
+  <LuceneContentTypeItemGuid>04da86b1-4d2f-4e2f-8305-b7f01898cd9e</LuceneContentTypeItemGuid>
+  <LuceneContentTypeItemIncludedPathItemId>
+    <GUID>2fd086a5-2517-4612-8722-43f8c2d3ae7b</GUID>
+    <ObjectType>kenticolucene.luceneincludedpathitem</ObjectType>
+  </LuceneContentTypeItemIncludedPathItemId>
+  <LuceneContentTypeItemIndexItemId>
+    <CodeName>BlogPosts</CodeName>
+    <GUID>ba267f8f-9cf9-45ce-a8dd-30ca95b71c06</GUID>
+    <ObjectType>kenticolucene.luceneindexitem</ObjectType>
+  </LuceneContentTypeItemIndexItemId>
+</kenticolucene.lucenecontenttypeitem>

--- a/src/Goldfinch.Web/App_Data/CIRepository/@global/kenticolucene.luceneincludedpathitem/2fd086a5-2517-4612-8722-43f8c2d3ae7b.xml
+++ b/src/Goldfinch.Web/App_Data/CIRepository/@global/kenticolucene.luceneincludedpathitem/2fd086a5-2517-4612-8722-43f8c2d3ae7b.xml
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<kenticolucene.luceneincludedpathitem>
+  <LuceneIncludedPathItemAliasPath>/%</LuceneIncludedPathItemAliasPath>
+  <LuceneIncludedPathItemChannelName>Goldfinch</LuceneIncludedPathItemChannelName>
+  <LuceneIncludedPathItemGuid>2fd086a5-2517-4612-8722-43f8c2d3ae7b</LuceneIncludedPathItemGuid>
+  <LuceneIncludedPathItemIndexItemId>
+    <CodeName>BlogPosts</CodeName>
+    <GUID>ba267f8f-9cf9-45ce-a8dd-30ca95b71c06</GUID>
+    <ObjectType>kenticolucene.luceneindexitem</ObjectType>
+  </LuceneIncludedPathItemIndexItemId>
+</kenticolucene.luceneincludedpathitem>

--- a/src/Goldfinch.Web/App_Data/CIRepository/@global/kenticolucene.luceneindexitem/blogposts.xml
+++ b/src/Goldfinch.Web/App_Data/CIRepository/@global/kenticolucene.luceneindexitem/blogposts.xml
@@ -1,0 +1,7 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<kenticolucene.luceneindexitem>
+  <LuceneIndexItemAnalyzerName>Standard</LuceneIndexItemAnalyzerName>
+  <LuceneIndexItemGuid>ba267f8f-9cf9-45ce-a8dd-30ca95b71c06</LuceneIndexItemGuid>
+  <LuceneIndexItemIndexName>BlogPosts</LuceneIndexItemIndexName>
+  <LuceneIndexItemStrategyName>BlogPosts</LuceneIndexItemStrategyName>
+</kenticolucene.luceneindexitem>

--- a/src/Goldfinch.Web/App_Data/CIRepository/@global/kenticolucene.luceneindexlanguageitem/c0d07dcc-a273-4ef3-bf9c-a3c2999e0320.xml
+++ b/src/Goldfinch.Web/App_Data/CIRepository/@global/kenticolucene.luceneindexlanguageitem/c0d07dcc-a273-4ef3-bf9c-a3c2999e0320.xml
@@ -1,0 +1,10 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<kenticolucene.luceneindexlanguageitem>
+  <LuceneIndexLanguageItemGuid>c0d07dcc-a273-4ef3-bf9c-a3c2999e0320</LuceneIndexLanguageItemGuid>
+  <LuceneIndexLanguageItemIndexItemId>
+    <CodeName>BlogPosts</CodeName>
+    <GUID>ba267f8f-9cf9-45ce-a8dd-30ca95b71c06</GUID>
+    <ObjectType>kenticolucene.luceneindexitem</ObjectType>
+  </LuceneIndexLanguageItemIndexItemId>
+  <LuceneIndexLanguageItemName>en</LuceneIndexLanguageItemName>
+</kenticolucene.luceneindexlanguageitem>

--- a/src/Goldfinch.Web/Features/Search/SearchApiController.cs
+++ b/src/Goldfinch.Web/Features/Search/SearchApiController.cs
@@ -1,12 +1,10 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Threading.Tasks;
-using CMS.Websites;
 using Goldfinch.Core.BlogPosts;
-using Goldfinch.Core.ContentTypes;
-using Goldfinch.Core.Extensions;
-using Kentico.Content.Web.Mvc;
+using Goldfinch.Core.Search;
 using Kentico.Content.Web.Mvc.Routing;
 using Microsoft.AspNetCore.Mvc;
 
@@ -17,29 +15,25 @@ namespace Goldfinch.Web.Features.Search;
 /// See docs/design-handoff/api-contracts.md for the full contract.
 /// </summary>
 /// <remarks>
-/// TODO: this is a v1 stub. It currently searches BlogPost titles + summaries only.
-/// The contract adds ranking (tag > title > summary > body), body search,
-/// <mark> highlights, tag results, and a 60s cache header. Implement properly
-/// once the Tag content type exists and we can index bodies.
+/// Post results come from the <c>BlogPosts</c> Lucene index (title &gt; summary &gt; body ranking,
+/// with body content + reading time + <c>&lt;mark&gt;</c> highlights). Tag results are resolved
+/// from the BlogTags taxonomy and emitted first on an exact tag match.
 /// </remarks>
 [ApiController]
 [Route("api/search")]
 public class SearchApiController : ControllerBase
 {
-    private readonly IBlogPostService _blogPostService;
+    private readonly ILuceneBlogSearchService _searchService;
     private readonly IBlogTagService _blogTagService;
-    private readonly IWebPageUrlRetriever _urlRetriever;
     private readonly IPreferredLanguageRetriever _preferredLanguageRetriever;
 
     public SearchApiController(
-        IBlogPostService blogPostService,
+        ILuceneBlogSearchService searchService,
         IBlogTagService blogTagService,
-        IWebPageUrlRetriever urlRetriever,
         IPreferredLanguageRetriever preferredLanguageRetriever)
     {
-        _blogPostService = blogPostService;
+        _searchService = searchService;
         _blogTagService = blogTagService;
-        _urlRetriever = urlRetriever;
         _preferredLanguageRetriever = preferredLanguageRetriever;
     }
 
@@ -55,67 +49,86 @@ public class SearchApiController : ControllerBase
             return BadRequest(new { error = "invalid_limit" });
         }
 
-        var started = DateTime.UtcNow;
-
+        var stopwatch = Stopwatch.StartNew();
         var needle = q.Trim();
 
-        // Scope to a tag when one is active (e.g. live search on /blog?tag=…).
-        List<BlogPost> all;
-        if (!string.IsNullOrWhiteSpace(tag))
+        var results = new List<object>();
+
+        // Tag results first (contract rank #1): exact match on tag slug or title.
+        // Skipped when already scoped to a tag (live search within /blog?tag=…).
+        if (string.IsNullOrWhiteSpace(tag))
         {
-            var tagGuid = await _blogTagService.ResolveTagSlugToGuid(tag);
-            all = tagGuid.HasValue
-                ? (await _blogPostService.GetBlogPostsByTag(tagGuid.Value)).ToList()
-                : [];
-        }
-        else
-        {
-            all = (await _blogPostService.GetAllBlogPosts())
-                .OrderByDescending(p => p.BlogPostDate)
-                .ToList();
+            results.AddRange(await GetTagResults(needle));
         }
 
-        var matches = all.Where(p =>
-                (p.BaseContentTitle?.Contains(needle, StringComparison.OrdinalIgnoreCase) ?? false)
-                || (p.BaseContentShortDescription?.Contains(needle, StringComparison.OrdinalIgnoreCase) ?? false))
-            .Take(limit)
-            .ToList();
-
-        var languageName = _preferredLanguageRetriever.Get();
-
-        var results = new object[matches.Count];
-        for (var i = 0; i < matches.Count; i++)
+        // Post results from the Lucene index.
+        var posts = _searchService.SearchPosts(needle, tag, limit);
+        foreach (var post in posts)
         {
-            var m = matches[i];
-            var url = (await _urlRetriever.Retrieve(m)).RelativePath.ToAbsolutePath();
-
-            var tags = Array.Empty<string>();
-            if (m.BlogPostTags?.Any() == true)
-            {
-                var resolvedTags = await _blogTagService.GetTagsByGuids(
-                    m.BlogPostTags.Select(t => t.Identifier), languageName);
-                tags = resolvedTags.Select(t => t.Name).ToArray();
-            }
-
-            results[i] = new
+            results.Add(new
             {
                 kind = "post",
-                title = m.BaseContentTitle,
-                summary = m.BaseContentShortDescription,
-                url,
-                date = m.BlogPostDate.ToString("yyyy-MM-dd"),
-                tags,
-                reading_minutes = 4,             // TODO: compute from body
-            };
+                slug = post.Slug,
+                title = post.Title,
+                summary = post.Summary,
+                url = post.Url,
+                date = post.Date,
+                tags = post.Tags,
+                reading_minutes = post.ReadingMinutes,
+                highlights = BuildHighlights(post),
+            });
         }
 
+        stopwatch.Stop();
+
         Response.Headers["Cache-Control"] = "public, max-age=60";
+        Response.Headers["Vary"] = "Accept-Encoding";
+
         return Ok(new
         {
             q = needle,
-            total = results.Length,
-            took_ms = (int)(DateTime.UtcNow - started).TotalMilliseconds,
+            total = results.Count,
+            took_ms = (int)stopwatch.ElapsedMilliseconds,
             results,
         });
+    }
+
+    private async Task<IEnumerable<object>> GetTagResults(string needle)
+    {
+        var languageName = _preferredLanguageRetriever.Get();
+        var tags = await _blogTagService.GetTagsWithPostCounts(languageName);
+
+        return tags
+            .Where(t =>
+                string.Equals(t.Tag.Name, needle, StringComparison.OrdinalIgnoreCase) ||
+                string.Equals(t.Tag.Title, needle, StringComparison.OrdinalIgnoreCase))
+            .Select(t => (object)new
+            {
+                kind = "tag",
+                slug = t.Tag.Name,
+                label = t.Tag.Title,
+                url = $"/blog?tag={t.Tag.Name}",
+                post_count = t.PostCount,
+            });
+    }
+
+    /// <summary>
+    /// Builds the optional highlights object, including only the parts that actually matched.
+    /// Returns null when there are no highlights so the property is omitted from the response.
+    /// </summary>
+    private static Dictionary<string, string>? BuildHighlights(BlogSearchResult post)
+    {
+        var highlights = new Dictionary<string, string>();
+
+        if (!string.IsNullOrEmpty(post.HighlightedTitle))
+        {
+            highlights["title"] = post.HighlightedTitle;
+        }
+        if (!string.IsNullOrEmpty(post.HighlightedSummary))
+        {
+            highlights["summary"] = post.HighlightedSummary;
+        }
+
+        return highlights.Count > 0 ? highlights : null;
     }
 }

--- a/src/Goldfinch.Web/Infrastructure/Storage/LuceneStorageModule.cs
+++ b/src/Goldfinch.Web/Infrastructure/Storage/LuceneStorageModule.cs
@@ -1,0 +1,68 @@
+using CMS;
+using CMS.Core;
+using CMS.DataEngine;
+using CMS.IO;
+using Goldfinch.Web.Infrastructure.Storage;
+using Kentico.Xperience.AzureStorage;
+using Kentico.Xperience.Lucene.Core.Store;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Hosting;
+
+[assembly: RegisterModule(typeof(LuceneStorageModule))]
+
+namespace Goldfinch.Web.Infrastructure.Storage;
+
+/// <summary>
+/// Maps the Lucene search index storage path to Azure Blob Storage in production, mirroring
+/// <see cref="StorageInitializationModule"/>. In development the indexes fall back to the local
+/// file system under <c>App_Data/LuceneSearch</c>. Storing the index in Blob persists it across
+/// deployments and shares it across instances; the integration also auto-disables web-farm index
+/// sync when it detects external storage.
+/// </summary>
+public class LuceneStorageModule : Module
+{
+    /// <summary>
+    /// Container name within Azure Blob Storage for Lucene indexes.
+    /// </summary>
+    private const string ContainerName = "lucene";
+
+    private IWebHostEnvironment? _environment;
+
+    public LuceneStorageModule()
+         : base(nameof(LuceneStorageModule))
+    {
+    }
+
+    /// <summary>
+    /// Gets the web hosting environment information.
+    /// </summary>
+    public IWebHostEnvironment Environment
+    {
+        get
+        {
+            return _environment ??= Service.Resolve<IWebHostEnvironment>();
+        }
+    }
+
+    protected override void OnInit()
+    {
+        base.OnInit();
+
+        if (!Environment.IsProduction())
+        {
+            return;
+        }
+
+        // Creates a new StorageProvider instance for Azure Blob storage
+        var luceneProvider = AzureStorageProvider.Create();
+
+        // Specifies the target container, the provider ensures its existence in the storage account
+        luceneProvider.CustomRootPath = ContainerName;
+
+        // Keeps the Lucene index container private
+        luceneProvider.PublicExternalFolderObject = false;
+
+        // Redirects all CMS.IO operations under the Lucene index path to Azure Blob storage
+        StorageHelper.MapStoragePath($"~/{LuceneStorageConstants.LUCENE_INDEX_PATH}/", luceneProvider);
+    }
+}

--- a/src/Goldfinch.Web/Program.cs
+++ b/src/Goldfinch.Web/Program.cs
@@ -1,5 +1,6 @@
 using Goldfinch.Core;
 using Goldfinch.Core.ContentTypes;
+using Goldfinch.Core.Search;
 using Goldfinch.Web.Components.Sections.ContentSection;
 using Goldfinch.Web.Infrastructure.StaticFiles;
 using Goldfinch.Web.Middleware;
@@ -78,6 +79,14 @@ builder.Services.Configure<RouteOptions>(options =>
 });
 
 builder.Services.AddCoreServices();
+
+// Lucene search — registers the blog indexing strategy used by the BlogPosts index.
+// Index storage maps to Azure Blob in production via LuceneStorageModule; local filesystem otherwise.
+builder.Services.AddKenticoLucene(luceneBuilder =>
+{
+    luceneBuilder.IncludeDefaultStrategy = false;
+    luceneBuilder.RegisterStrategy<BlogPostSearchIndexingStrategy>(BlogSearchConstants.INDEX_NAME);
+});
 
 builder.Services.AddXperienceCommunityCspManagement();
 

--- a/src/Goldfinch.Web/appsettings.Production.json
+++ b/src/Goldfinch.Web/appsettings.Production.json
@@ -12,5 +12,6 @@
   "ConnectionStrings": {
     "CMSConnectionString": "Data Source=#{CMSSQLServer}#;Initial Catalog=#{CMSSQLDatabase}#;Integrated Security=False;Persist Security Info=False;User ID=#{CMSSQLUser}#;Password=#{CMSSQLPassword}#;Connect Timeout=60;Encrypt=False;Current Language=English;"
   },
-  "CMSHashStringSalt": "#{CMSHashStringSalt}#"
+  "CMSHashStringSalt": "#{CMSHashStringSalt}#",
+  "WebCrawlerBaseUrl": "https://www.goldfinch.me/"
 }

--- a/src/Goldfinch.Web/appsettings.json
+++ b/src/Goldfinch.Web/appsettings.json
@@ -15,6 +15,7 @@
   },
   "AllowedHosts": "*",
   "CMSHashStringSalt": "hash-string-salt",
+  "WebCrawlerBaseUrl": "https://localhost:52623/",
   "CMSAdminClientModuleSettings": {
     "goldfinch-web-admin": {
       //"Mode": "Proxy",

--- a/src/Goldfinch.Web/packages.lock.json
+++ b/src/Goldfinch.Web/packages.lock.json
@@ -100,11 +100,6 @@
           "Kentico.Xperience.Admin": "30.11.0"
         }
       },
-      "AngleSharp": {
-        "type": "Transitive",
-        "resolved": "0.17.1",
-        "contentHash": "5MPI4bbixlwxb0W/smOMeIR+QlxMy5/5jD+WnIAw4pBC+7AhLPe5bS3cLgQMJyvd6q0A48sG+uYOt/ep406GLA=="
-      },
       "AngleSharp.Css": {
         "type": "Transitive",
         "resolved": "0.17.0",
@@ -524,6 +519,11 @@
           "AngleSharp.Css": "[0.17.0]"
         }
       },
+      "J2N": {
+        "type": "Transitive",
+        "resolved": "2.1.0",
+        "contentHash": "Vooz1wbnnqWuS+u93tADXK5Owxo8vLJhSrZ9Ac+KpgDF3GJq9TybXXTF1TFcWILgEtRThc8AOBENEzB0TQH1JA=="
+      },
       "Kentico.Aira.Client": {
         "type": "Transitive",
         "resolved": "6.1.0",
@@ -548,6 +548,84 @@
           "ReverseMarkdown": "5.3.0",
           "System.CodeDom": "8.0.0",
           "System.IO.Hashing": "10.0.7"
+        }
+      },
+      "Kentico.Xperience.Lucene.Admin": {
+        "type": "Transitive",
+        "resolved": "15.0.3",
+        "contentHash": "q2AyXL+nDnQMtlgDWhAc3pLbH5VpY2Z2+b71lu/wzA70wrNJka3vJ6/caj/UZKHgqfEtvgj6CsJ37AGz6P/jVw==",
+        "dependencies": {
+          "Kentico.Xperience.Admin": "31.0.0",
+          "Kentico.Xperience.Lucene.Core": "15.0.3"
+        }
+      },
+      "Kentico.Xperience.Lucene.Core": {
+        "type": "Transitive",
+        "resolved": "15.0.3",
+        "contentHash": "VGQ83QOfNwm9tJVDnUgJTFopx6SEzPTlxZ9ouNkziQpxEIjcy/tj//54H/vjTFsUGzXFOJSErOPqLTUGlE3Qww==",
+        "dependencies": {
+          "Kentico.Xperience.Core": "31.0.0",
+          "Lucene.Net": "4.8.0-beta00017",
+          "Lucene.Net.Analysis.Common": "4.8.0-beta00017",
+          "Lucene.Net.Facet": "4.8.0-beta00017"
+        }
+      },
+      "Lucene.Net": {
+        "type": "Transitive",
+        "resolved": "4.8.0-beta00017",
+        "contentHash": "7LLWS9nNwx01AyE/KXMh+qdAlzDkRANE8407AO/wEmLL1InzVKFwfsRdRmwg4ILOMFui4xZ1Y54eqvzo3Tf9Vw==",
+        "dependencies": {
+          "J2N": "[2.1.0, 3.0.0)"
+        }
+      },
+      "Lucene.Net.Analysis.Common": {
+        "type": "Transitive",
+        "resolved": "4.8.0-beta00017",
+        "contentHash": "rPpmww/HgwEwhvfvZgdWITxFsWRoCEpP3+WQBFgbGxTn4eLDr3U/oFoe8KS+8jUNAl2+5atErDrW5JOcFG+gcQ==",
+        "dependencies": {
+          "Lucene.Net": "4.8.0-beta00017"
+        }
+      },
+      "Lucene.Net.Facet": {
+        "type": "Transitive",
+        "resolved": "4.8.0-beta00017",
+        "contentHash": "LVxGwgRAVq9XdwvNfgCB8OH+ou40I0E1NYN53muPjQK5oUY+HpkgkFUhTFSHdajWWj7xFI1f+UFB23iweoVf2w==",
+        "dependencies": {
+          "Lucene.Net.Join": "4.8.0-beta00017",
+          "Lucene.Net.Queries": "4.8.0-beta00017"
+        }
+      },
+      "Lucene.Net.Grouping": {
+        "type": "Transitive",
+        "resolved": "4.8.0-beta00017",
+        "contentHash": "nzMGvz0b1cedS8KKOlglJQJpyz8fT0ojgXFkgSkLLhwPNbMPwVoBsR7RlZs1FrF60Oz369O3Pm1a+MIr52KcLQ==",
+        "dependencies": {
+          "Lucene.Net": "4.8.0-beta00017",
+          "Lucene.Net.Queries": "4.8.0-beta00017"
+        }
+      },
+      "Lucene.Net.Join": {
+        "type": "Transitive",
+        "resolved": "4.8.0-beta00017",
+        "contentHash": "WcJl4O6t3iXiXwXHnhmbVCO7C6ilPxabBCsdW/auQN0lrDpbVIcHorCxwd199fGBEQnk7wbl5pPnk8nw/VK4eQ==",
+        "dependencies": {
+          "Lucene.Net.Grouping": "4.8.0-beta00017"
+        }
+      },
+      "Lucene.Net.Memory": {
+        "type": "Transitive",
+        "resolved": "4.8.0-beta00017",
+        "contentHash": "T4uG0k1iGzXXRRlmsFTtRPhnc2Ef1wlh68TxO2dN8qLW7AXX9qsIjOuN64+IXAPUkysvvks8psoU6epi642MUw==",
+        "dependencies": {
+          "Lucene.Net": "4.8.0-beta00017"
+        }
+      },
+      "Lucene.Net.Queries": {
+        "type": "Transitive",
+        "resolved": "4.8.0-beta00017",
+        "contentHash": "RVpZCfa/7pgvytFw64zLqinvZPQt4TojvcFghdAA5vhnpSs5GTbtciPIxFH3wwH3f2dYJywiqYKo1h3JBCXRBA==",
+        "dependencies": {
+          "Lucene.Net": "4.8.0-beta00017"
         }
       },
       "Magick.NET-Q8-AnyCPU": {
@@ -988,9 +1066,38 @@
       "goldfinch.core": {
         "type": "Project",
         "dependencies": {
+          "AngleSharp": "[0.17.1, )",
           "Kentico.Xperience.Admin": "[31.5.3, )",
+          "Kentico.Xperience.Lucene": "[15.0.3, )",
           "Kentico.Xperience.WebApp": "[31.5.3, )",
+          "Lucene.Net.Highlighter": "[4.8.0-beta00017, )",
           "Sidio.Sitemap.AspNetCore": "[3.1.1, )"
+        }
+      },
+      "AngleSharp": {
+        "type": "CentralTransitive",
+        "requested": "[0.17.1, )",
+        "resolved": "0.17.1",
+        "contentHash": "5MPI4bbixlwxb0W/smOMeIR+QlxMy5/5jD+WnIAw4pBC+7AhLPe5bS3cLgQMJyvd6q0A48sG+uYOt/ep406GLA=="
+      },
+      "Kentico.Xperience.Lucene": {
+        "type": "CentralTransitive",
+        "requested": "[15.0.3, )",
+        "resolved": "15.0.3",
+        "contentHash": "xihyGfQ59suos8OBXosEev/oIPHlcPd5CXuDE6a/mAAUyN9Vi3Mnw2qGYJ1czF6WaflvUpesnfpYSqDj079PsQ==",
+        "dependencies": {
+          "Kentico.Xperience.Lucene.Admin": "15.0.3",
+          "Kentico.Xperience.Lucene.Core": "15.0.3"
+        }
+      },
+      "Lucene.Net.Highlighter": {
+        "type": "CentralTransitive",
+        "requested": "[4.8.0-beta00017, )",
+        "resolved": "4.8.0-beta00017",
+        "contentHash": "Mqm+KlBHhNO+jhmSkC1xD88qSAWEcFu7vGt7utpoZZn9RGD5TVXavJHNLXYjvj9O5NQtDAjeKZ0T9toVCY0REw==",
+        "dependencies": {
+          "Lucene.Net.Memory": "4.8.0-beta00017",
+          "Lucene.Net.Queries": "4.8.0-beta00017"
         }
       }
     }

--- a/src/Goldfinch.Web/wwwroot/sitefiles/src/global.css
+++ b/src/Goldfinch.Web/wwwroot/sitefiles/src/global.css
@@ -2383,6 +2383,13 @@ a.pager-btn:hover {
   text-overflow: ellipsis;
   white-space: nowrap;
 }
+/* Matched-term highlight in search results (command palette + blog toolbar).
+   The only <mark> on the site comes from /api/search highlights. */
+mark {
+  background: transparent;
+  color: var(--accent-hot);
+  font-weight: 600;
+}
 .palette-item__meta {
   display: block;
   font-family: var(--font-mono);

--- a/src/Goldfinch.Web/wwwroot/sitefiles/src/scripts/search.js
+++ b/src/Goldfinch.Web/wwwroot/sitefiles/src/scripts/search.js
@@ -22,6 +22,10 @@
     clearTimeout(timer);
     abortCtl?.abort();
     if (!q) { resultsEl.hidden = true; resultsEl.innerHTML = ''; return; }
+    // Show a loading state immediately so a stale "no results" isn't shown while
+    // the debounced request is in flight (mirrors the command palette).
+    resultsEl.innerHTML = `<div class="live-search-empty mono">&gt; searching…</div>`;
+    resultsEl.hidden = false;
     timer = setTimeout(() => run(q), 180);
   });
 


### PR DESCRIPTION
## What

Replaces the title+summary `string.Contains` stub in `/api/search` with the official **Kentico Xperience Lucene** integration, fulfilling the `docs/design-handoff/api-contracts.md` contract. The command palette (⌘K) and blog toolbar were already wired for the richer response shape — this fills in the backend.

## How

- **Index** `BlogPost` title, summary, tags, date, reading time, and full body. The body lives in Page Builder editable areas, so it is crawled from the rendered page (`WebCrawlerService`) and sanitized to text (`WebScraperHtmlSanitizer`, `.post-body` container).
- **Ranking** via a boosted query: exact/near-exact **phrase** matches rank above scattered term matches, and title > summary > body.
- **Highlights**: matched terms wrapped in literal `<mark>`; the client re-escapes everything except `<mark>` (no double-encoding). Themed `<mark>` to glow amber instead of the browser default.
- **Tag results**: an exact tag match is returned first (`kind:"tag"`), resolved from the BlogTags taxonomy.
- **Storage**: `LuceneStorageModule` maps the index to a private `lucene` Azure Blob container in production (auto-created), and the local filesystem in dev — mirroring `StorageInitializationModule`.
- **UX**: the blog toolbar now shows a `searching…` state while the request is in flight, matching the command palette.
- All search logic lives in `Goldfinch.Core/Search`; `Web` keeps only the storage module, `AddKenticoLucene` wiring, appsettings, and the controller.
- Pins AngleSharp to 0.17.1 to match Kentico's transitive version. Commits the Lucene module + `BlogPosts` index config to the CI repository; gitignores the runtime index + locks.

## Verified locally (24-post index)

Body-only matches, title > summary > body ranking, exact-phrase boosting, real `reading_minutes`, tag results, `<mark>` highlights, `?tag=` scoping, `missing_query`/`invalid_limit` 400s, and `Cache-Control: public, max-age=60` + `Vary` headers. Response times 3–73 ms.

## Deploy notes (CI-only, no CD)

After merge + CI restore, **rebuild the `BlogPosts` index once in the prod admin** — it crawls `https://www.goldfinch.me/` and auto-creates the private `lucene` blob container. No Azure setup or new connection strings needed.

Closes #202
Refs #203 — this lays the body-extraction groundwork and fixes the search hardcoded reading time; surfacing real reading time on the home/listing/detail pages is a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)