### PR TITLE
Update blog search placeholder to “Search posts…”

### DIFF
--- a/src/Goldfinch.Web/Features/BlogList/Listing.cshtml
+++ b/src/Goldfinch.Web/Features/BlogList/Listing.cshtml
@@ -44,7 +44,7 @@
             <input type="search"
                    name="q"
                    value="@Model.Query"
-                   placeholder="Filter posts by title or summary…"
+                   placeholder="Search posts…"
                    class="mono"
                    autocomplete="off"
                    data-live-search


### PR DESCRIPTION
Small copy fix: the blog toolbar placeholder said "Filter posts by title or summary...", which understates the live search now that it covers full body content + tags via the Lucene index (#202). Switches to neutral "Search posts..." — accurate for both the live full-text dropdown and the non-JS title/summary fallback, and consistent with the nav search trigger wording.

Also serves as a low-risk change to validate that the Lucene index persists across a deploy (Azure Blob storage) without a manual rebuild.

🤖 Generated with [Claude Code](https://claude.com/claude-code)