### PR TITLE
Reading-minutes: compute from full body content instead of summary

### DIFF
--- a/src/Goldfinch.Core/Search/BlogPostSearchIndexingStrategy.cs
+++ b/src/Goldfinch.Core/Search/BlogPostSearchIndexingStrategy.cs
@@ -71,7 +71,7 @@ public class BlogPostSearchIndexingStrategy : DefaultLuceneIndexingStrategy
         var rawHtml = await _webCrawler.CrawlWebPage(page);
         var body = _htmlSanitizer.SanitizeHtmlDocument(rawHtml);
 
-        var readingMinutes = EstimateReadingMinutes(body);
+        var readingMinutes = ReadingTimeEstimator.EstimateMinutes(body);
 
         var url = string.Empty;
         try
@@ -116,17 +116,5 @@ public class BlogPostSearchIndexingStrategy : DefaultLuceneIndexingStrategy
         var result = await _queryExecutor.GetMappedWebPageResult<BlogPost>(builder);
 
         return result.FirstOrDefault();
-    }
-
-    private static int EstimateReadingMinutes(string body)
-    {
-        if (string.IsNullOrWhiteSpace(body))
-        {
-            return 1;
-        }
-
-        var wordCount = body.Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries).Length;
-
-        return Math.Max(1, (int)Math.Ceiling((double)wordCount / BlogSearchConstants.WORDS_PER_MINUTE));
     }
 }

--- a/src/Goldfinch.Core/Search/ILuceneBlogSearchService.cs
+++ b/src/Goldfinch.Core/Search/ILuceneBlogSearchService.cs
@@ -15,4 +15,12 @@ public interface ILuceneBlogSearchService
     /// <param name="tag">Optional tag slug to scope results to.</param>
     /// <param name="limit">Maximum number of post hits to return.</param>
     IReadOnlyList<BlogSearchResult> SearchPosts(string query, string? tag, int limit);
+
+    /// <summary>
+    /// Looks up the reading-minutes value stored for a post by its absolute URL. Returns
+    /// <c>null</c> if the post hasn't been indexed yet (e.g. published since the last reindex) —
+    /// callers should fall back to <see cref="ReadingTimeEstimator"/> in that case.
+    /// </summary>
+    /// <param name="url">The post's absolute, root-relative URL (e.g. <c>/blog/my-post</c>).</param>
+    int? GetReadingMinutes(string url);
 }

--- a/src/Goldfinch.Core/Search/LuceneBlogSearchService.cs
+++ b/src/Goldfinch.Core/Search/LuceneBlogSearchService.cs
@@ -106,6 +106,23 @@ public class LuceneBlogSearchService : ILuceneBlogSearchService
         });
     }
 
+    public int? GetReadingMinutes(string url)
+    {
+        var index = _indexManager.GetRequiredIndex(BlogSearchConstants.INDEX_NAME);
+
+        return _searchService.UseSearcher(index, searcher =>
+        {
+            var topDocs = searcher.Search(new TermQuery(new Term(BaseDocumentProperties.URL, url)), 1);
+            if (topDocs.ScoreDocs.Length == 0)
+            {
+                return (int?)null;
+            }
+
+            var doc = searcher.Doc(topDocs.ScoreDocs[0].Doc);
+            return doc.GetField(BlogSearchConstants.FIELD_READING_MINUTES)?.GetInt32Value();
+        });
+    }
+
     private static void AddFieldClauses(BooleanQuery target, QueryBuilder queryBuilder, string field, string query, float phraseBoost, float termBoost)
     {
         // Phrase clause: rewards an exact/near-exact match of the whole query in this field.

--- a/src/Goldfinch.Core/Search/ReadingTimeEstimator.cs
+++ b/src/Goldfinch.Core/Search/ReadingTimeEstimator.cs
@@ -1,0 +1,23 @@
+using System;
+
+namespace Goldfinch.Core.Search;
+
+/// <summary>
+/// Word-count/200wpm reading-time estimate. Used by the Lucene indexing strategy against the
+/// full crawled post body, and reused as a fallback (against the shorter summary) wherever a
+/// post hasn't been indexed yet.
+/// </summary>
+public static class ReadingTimeEstimator
+{
+    public static int EstimateMinutes(string? text)
+    {
+        if (string.IsNullOrWhiteSpace(text))
+        {
+            return 1;
+        }
+
+        var wordCount = text.Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries).Length;
+
+        return Math.Max(1, (int)Math.Ceiling((double)wordCount / BlogSearchConstants.WORDS_PER_MINUTE));
+    }
+}

