### PR TITLE
fix(update-xperience): always enable CI instead of skipping when disabled

### DIFF
--- a/.claude/skills/update-xperience/SKILL.md
+++ b/.claude/skills/update-xperience/SKILL.md
@@ -47,14 +47,14 @@ Execute the `Update-Xperience.ps1` PowerShell script to automate mechanical task
 The script will:
 - Validate prerequisites (Directory.Packages.props exists, clean git state, feature branch)
 - Check current Kentico package versions in Directory.Packages.props
-- If CI is enabled: clear `CI_FileMetadata` and run `--kxp-ci-restore` to apply CI XML files to the database **before any package updates** (assembly and DB are still on the same version at this point)
-- Disable CI (CMSEnableCI) if enabled
+- Ensure CI (CMSEnableCI) is enabled, then clear `CI_FileMetadata` and run `--kxp-ci-restore` to apply CI XML files to the database **before any package updates** (assembly and DB are still on the same version at this point). CI is always expected to be enabled for this project, so it is enabled unconditionally — this self-heals a DB left disabled by a previously interrupted run.
+- Disable CI before the package update so `dotnet restore` doesn't trigger CI side-effects
 - Update Kentico.Xperience.* packages in Directory.Packages.props and run `dotnet restore` (preserves Kentico.Xperience.MiniProfiler which has independent versioning)
 - Update @kentico/* npm packages in admin client only (not custom frontend dependencies)
 - Run `npm audit fix` for security vulnerabilities
 - Build the solution with the new packages
 - Run `dotnet run --kxp-update --skip-confirmation` for database migrations
-- Re-enable CI if it was previously enabled
+- Re-enable CI (always left enabled at the end)
 - Run `dotnet run --kxp-ci-store` to serialize updated objects
 - Check for CI repository changes
 
@@ -121,7 +121,8 @@ When everything is working:
 
 - **Central Package Management**: Uses Directory.Packages.props for all NuGet package versions
 - **Preserved Packages**: Kentico.Xperience.MiniProfiler has independent versioning and won't be automatically updated
-- **CI Restore First**: When CI is enabled, the script clears `CI_FileMetadata` and runs `--kxp-ci-restore` **before the NuGet package update**. This is critical — the assembly and DB must be on the same version for CI restore to run, and it must happen before the migration so `--kxp-ci-store` serialises the CI XML state, not stale seed-DB state (which would roll back fields on custom content types)
+- **CI Always Enabled**: CI is always expected to be enabled for this project. The script enables CI unconditionally at the start (self-healing a DB left disabled by a previously interrupted run) and always leaves it enabled at the end — it never skips the CI steps based on the current `CMSEnableCI` value
+- **CI Restore First**: The script clears `CI_FileMetadata` and runs `--kxp-ci-restore` **before the NuGet package update**. This is critical — the assembly and DB must be on the same version for CI restore to run, and it must happen before the migration so `--kxp-ci-store` serialises the CI XML state, not stale seed-DB state (which would roll back fields on custom content types)
 - **CI Toggle**: The script disables CI before the NuGet update and re-enables it after `--kxp-update` (per Kentico best practices)
 - **CI Repository**: Changes to `App_Data/CIRepository/` are expected and necessary after CI store operation
 - **Nullable Reference Types**: This project has nullable reference types enabled - ensure any code changes respect this

--- a/scripts/Update-Xperience.ps1
+++ b/scripts/Update-Xperience.ps1
@@ -24,7 +24,6 @@ $ErrorActionPreference = "Stop"
 $script:hasErrors = $false
 $script:updatedVersion = $null
 $script:resolvedVersions = @{}
-$script:ciWasEnabled = $false
 $script:connectionString = $null
 
 #region Helper Functions
@@ -442,15 +441,17 @@ function Clear-CIFileMetadata {
 }
 
 # Runs BEFORE any package updates while the assembly version still matches the DB version.
-# Restores CI XML files into the DB so the migration runs on top of the correct object state,
-# then disables CI so the package update and dotnet restore don't trigger CI side-effects.
-# This is critical: skipping it causes --kxp-ci-store to serialise stale seed-DB state back
-# into the CI XML files, rolling back fields on custom content types.
+# CI is always expected to be enabled for this project, so it is enabled unconditionally here
+# (self-healing a DB left disabled by a previously interrupted run). Restores CI XML files into
+# the DB so the migration runs on top of the correct object state, then disables CI so the
+# package update and dotnet restore don't trigger CI side-effects.
+# This is critical: skipping the restore causes --kxp-ci-store to serialise stale seed-DB state
+# back into the CI XML files, rolling back fields on custom content types.
 function Invoke-CIPreRestore {
     Write-Section "CI Pre-Restore (before package update)"
 
     if ($DryRun) {
-        Write-Warning "DRY RUN: Would check CI status, clear CI_FileMetadata, run --kxp-ci-restore, then disable CI"
+        Write-Warning "DRY RUN: Would ensure CI is enabled, clear CI_FileMetadata, run --kxp-ci-restore, then disable CI"
         return
     }
 
@@ -458,40 +459,44 @@ function Invoke-CIPreRestore {
         $script:connectionString = Get-ConnectionString
         Write-Success "Connection string retrieved"
 
-        Write-Host "Checking CI status..." -ForegroundColor Gray
-        $script:ciWasEnabled = Get-CIEnabled -ConnectionString $script:connectionString
-
-        if ($script:ciWasEnabled) {
-            Write-Host "CI is currently enabled" -ForegroundColor Gray
-
-            Write-Host "`nClearing CI_FileMetadata before restore..." -ForegroundColor Yellow
-            Clear-CIFileMetadata -ConnectionString $script:connectionString
-
-            Push-Location "src/Goldfinch.Web"
-            try {
-                Write-Host "`nRestoring CI objects before package update..." -ForegroundColor Yellow
-                & dotnet run --kxp-ci-restore
-
-                if ($LASTEXITCODE -eq 0) {
-                    Write-Success "CI restore completed"
-                } else {
-                    throw "CI restore failed with exit code $LASTEXITCODE"
-                }
-            } finally {
-                Pop-Location
-            }
-
-            Write-Host "`nDisabling CI before package update..." -ForegroundColor Yellow
-            $success = Set-CIEnabled -ConnectionString $script:connectionString -Enabled $false
-
-            if (-not $success) {
-                throw "Failed to disable CI. Cannot proceed with update."
-            }
-
-            Write-Success "CI disabled"
+        # CI is always enabled for this project. Enable it unconditionally so the pre-restore
+        # syncs the DB from the repo CI XML before migration, even if a prior run left it off.
+        Write-Host "Ensuring CI is enabled..." -ForegroundColor Gray
+        if (Get-CIEnabled -ConnectionString $script:connectionString) {
+            Write-Host "CI is already enabled" -ForegroundColor Gray
         } else {
-            Write-Host "CI is not enabled - skipping CI pre-restore" -ForegroundColor Gray
+            $success = Set-CIEnabled -ConnectionString $script:connectionString -Enabled $true
+            if (-not $success) {
+                throw "Failed to enable CI. Cannot proceed with update."
+            }
+            Write-Success "CI enabled"
         }
+
+        Write-Host "`nClearing CI_FileMetadata before restore..." -ForegroundColor Yellow
+        Clear-CIFileMetadata -ConnectionString $script:connectionString
+
+        Push-Location "src/Goldfinch.Web"
+        try {
+            Write-Host "`nRestoring CI objects before package update..." -ForegroundColor Yellow
+            & dotnet run --kxp-ci-restore
+
+            if ($LASTEXITCODE -eq 0) {
+                Write-Success "CI restore completed"
+            } else {
+                throw "CI restore failed with exit code $LASTEXITCODE"
+            }
+        } finally {
+            Pop-Location
+        }
+
+        Write-Host "`nDisabling CI before package update..." -ForegroundColor Yellow
+        $success = Set-CIEnabled -ConnectionString $script:connectionString -Enabled $false
+
+        if (-not $success) {
+            throw "Failed to disable CI. Cannot proceed with update."
+        }
+
+        Write-Success "CI disabled"
     } catch {
         Write-ErrorMessage "Failed during CI pre-restore: $_"
         throw
@@ -535,38 +540,36 @@ function Invoke-KenticoUpdate {
             Pop-Location
         }
 
-        # Re-enable CI and store if it was originally enabled
-        if ($script:ciWasEnabled) {
-            Write-Host "`nRe-enabling CI..." -ForegroundColor Yellow
-            $success = Set-CIEnabled -ConnectionString $script:connectionString -Enabled $true
+        # Re-enable CI and store (CI is always enabled for this project)
+        Write-Host "`nRe-enabling CI..." -ForegroundColor Yellow
+        $success = Set-CIEnabled -ConnectionString $script:connectionString -Enabled $true
 
-            if (-not $success) {
-                Write-ErrorMessage "Failed to re-enable CI"
-                return
+        if (-not $success) {
+            Write-ErrorMessage "Failed to re-enable CI"
+            return
+        }
+
+        Write-Success "CI re-enabled"
+
+        Write-Host "`nStoring CI objects..." -ForegroundColor Gray
+        Push-Location "src/Goldfinch.Web"
+        try {
+            & dotnet run --no-build --kxp-ci-store
+
+            if ($LASTEXITCODE -eq 0) {
+                Write-Success "CI objects stored successfully"
+            } else {
+                Write-ErrorMessage "Failed to store CI objects. Run 'dotnet run --kxp-ci-store' manually after fixing issues."
             }
-
-            Write-Success "CI re-enabled"
-
-            Write-Host "`nStoring CI objects..." -ForegroundColor Gray
-            Push-Location "src/Goldfinch.Web"
-            try {
-                & dotnet run --no-build --kxp-ci-store
-
-                if ($LASTEXITCODE -eq 0) {
-                    Write-Success "CI objects stored successfully"
-                } else {
-                    Write-ErrorMessage "Failed to store CI objects. Run 'dotnet run --kxp-ci-store' manually after fixing issues."
-                }
-            } finally {
-                Pop-Location
-            }
+        } finally {
+            Pop-Location
         }
 
     } catch {
         Write-ErrorMessage "Failed to run Kentico update: $_"
     } finally {
-        # Always re-enable CI if it was originally on — runs whether the update succeeded or failed
-        if ($script:ciWasEnabled -and $null -ne $script:connectionString) {
+        # Always leave CI enabled — runs whether the update succeeded or failed
+        if ($null -ne $script:connectionString) {
             try {
                 $currentCIState = Get-CIEnabled -ConnectionString $script:connectionString
                 if (-not $currentCIState) {


### PR DESCRIPTION
## Problem

`Update-Xperience.ps1` read `CMSEnableCI` from the DB at the start of the run and gated **all** CI work behind `if ($script:ciWasEnabled)`. When CI was found disabled it skipped:

- the CI pre-restore (`--kxp-ci-restore`) before the package update,
- the disable/re-enable toggle, and
- the final `--kxp-ci-store`.

The failure mode: if a previous run was interrupted between "disable CI" and "re-enable CI", the DB is left at `CMSEnableCI=False`. The script's `finally` safety net only re-enables CI if it was on *at that run's start*, so every subsequent run keeps silently skipping CI — packages and the DB migrate, but `App_Data/CIRepository/` is never re-serialized. This actually happened on a local `31.5.3 → 31.6.0` run.

## Fix

CI is always expected to be enabled for this project, so the script no longer makes CI work conditional:

- `Invoke-CIPreRestore` now **enables CI unconditionally** before the restore (self-healing a DB left disabled), rather than skipping.
- The re-enable + `--kxp-ci-store` after `--kxp-update` always run — removed the `if ($script:ciWasEnabled)` guards and the now-unused `$script:ciWasEnabled` variable.
- The `finally` block always leaves CI enabled.
- `SKILL.md` updated to document the always-on behaviour.

## Testing

- `[System.Management.Automation.Language.Parser]::ParseFile(...)` → **PARSE OK**.
- No functional change for the normal case (CI already enabled). Behaviour only differs when CI is found disabled, where it now self-heals instead of no-op-ing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)