### PR TITLE
fix(web): exclude Management API from production builds

### DIFF
--- a/src/Goldfinch.Web/Goldfinch.Web.csproj
+++ b/src/Goldfinch.Web/Goldfinch.Web.csproj
@@ -2,7 +2,8 @@
 	<ItemGroup>
 		<PackageReference Include="Kentico.Xperience.Admin" />
 		<PackageReference Include="Kentico.Xperience.AzureStorage" />
-		<PackageReference Include="Kentico.Xperience.ManagementApi" />
+		<!-- Local-development-only tool; excluded from Release builds so it never ships to production. See Program.cs (#if DEBUG). -->
+		<PackageReference Include="Kentico.Xperience.ManagementApi" Condition="'$(Configuration)' == 'Debug'" />
 		<PackageReference Include="Kentico.Xperience.MiniProfiler" />
 		<PackageReference Include="Kentico.Xperience.WebApp" />
 		<PackageReference Include="Schema.NET" />

--- a/src/Goldfinch.Web/Program.cs
+++ b/src/Goldfinch.Web/Program.cs
@@ -9,7 +9,9 @@ using Kentico.Membership;
 using Kentico.PageBuilder.Web.Mvc;
 using Kentico.Web.Mvc;
 using Kentico.Xperience.Admin.Base;
+#if DEBUG
 using Kentico.Xperience.ManagementApi;
+#endif
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Routing;
@@ -99,10 +101,19 @@ if (env.IsDevelopment())
         options.PopupRenderPosition = RenderPosition.BottomLeft;
     });
 
+#if DEBUG
+    // The Management API is a local-development-only tool and must never ship to production
+    // (per Kentico's own guidance). The Kentico.Xperience.ManagementApi package is referenced
+    // only in Debug builds (see Goldfinch.Web.csproj), so this call, the using directive, and the
+    // UseKenticoManagementApi() middleware below are all compiled out of Release builds. This keeps
+    // the assembly — and its auto-initialising ManagementApiModule — out of the production
+    // deployment entirely, which also avoids the 31.6.0-preview startup crash where the module
+    // resolves IOpenApiReferenceRegister even when the API was never enabled.
     builder.Services.AddKenticoManagementApi(options =>
     {
         options.Secret = "HelloThisIsMySuperSuperSecretApiKey";
     });
+#endif
 }
 else
 {
@@ -130,10 +141,12 @@ app.UseStaticFiles();
 
 app.UseAuthentication();
 
+#if DEBUG
 if (builder.Environment.IsDevelopment())
 {
     app.UseKenticoManagementApi();
 }
+#endif
 
 app.UseKentico();
 


### PR DESCRIPTION
## Incident

After the Xperience 31.6.0 update (#227) deployed to production, the site returned **503 Application Error**. The container was crash-looping with **exit code 134 (SIGABRT)** ~24s into startup, surfaced by Azure as `ContainerTimeout`.

## Root cause

The startup failure log shows:

```
Unhandled exception. System.InvalidOperationException: No service for type
'Kentico.Xperience.ManagementApi.IOpenApiReferenceRegister' has been registered.
   at Kentico.Xperience.ManagementApi.ManagementApiModule.OnInit(...)
   at CMS.Core.AppCore.Init()
   at Kentico.Web.Mvc.IApplicationBuilderExtensions.InitKentico(...)
```

In `Kentico.Xperience.ManagementApi` **31.6.0-preview**, the auto-registered `ManagementApiModule.OnInit()` does:

```csharp
var options = parameters.Services.GetService<IOptions<ManagementApiOptions>>();
if (options?.Value != null)   // always true — IOptions<T>.Value never returns null
{
    var register = parameters.Services.GetRequiredService<IOpenApiReferenceRegister>();  // throws
    ...
}
```

`IOpenApiReferenceRegister` is only registered by `AddKenticoManagementApi()`, which this project calls **dev-only** (the API is a local-development tool that must not ship to production). Because the package assembly is always referenced, the module initialises on every startup — so production threw before the app could bind a port. (This appears to be a Kentico bug: the asset block immediately below uses `GetService` + a null check, which is the correct pattern.)

## Fix

The Management API should not be present in production at all. So it's excluded from Release builds rather than enabled in prod:

- **`Goldfinch.Web.csproj`** — reference `Kentico.Xperience.ManagementApi` only when `Configuration == Debug`.
- **`Program.cs`** — compile out the `using`, `AddKenticoManagementApi()`, and `UseKenticoManagementApi()` with `#if DEBUG`.

The deploy pipeline publishes `-c Release`, so the assembly and its auto-initialising module never reach production.

## Verification

- ✅ `dotnet publish -c Release` output no longer contains `Kentico.Xperience.ManagementApi.dll`.
- ✅ Debug build still includes it for local development.
- ✅ Both configurations build with 0 warnings / 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