--- a/src/Goldfinch.Web/Components/ViewComponents/LatestBlogPosts/LatestBlogPostsViewComponent.cs
+++ b/src/Goldfinch.Web/Components/ViewComponents/LatestBlogPosts/LatestBlogPostsViewComponent.cs
@@ -1,5 +1,6 @@
 ﻿using CMS.Websites;
 using Goldfinch.Core.BlogPosts;
+using Goldfinch.Core.Search;
 using Goldfinch.Web.Features.BlogDetail;
 using Goldfinch.Web.Features.BlogList;
 using Kentico.Content.Web.Mvc;
@@ -18,19 +19,22 @@ public class LatestBlogPostsViewComponent : ViewComponent
     private readonly IWebPageDataContextRetriever _pageDataContextRetriever;
     private readonly IBlogTagService _blogTagService;
     private readonly IPreferredLanguageRetriever _preferredLanguageRetriever;
+    private readonly ILuceneBlogSearchService _luceneBlogSearchService;
 
     public LatestBlogPostsViewComponent(
         IWebPageUrlRetriever pageUrlRetriever,
         IBlogPostService blogPostService,
         IWebPageDataContextRetriever pageDataContextRetriever,
         IBlogTagService blogTagService,
-        IPreferredLanguageRetriever preferredLanguageRetriever)
+        IPreferredLanguageRetriever preferredLanguageRetriever,
+        ILuceneBlogSearchService luceneBlogSearchService)
     {
         _pageUrlRetriever = pageUrlRetriever;
         _blogPostService = blogPostService;
         _pageDataContextRetriever = pageDataContextRetriever;
         _blogTagService = blogTagService;
         _preferredLanguageRetriever = preferredLanguageRetriever;
+        _luceneBlogSearchService = luceneBlogSearchService;
     }
 
     public async Task<IViewComponentResult> InvokeAsync(string title)
@@ -51,7 +55,7 @@ public class LatestBlogPostsViewComponent : ViewComponent
 
         foreach (var blogPost in blogPosts)
         {
-            var blogPostViewModel = await BlogPostViewModel.GetViewModelAsync(blogPost, _pageUrlRetriever);
+            var blogPostViewModel = await BlogPostViewModel.GetViewModelAsync(blogPost, _pageUrlRetriever, _luceneBlogSearchService);
 
             if (blogPost.BlogPostTags?.Any() == true)
             {

--- a/src/Goldfinch.Web/Features/BlogDetail/BlogDetail.cshtml
+++ b/src/Goldfinch.Web/Features/BlogDetail/BlogDetail.cshtml
@@ -45,6 +45,8 @@
                 <time datetime="@Model.BlogPostDate.ToString("yyyy-MM-dd")">@Model.BlogPostDate.ToString("dd MMM yyyy")</time>
                 <span class="sep">·</span>
                 <span>by <a href="/about" class="author-name">liam</a></span>
+                <span class="sep">·</span>
+                <span class="clock"><icon name="clock" size="12" /> @Model.ReadingMinutes min read</span>
             </div>
             <h1>@Model.Title</h1>
             @if (!string.IsNullOrWhiteSpace(Model.Summary))

--- a/src/Goldfinch.Web/Features/BlogDetail/BlogDetailController.cs
+++ b/src/Goldfinch.Web/Features/BlogDetail/BlogDetailController.cs
@@ -1,6 +1,7 @@
 ﻿using CMS.Websites;
 using Goldfinch.Core.BlogPosts;
 using Goldfinch.Core.ContentTypes;
+using Goldfinch.Core.Search;
 using Goldfinch.Web.Features.BlogDetail;
 using Goldfinch.Web.Features.BlogList;
 using Kentico.Content.Web.Mvc;
@@ -26,19 +27,22 @@ public class BlogDetailController : Controller
     private readonly IWebPageUrlRetriever _webPageUrlRetriever;
     private readonly IWebPageDataContextRetriever _webPageDataContextRetriever;
     private readonly IPreferredLanguageRetriever _preferredLanguageRetriever;
+    private readonly ILuceneBlogSearchService _luceneBlogSearchService;
 
     public BlogDetailController(
         IBlogPostService blogPostService,
         IBlogTagService blogTagService,
         IWebPageDataContextRetriever webPageDataContextRetriever,
         IWebPageUrlRetriever webPageUrlRetriever,
-        IPreferredLanguageRetriever preferredLanguageRetriever)
+        IPreferredLanguageRetriever preferredLanguageRetriever,
+        ILuceneBlogSearchService luceneBlogSearchService)
     {
         _blogPostService = blogPostService;
         _blogTagService = blogTagService;
         _webPageDataContextRetriever = webPageDataContextRetriever;
         _webPageUrlRetriever = webPageUrlRetriever;
         _preferredLanguageRetriever = preferredLanguageRetriever;
+        _luceneBlogSearchService = luceneBlogSearchService;
     }
 
     public async Task<IActionResult> Index()
@@ -57,7 +61,7 @@ public class BlogDetailController : Controller
             return NotFound();
         }
 
-        var viewModel = await BlogPostViewModel.GetViewModelAsync(currentPage, _webPageUrlRetriever);
+        var viewModel = await BlogPostViewModel.GetViewModelAsync(currentPage, _webPageUrlRetriever, _luceneBlogSearchService);
 
         if (currentPage.BlogPostTags?.Any() == true)
         {

--- a/src/Goldfinch.Web/Features/BlogDetail/BlogPostViewModel.cs
+++ b/src/Goldfinch.Web/Features/BlogDetail/BlogPostViewModel.cs
@@ -1,5 +1,7 @@
 using CMS.Websites;
 using Goldfinch.Core.ContentTypes;
+using Goldfinch.Core.Extensions;
+using Goldfinch.Core.Search;
 using Goldfinch.Web.Features.BlogList;
 using System;
 using System.Collections.Generic;
@@ -26,9 +28,22 @@ public class BlogPostViewModel
     /// <summary>Tags assigned to this post, for display in list view rows.</summary>
     public IReadOnlyList<BlogTagViewModel> Tags { get; set; } = [];
 
-    public static async Task<BlogPostViewModel> GetViewModelAsync(BlogPost blogPost, IWebPageUrlRetriever pageUrlRetriever)
+    /// <summary>
+    /// Reading time in minutes. Read from the <c>BlogPosts</c> Lucene index (computed there from
+    /// the full post body); falls back to a summary-based estimate if the post hasn't been
+    /// indexed yet.
+    /// </summary>
+    public int ReadingMinutes { get; set; }
+
+    public static async Task<BlogPostViewModel> GetViewModelAsync(
+        BlogPost blogPost,
+        IWebPageUrlRetriever pageUrlRetriever,
+        ILuceneBlogSearchService readingTimeService)
     {
         var url = (await pageUrlRetriever.Retrieve(blogPost)).RelativePath;
+        var readingMinutes = readingTimeService.GetReadingMinutes(url.ToAbsolutePath())
+            ?? ReadingTimeEstimator.EstimateMinutes(blogPost.BaseContentShortDescription);
+
         return new BlogPostViewModel
         {
             Title = blogPost.BaseContentTitle,
@@ -36,6 +51,7 @@ public class BlogPostViewModel
             BlogPostDate = blogPost.BlogPostDate,
             Url = url,
             Filename = FilenameFromUrl(url),
+            ReadingMinutes = readingMinutes,
         };
     }
 

--- a/src/Goldfinch.Web/Features/BlogList/BlogListController.cs
+++ b/src/Goldfinch.Web/Features/BlogList/BlogListController.cs
@@ -8,6 +8,7 @@ using Goldfinch.Core.BlogPosts;
 using Goldfinch.Core.ContentTypes;
 using Goldfinch.Core.SEO.Constants;
 using Goldfinch.Core.Extensions;
+using Goldfinch.Core.Search;
 using Goldfinch.Web.Features.BlogDetail;
 using Goldfinch.Web.Features.BlogList;
 using Kentico.Content.Web.Mvc;
@@ -35,6 +36,7 @@ public class BlogListController : Controller
     private readonly IBlogTagService _blogTagService;
     private readonly IPreferredLanguageRetriever _preferredLanguageRetriever;
     private readonly IWebsiteChannelContext _websiteChannelContext;
+    private readonly ILuceneBlogSearchService _luceneBlogSearchService;
 
     public BlogListController(
         IWebPageDataContextInitializer webPageDataContextInitializer,
@@ -43,7 +45,8 @@ public class BlogListController : Controller
         IBlogPostService blogPostService,
         IBlogTagService blogTagService,
         IPreferredLanguageRetriever preferredLanguageRetriever,
-        IWebsiteChannelContext websiteChannelContext)
+        IWebsiteChannelContext websiteChannelContext,
+        ILuceneBlogSearchService luceneBlogSearchService)
     {
         _webPageDataContextInitializer = webPageDataContextInitializer;
         _webPageUrlRetriever = webPageUrlRetriever;
@@ -52,6 +55,7 @@ public class BlogListController : Controller
         _blogTagService = blogTagService;
         _preferredLanguageRetriever = preferredLanguageRetriever;
         _websiteChannelContext = websiteChannelContext;
+        _luceneBlogSearchService = luceneBlogSearchService;
     }
 
     public async Task<IActionResult> Index(int page = 1, string? tag = null, string? q = null, string? view = null)
@@ -135,7 +139,7 @@ public class BlogListController : Controller
 
         foreach (var blogPost in pageItems)
         {
-            var vm = await BlogPostViewModel.GetViewModelAsync(blogPost, _webPageUrlRetriever);
+            var vm = await BlogPostViewModel.GetViewModelAsync(blogPost, _webPageUrlRetriever, _luceneBlogSearchService);
 
             if (blogPost.BlogPostTags?.Any() == true)
             {

--- a/src/Goldfinch.Web/Features/BlogList/Listing.cshtml
+++ b/src/Goldfinch.Web/Features/BlogList/Listing.cshtml
@@ -141,7 +141,7 @@
                                 <span class="post-tag mono">#@tag.Slug</span>
                             }
                         </div>
-                        <span class="post-list__mins">4m</span>
+                        <span class="post-list__mins">@(post.ReadingMinutes)m</span>
                     </a>
                 }
             </div>
@@ -156,7 +156,7 @@
                     <div class="post-card__head">
                         <span class="post-card__dots"><span></span><span></span><span></span></span>
                         <span class="post-card__filename">@post.Filename</span>
-                        <span class="post-card__mins">4 min</span>
+                        <span class="post-card__mins">@post.ReadingMinutes min</span>
                     </div>
                     <div class="post-card__thumb">
                         <partial name="PartialViews/_PostCardDots" />

--- a/src/Goldfinch.Web/Features/Home/Components/HomePageViewComponent.cs
+++ b/src/Goldfinch.Web/Features/Home/Components/HomePageViewComponent.cs
@@ -3,6 +3,8 @@ using System.Linq;
 using System.Threading.Tasks;
 using CMS.Websites;
 using Goldfinch.Core.BlogPosts;
+using Goldfinch.Core.Extensions;
+using Goldfinch.Core.Search;
 using Goldfinch.Core.SiteStats;
 using Goldfinch.Web.Features.BlogDetail;
 using Goldfinch.Web.Features.BlogList;
@@ -26,19 +28,22 @@ public class HomePageViewComponent : ViewComponent
     private readonly IWebPageUrlRetriever _urlRetriever;
     private readonly IBlogTagService _blogTagService;
     private readonly IPreferredLanguageRetriever _preferredLanguageRetriever;
+    private readonly ILuceneBlogSearchService _luceneBlogSearchService;
 
     public HomePageViewComponent(
         IContentRetriever contentRetriever,
         IBlogPostService blogPostService,
         IWebPageUrlRetriever urlRetriever,
         IBlogTagService blogTagService,
-        IPreferredLanguageRetriever preferredLanguageRetriever)
+        IPreferredLanguageRetriever preferredLanguageRetriever,
+        ILuceneBlogSearchService luceneBlogSearchService)
     {
         _contentRetriever = contentRetriever;
         _blogPostService = blogPostService;
         _urlRetriever = urlRetriever;
         _blogTagService = blogTagService;
         _preferredLanguageRetriever = preferredLanguageRetriever;
+        _luceneBlogSearchService = luceneBlogSearchService;
     }
 
     public async Task<IViewComponentResult> InvokeAsync(RoutedWebPage page, HomePageTemplateProperties props)
@@ -67,7 +72,7 @@ public class HomePageViewComponent : ViewComponent
                 Url: topUrl,
                 Filename: BlogPostViewModel.FilenameFromUrl(topUrl),
                 PublishedOn: top.BlogPostDate,
-                ReadingMinutes: EstimateReadingMinutes(top.BaseContentShortDescription),
+                ReadingMinutes: GetReadingMinutes(topUrl, top.BaseContentShortDescription),
                 Tags: topTags);
 
             foreach (var post in allPosts.Skip(1).Take(RecentPostCount))
@@ -80,7 +85,7 @@ public class HomePageViewComponent : ViewComponent
                     Url: url,
                     Filename: BlogPostViewModel.FilenameFromUrl(url),
                     PublishedOn: post.BlogPostDate,
-                    ReadingMinutes: EstimateReadingMinutes(post.BaseContentShortDescription),
+                    ReadingMinutes: GetReadingMinutes(url, post.BaseContentShortDescription),
                     Tags: tags));
             }
         }
@@ -123,15 +128,11 @@ public class HomePageViewComponent : ViewComponent
     }
 
     /// <summary>
-    /// Rough reading-time estimate based on summary length.
-    /// TODO: compute from full post body once we have a consistent way to read it.
+    /// Reading time in minutes, read from the <c>BlogPosts</c> Lucene index (computed there from
+    /// the full post body); falls back to a summary-based estimate if the post hasn't been
+    /// indexed yet.
     /// </summary>
-    private static int EstimateReadingMinutes(string? summary)
-    {
-        if (string.IsNullOrWhiteSpace(summary)) return 4;
-        var words = summary.Split(' ', System.StringSplitOptions.RemoveEmptyEntries).Length;
-        // Summary is ~40 words; multiply to approximate a full article length.
-        var estimated = System.Math.Max(3, (int)System.Math.Round(words * 0.15));
-        return System.Math.Min(15, estimated);
-    }
+    private int GetReadingMinutes(string relativeUrl, string? summary) =>
+        _luceneBlogSearchService.GetReadingMinutes(relativeUrl.ToAbsolutePath())
+            ?? ReadingTimeEstimator.EstimateMinutes(summary);
 }

--- a/src/Goldfinch.Web/Views/Shared/PartialViews/BlogPost.cshtml
+++ b/src/Goldfinch.Web/Views/Shared/PartialViews/BlogPost.cshtml
@@ -5,6 +5,7 @@
     <div class="post-card__head">
         <span class="post-card__dots"><span></span><span></span><span></span></span>
         <span class="post-card__filename">@Model.Filename</span>
+        <span class="post-card__mins">@Model.ReadingMinutes min</span>
     </div>
     <div class="post-card__thumb">
         <partial name="PartialViews/_PostCardDots" />

--- a/src/Goldfinch.Web/wwwroot/sitefiles/src/scripts/command-palette.js
+++ b/src/Goldfinch.Web/wwwroot/sitefiles/src/scripts/command-palette.js
@@ -95,7 +95,11 @@
     const active = i === state.active;
     const title = it.highlights?.title ? safeHighlight(it.highlights.title) : escape(it.title || it.label);
     const meta = it.kind === 'post'
-      ? `${(it.tags || []).map(t => `#${t}`).join(' ')} · ${formatDate(it.date)}`
+      ? [
+          (it.tags || []).map(t => `#${t}`).join(' '),
+          formatDate(it.date),
+          it.reading_minutes ? `${it.reading_minutes}m` : '',
+        ].filter(Boolean).join(' · ')
       : it.kind === 'tag'
         ? `${it.post_count} post${it.post_count === 1 ? '' : 's'}`
         : '';

--- a/src/Goldfinch.Web/wwwroot/sitefiles/src/scripts/search.js
+++ b/src/Goldfinch.Web/wwwroot/sitefiles/src/scripts/search.js
@@ -65,12 +65,19 @@
         headers: { Accept: 'application/json' },
       });
       const data = await res.json();
-      resultsEl.innerHTML = (data.results || []).map(r => `
+      resultsEl.innerHTML = (data.results || []).map(r => {
+        const meta = [
+          (r.tags || []).map(t => `#${t}`).join(' '),
+          r.date ? formatDate(r.date) : '',
+          r.reading_minutes ? `${r.reading_minutes}m` : '',
+        ].filter(Boolean).join(' · ');
+        return `
         <a class="live-search-item" href="${escape(r.url)}">
           <span class="live-search-item__title">${r.highlights?.title ? safeHighlight(r.highlights.title) : escape(r.title || r.label)}</span>
-          ${r.date ? `<span class="live-search-item__meta mono">${formatDate(r.date)}</span>` : ''}
+          ${meta ? `<span class="live-search-item__meta mono">${escape(meta)}</span>` : ''}
         </a>
-      `).join('') || `<div class="live-search-empty mono">&gt; no results</div>`;
+      `;
+      }).join('') || `<div class="live-search-empty mono">&gt; no results</div>`;
       resultsEl.hidden = false;
     } catch (err) {
       if (err.name !== 'AbortError') {


### PR DESCRIPTION
## Summary
- Closes #203. `HomePageViewComponent.EstimateReadingMinutes()` estimated from the post summary (capped 3–15 min); the blog archive grid/list views rendered a hardcoded `4 min` / `4m` placeholder; the detail page and "Keep reading" cards showed no reading time at all.
- Per the latest comment on the issue, reuses the `ReadingMinutes` field already stored in the `BlogPosts` Lucene index (computed there from the full crawled post body) instead of building a separate extraction service. Added `ILuceneBlogSearchService.GetReadingMinutes(url)` for the lookup, with a shared `ReadingTimeEstimator` (word-count/200wpm) as a fallback for posts not yet reindexed.
- Wired the real value into every place a post renders reading time: home (featured + recent cards), `/blog` grid + list views, the detail page meta row (CSS already had an unused `.clock` class prepped for this), and the "Keep reading" cards (shared `BlogPost.cshtml` partial).
- Bonus: the command palette already showed `#tags · date` for post results but not reading time; the blog toolbar's live search only showed the date. Both `/api/search` responses already carried `tags` and `reading_minutes` — brought both dropdowns to parity (`#tags · date · Nm`).

## Test plan
- [x] `dotnet build` — clean, 0 warnings/errors
- [x] Front-end `npm run build` — clean
- [x] Ran the app locally and verified real, varied per-post values (not a uniform placeholder) on: home page cards, `/blog` grid view, `/blog?view=list`, a post detail page's meta row, the "Keep reading" cards, the blog toolbar live search dropdown, and the ⌘K command palette