### PR TITLE
fix(web): move reading-minutes off the request path entirely

### DIFF
--- a/src/Goldfinch.Core/BlogPosts/BlogPostExtensions.cs
+++ b/src/Goldfinch.Core/BlogPosts/BlogPostExtensions.cs
@@ -1,0 +1,17 @@
+using Goldfinch.Core.ContentTypes;
+using Goldfinch.Core.Search;
+
+namespace Goldfinch.Core.BlogPosts;
+
+public static class BlogPostExtensions
+{
+    /// <summary>
+    /// The reading time to display for this post: <see cref="BlogPost.BlogPostReadingMinutes"/> if
+    /// it's been set, falling back to a summary-based estimate for posts that haven't been given
+    /// one yet (e.g. published before the field existed).
+    /// </summary>
+    public static int GetEffectiveReadingMinutes(this BlogPost post) =>
+        post.BlogPostReadingMinutes > 0
+            ? post.BlogPostReadingMinutes
+            : ReadingTimeEstimator.EstimateMinutes(post.BaseContentShortDescription);
+}

--- a/src/Goldfinch.Core/ContentTypes/PageContentTypes/Goldfinch/BlogPost/BlogPost.generated.cs
+++ b/src/Goldfinch.Core/ContentTypes/PageContentTypes/Goldfinch/BlogPost/BlogPost.generated.cs
@@ -48,6 +48,12 @@ namespace Goldfinch.Core.ContentTypes
 
 
 		/// <summary>
+		/// BlogPostReadingMinutes.
+		/// </summary>
+		public int BlogPostReadingMinutes { get; set; }
+
+
+		/// <summary>
 		/// BaseContentTitle.
 		/// </summary>
 		public string BaseContentTitle { get; set; }

--- a/src/Goldfinch.Core/Search/BlogPostSearchIndexingStrategy.cs
+++ b/src/Goldfinch.Core/Search/BlogPostSearchIndexingStrategy.cs
@@ -15,8 +15,9 @@ namespace Goldfinch.Core.Search;
 
 /// <summary>
 /// Lucene indexing strategy for <see cref="BlogPost"/> web pages. Indexes the title, summary,
-/// resolved tag slugs, publish date, an estimated reading time, and the full rendered post body
-/// (crawled and sanitized to plain text, since the body lives in Page Builder editable areas).
+/// resolved tag slugs, publish date, reading time, and the full rendered post body (crawled and
+/// sanitized to plain text, since the body lives in Page Builder editable areas — still needed for
+/// full-text matching even though reading time itself now comes from the post's own field).
 /// </summary>
 public class BlogPostSearchIndexingStrategy : DefaultLuceneIndexingStrategy
 {
@@ -67,11 +68,13 @@ public class BlogPostSearchIndexingStrategy : DefaultLuceneIndexingStrategy
             tagSlugs = tags.Select(t => t.Name).ToArray();
         }
 
-        // Crawl the rendered page and reduce it to the post body text.
+        // Crawl the rendered page and reduce it to the post body text (used for full-text matching).
         var rawHtml = await _webCrawler.CrawlWebPage(page);
         var body = _htmlSanitizer.SanitizeHtmlDocument(rawHtml);
 
-        var readingMinutes = ReadingTimeEstimator.EstimateMinutes(body);
+        // Reading time is a normal editor-set field now (no longer computed from a separate async
+        // write that could race the reindex task), so read it directly instead of recomputing it.
+        var readingMinutes = page.GetEffectiveReadingMinutes();
 
         var url = string.Empty;
         try

--- a/src/Goldfinch.Core/Search/ILuceneBlogSearchService.cs
+++ b/src/Goldfinch.Core/Search/ILuceneBlogSearchService.cs
@@ -15,12 +15,4 @@ public interface ILuceneBlogSearchService
     /// <param name="tag">Optional tag slug to scope results to.</param>
     /// <param name="limit">Maximum number of post hits to return.</param>
     IReadOnlyList<BlogSearchResult> SearchPosts(string query, string? tag, int limit);
-
-    /// <summary>
-    /// Looks up the reading-minutes value stored for a post by its absolute URL. Returns
-    /// <c>null</c> if the post hasn't been indexed yet (e.g. published since the last reindex) —
-    /// callers should fall back to <see cref="ReadingTimeEstimator"/> in that case.
-    /// </summary>
-    /// <param name="url">The post's absolute, root-relative URL (e.g. <c>/blog/my-post</c>).</param>
-    int? GetReadingMinutes(string url);
 }

--- a/src/Goldfinch.Core/Search/LuceneBlogSearchService.cs
+++ b/src/Goldfinch.Core/Search/LuceneBlogSearchService.cs
@@ -106,23 +106,6 @@ public class LuceneBlogSearchService : ILuceneBlogSearchService
         });
     }
 
-    public int? GetReadingMinutes(string url)
-    {
-        var index = _indexManager.GetRequiredIndex(BlogSearchConstants.INDEX_NAME);
-
-        return _searchService.UseSearcher(index, searcher =>
-        {
-            var topDocs = searcher.Search(new TermQuery(new Term(BaseDocumentProperties.URL, url)), 1);
-            if (topDocs.ScoreDocs.Length == 0)
-            {
-                return (int?)null;
-            }
-
-            var doc = searcher.Doc(topDocs.ScoreDocs[0].Doc);
-            return doc.GetField(BlogSearchConstants.FIELD_READING_MINUTES)?.GetInt32Value();
-        });
-    }
-
     private static void AddFieldClauses(BooleanQuery target, QueryBuilder queryBuilder, string field, string query, float phraseBoost, float termBoost)
     {
         // Phrase clause: rewards an exact/near-exact match of the whole query in this field.

--- a/src/Goldfinch.Core/Search/PageBuilderTextExtractor.cs
+++ b/src/Goldfinch.Core/Search/PageBuilderTextExtractor.cs
@@ -1,0 +1,56 @@
+using System.Text;
+using System.Text.Json;
+using System.Text.RegularExpressions;
+
+namespace Goldfinch.Core.Search;
+
+/// <summary>
+/// Extracts plain text from a page's raw Page Builder JSON (the
+/// <c>ContentItemCommonDataVisualBuilderWidgets</c> column) for word-counting, without needing the
+/// page to be live/rendered. Walks every widget property generically rather than per widget type —
+/// collects every string value found anywhere in the tree, strips HTML tags, and trims whitespace.
+/// Picks up some non-prose noise (GUIDs, type identifiers, a code block's language tag) alongside
+/// real content; negligible for a coarse reading-time estimate.
+/// </summary>
+public static class PageBuilderTextExtractor
+{
+    private static readonly Regex TagRegex = new("<[^>]+>", RegexOptions.Compiled);
+    private static readonly Regex WhitespaceRegex = new(@"\s+", RegexOptions.Compiled);
+
+    public static string ExtractText(string? visualBuilderWidgetsJson)
+    {
+        if (string.IsNullOrWhiteSpace(visualBuilderWidgetsJson))
+        {
+            return string.Empty;
+        }
+
+        var sb = new StringBuilder();
+        using var doc = JsonDocument.Parse(visualBuilderWidgetsJson);
+        CollectStrings(doc.RootElement, sb);
+
+        var withoutTags = TagRegex.Replace(sb.ToString(), " ");
+        return WhitespaceRegex.Replace(withoutTags, " ").Trim();
+    }
+
+    private static void CollectStrings(JsonElement element, StringBuilder sb)
+    {
+        switch (element.ValueKind)
+        {
+            case JsonValueKind.Object:
+                foreach (var property in element.EnumerateObject())
+                {
+                    CollectStrings(property.Value, sb);
+                }
+                break;
+            case JsonValueKind.Array:
+                foreach (var item in element.EnumerateArray())
+                {
+                    CollectStrings(item, sb);
+                }
+                break;
+            case JsonValueKind.String:
+                sb.Append(' ').Append(element.GetString());
+                break;
+        }
+    }
+}

--- a/src/Goldfinch.Web/App_Data/CIRepository/@global/cms.contenttype/goldfinch.blogpost.xml
+++ b/src/Goldfinch.Web/App_Data/CIRepository/@global/cms.contenttype/goldfinch.blogpost.xml
@@ -39,6 +39,21 @@
           </TaxonomyGroup>
         </settings>
       </field>
+      <field allowempty="true" column="BlogPostReadingMinutes" columnprecision="0" columntype="integer" enabled="true" guid="b6c23f6f-314d-4325-a3b4-ee918c8aa30a" visible="true">
+        <properties>
+          <defaultvalue>0</defaultvalue>
+          <explanationtextashtml>False</explanationtextashtml>
+          <fieldcaption>Reading time (minutes)</fieldcaption>
+          <fielddescription>
+            <![CDATA[Estimated reading time shown on the post. Leave at 0 to fall back to an automatic estimate based on the summary.]]>
+          </fielddescription>
+          <fielddescriptionashtml>False</fielddescriptionashtml>
+        </properties>
+        <settings>
+          <controlname>Kentico.Administration.NumberInput</controlname>
+          <WatermarkText>e.g. 5</WatermarkText>
+        </settings>
+      </field>
     </form>
   </ClassFormDefinition>
   <ClassGUID>c3495cd5-11e9-4fca-a6be-85123e9e4b6e</ClassGUID>

--- a/src/Goldfinch.Web/App_Data/CIRepository/Goldfinch/cms.contentitemcommondata/settingupazurekeyv..erience13-ytfw3kll@626658a663/0cbd0d7b-450f-411f-b3d6-f0d7ee79374f_en@b8e9879cd5.xml
+++ b/src/Goldfinch.Web/App_Data/CIRepository/Goldfinch/cms.contentitemcommondata/settingupazurekeyv..erience13-ytfw3kll@626658a663/0cbd0d7b-450f-411f-b3d6-f0d7ee79374f_en@b8e9879cd5.xml
@@ -16,7 +16,7 @@
   </ContentItemCommonDataContentLanguageID>
   <ContentItemCommonDataGUID>0cbd0d7b-450f-411f-b3d6-f0d7ee79374f</ContentItemCommonDataGUID>
   <ContentItemCommonDataIsLatest>True</ContentItemCommonDataIsLatest>
-  <ContentItemCommonDataLastPublishedWhen>2026-06-09 19:27:34Z</ContentItemCommonDataLastPublishedWhen>
+  <ContentItemCommonDataLastPublishedWhen>2026-06-30 21:48:28Z</ContentItemCommonDataLastPublishedWhen>
   <ContentItemCommonDataVersionStatus>2</ContentItemCommonDataVersionStatus>
   <ContentItemCommonDataVisualBuilderTemplateConfiguration />
   <ContentItemCommonDataVisualBuilderWidgets>
@@ -323,7 +323,7 @@
   <ContentItemReferences>
     <cms.contentitemreference>
       <ContentItemReferenceGroupGUID>f151233e-6d89-4b39-bff0-f8e822e96875</ContentItemReferenceGroupGUID>
-      <ContentItemReferenceGUID>97371d3e-99d8-4552-89b7-12310304d4c8</ContentItemReferenceGUID>
+      <ContentItemReferenceGUID>a582c6d9-c022-4e6c-a4b2-53d29b46f5de</ContentItemReferenceGUID>
       <ContentItemReferenceSourceCommonDataID>
         <GUID>0cbd0d7b-450f-411f-b3d6-f0d7ee79374f</GUID>
         <ObjectType>cms.contentitemcommondata</ObjectType>

--- a/src/Goldfinch.Web/App_Data/CIRepository/Goldfinch/contentitemdata.goldfinch.blogpost/settingupazurekeyv..d6-f0d7ee79374f_en@1e399ad396/c892f84f-6531-4065-9fa1-eb5ed4099170.xml
+++ b/src/Goldfinch.Web/App_Data/CIRepository/Goldfinch/contentitemdata.goldfinch.blogpost/settingupazurekeyv..d6-f0d7ee79374f_en@1e399ad396/c892f84f-6531-4065-9fa1-eb5ed4099170.xml
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <contentitemdata.goldfinch.blogpost>
   <BlogPostDate>2023-10-22 23:00:00Z</BlogPostDate>
+  <BlogPostReadingMinutes>6</BlogPostReadingMinutes>
   <BlogPostTags>
     <![CDATA[[{"Identifier":"60aba381-f44d-447f-b03f-a231d16ff797"},{"Identifier":"456c83c7-9445-4066-a381-b606797dcac7"}]]]>
   </BlogPostTags>

--- a/src/Goldfinch.Web/Components/ViewComponents/LatestBlogPosts/LatestBlogPostsViewComponent.cs
+++ b/src/Goldfinch.Web/Components/ViewComponents/LatestBlogPosts/LatestBlogPostsViewComponent.cs
@@ -1,6 +1,5 @@
 ﻿using CMS.Websites;
 using Goldfinch.Core.BlogPosts;
-using Goldfinch.Core.Search;
 using Goldfinch.Web.Features.BlogDetail;
 using Goldfinch.Web.Features.BlogList;
 using Kentico.Content.Web.Mvc;
@@ -19,22 +18,19 @@ public class LatestBlogPostsViewComponent : ViewComponent
     private readonly IWebPageDataContextRetriever _pageDataContextRetriever;
     private readonly IBlogTagService _blogTagService;
     private readonly IPreferredLanguageRetriever _preferredLanguageRetriever;
-    private readonly ILuceneBlogSearchService _luceneBlogSearchService;
 
     public LatestBlogPostsViewComponent(
         IWebPageUrlRetriever pageUrlRetriever,
         IBlogPostService blogPostService,
         IWebPageDataContextRetriever pageDataContextRetriever,
         IBlogTagService blogTagService,
-        IPreferredLanguageRetriever preferredLanguageRetriever,
-        ILuceneBlogSearchService luceneBlogSearchService)
+        IPreferredLanguageRetriever preferredLanguageRetriever)
     {
         _pageUrlRetriever = pageUrlRetriever;
         _blogPostService = blogPostService;
         _pageDataContextRetriever = pageDataContextRetriever;
         _blogTagService = blogTagService;
         _preferredLanguageRetriever = preferredLanguageRetriever;
-        _luceneBlogSearchService = luceneBlogSearchService;
     }
 
     public async Task<IViewComponentResult> InvokeAsync(string title)
@@ -55,7 +51,7 @@ public class LatestBlogPostsViewComponent : ViewComponent
 
         foreach (var blogPost in blogPosts)
         {
-            var blogPostViewModel = await BlogPostViewModel.GetViewModelAsync(blogPost, _pageUrlRetriever, _luceneBlogSearchService);
+            var blogPostViewModel = await BlogPostViewModel.GetViewModelAsync(blogPost, _pageUrlRetriever);
 
             if (blogPost.BlogPostTags?.Any() == true)
             {

--- a/src/Goldfinch.Web/Features/BlogDetail/BlogDetailController.cs
+++ b/src/Goldfinch.Web/Features/BlogDetail/BlogDetailController.cs
@@ -1,7 +1,6 @@
 ﻿using CMS.Websites;
 using Goldfinch.Core.BlogPosts;
 using Goldfinch.Core.ContentTypes;
-using Goldfinch.Core.Search;
 using Goldfinch.Web.Features.BlogDetail;
 using Goldfinch.Web.Features.BlogList;
 using Kentico.Content.Web.Mvc;
@@ -27,22 +26,19 @@ public class BlogDetailController : Controller
     private readonly IWebPageUrlRetriever _webPageUrlRetriever;
     private readonly IWebPageDataContextRetriever _webPageDataContextRetriever;
     private readonly IPreferredLanguageRetriever _preferredLanguageRetriever;
-    private readonly ILuceneBlogSearchService _luceneBlogSearchService;
 
     public BlogDetailController(
         IBlogPostService blogPostService,
         IBlogTagService blogTagService,
         IWebPageDataContextRetriever webPageDataContextRetriever,
         IWebPageUrlRetriever webPageUrlRetriever,
-        IPreferredLanguageRetriever preferredLanguageRetriever,
-        ILuceneBlogSearchService luceneBlogSearchService)
+        IPreferredLanguageRetriever preferredLanguageRetriever)
     {
         _blogPostService = blogPostService;
         _blogTagService = blogTagService;
         _webPageDataContextRetriever = webPageDataContextRetriever;
         _webPageUrlRetriever = webPageUrlRetriever;
         _preferredLanguageRetriever = preferredLanguageRetriever;
-        _luceneBlogSearchService = luceneBlogSearchService;
     }
 
     public async Task<IActionResult> Index()
@@ -61,7 +57,7 @@ public class BlogDetailController : Controller
             return NotFound();
         }
 
-        var viewModel = await BlogPostViewModel.GetViewModelAsync(currentPage, _webPageUrlRetriever, _luceneBlogSearchService);
+        var viewModel = await BlogPostViewModel.GetViewModelAsync(currentPage, _webPageUrlRetriever);
 
         if (currentPage.BlogPostTags?.Any() == true)
         {

--- a/src/Goldfinch.Web/Features/BlogDetail/BlogPostViewModel.cs
+++ b/src/Goldfinch.Web/Features/BlogDetail/BlogPostViewModel.cs
@@ -1,7 +1,6 @@
 using CMS.Websites;
+using Goldfinch.Core.BlogPosts;
 using Goldfinch.Core.ContentTypes;
-using Goldfinch.Core.Extensions;
-using Goldfinch.Core.Search;
 using Goldfinch.Web.Features.BlogList;
 using System;
 using System.Collections.Generic;
@@ -29,20 +28,15 @@ public class BlogPostViewModel
     public IReadOnlyList<BlogTagViewModel> Tags { get; set; } = [];
 
     /// <summary>
-    /// Reading time in minutes. Read from the <c>BlogPosts</c> Lucene index (computed there from
-    /// the full post body); falls back to a summary-based estimate if the post hasn't been
-    /// indexed yet.
+    /// Reading time in minutes — see <see cref="BlogPostExtensions.GetEffectiveReadingMinutes"/>.
     /// </summary>
     public int ReadingMinutes { get; set; }
 
     public static async Task<BlogPostViewModel> GetViewModelAsync(
         BlogPost blogPost,
-        IWebPageUrlRetriever pageUrlRetriever,
-        ILuceneBlogSearchService readingTimeService)
+        IWebPageUrlRetriever pageUrlRetriever)
     {
         var url = (await pageUrlRetriever.Retrieve(blogPost)).RelativePath;
-        var readingMinutes = readingTimeService.GetReadingMinutes(url.ToAbsolutePath())
-            ?? ReadingTimeEstimator.EstimateMinutes(blogPost.BaseContentShortDescription);
 
         return new BlogPostViewModel
         {
@@ -51,7 +45,7 @@ public class BlogPostViewModel
             BlogPostDate = blogPost.BlogPostDate,
             Url = url,
             Filename = FilenameFromUrl(url),
-            ReadingMinutes = readingMinutes,
+            ReadingMinutes = blogPost.GetEffectiveReadingMinutes(),
         };
     }
 

--- a/src/Goldfinch.Web/Features/BlogList/BlogListController.cs
+++ b/src/Goldfinch.Web/Features/BlogList/BlogListController.cs
@@ -8,7 +8,6 @@ using Goldfinch.Core.BlogPosts;
 using Goldfinch.Core.ContentTypes;
 using Goldfinch.Core.SEO.Constants;
 using Goldfinch.Core.Extensions;
-using Goldfinch.Core.Search;
 using Goldfinch.Web.Features.BlogDetail;
 using Goldfinch.Web.Features.BlogList;
 using Kentico.Content.Web.Mvc;
@@ -36,7 +35,6 @@ public class BlogListController : Controller
     private readonly IBlogTagService _blogTagService;
     private readonly IPreferredLanguageRetriever _preferredLanguageRetriever;
     private readonly IWebsiteChannelContext _websiteChannelContext;
-    private readonly ILuceneBlogSearchService _luceneBlogSearchService;
 
     public BlogListController(
         IWebPageDataContextInitializer webPageDataContextInitializer,
@@ -45,8 +43,7 @@ public class BlogListController : Controller
         IBlogPostService blogPostService,
         IBlogTagService blogTagService,
         IPreferredLanguageRetriever preferredLanguageRetriever,
-        IWebsiteChannelContext websiteChannelContext,
-        ILuceneBlogSearchService luceneBlogSearchService)
+        IWebsiteChannelContext websiteChannelContext)
     {
         _webPageDataContextInitializer = webPageDataContextInitializer;
         _webPageUrlRetriever = webPageUrlRetriever;
@@ -55,7 +52,6 @@ public class BlogListController : Controller
         _blogTagService = blogTagService;
         _preferredLanguageRetriever = preferredLanguageRetriever;
         _websiteChannelContext = websiteChannelContext;
-        _luceneBlogSearchService = luceneBlogSearchService;
     }
 
     public async Task<IActionResult> Index(int page = 1, string? tag = null, string? q = null, string? view = null)
@@ -139,7 +135,7 @@ public class BlogListController : Controller
 
         foreach (var blogPost in pageItems)
         {
-            var vm = await BlogPostViewModel.GetViewModelAsync(blogPost, _webPageUrlRetriever, _luceneBlogSearchService);
+            var vm = await BlogPostViewModel.GetViewModelAsync(blogPost, _webPageUrlRetriever);
 
             if (blogPost.BlogPostTags?.Any() == true)
             {

--- a/src/Goldfinch.Web/Features/Home/Components/HomePageViewComponent.cs
+++ b/src/Goldfinch.Web/Features/Home/Components/HomePageViewComponent.cs
@@ -3,8 +3,6 @@ using System.Linq;
 using System.Threading.Tasks;
 using CMS.Websites;
 using Goldfinch.Core.BlogPosts;
-using Goldfinch.Core.Extensions;
-using Goldfinch.Core.Search;
 using Goldfinch.Core.SiteStats;
 using Goldfinch.Web.Features.BlogDetail;
 using Goldfinch.Web.Features.BlogList;
@@ -28,22 +26,19 @@ public class HomePageViewComponent : ViewComponent
     private readonly IWebPageUrlRetriever _urlRetriever;
     private readonly IBlogTagService _blogTagService;
     private readonly IPreferredLanguageRetriever _preferredLanguageRetriever;
-    private readonly ILuceneBlogSearchService _luceneBlogSearchService;
 
     public HomePageViewComponent(
         IContentRetriever contentRetriever,
         IBlogPostService blogPostService,
         IWebPageUrlRetriever urlRetriever,
         IBlogTagService blogTagService,
-        IPreferredLanguageRetriever preferredLanguageRetriever,
-        ILuceneBlogSearchService luceneBlogSearchService)
+        IPreferredLanguageRetriever preferredLanguageRetriever)
     {
         _contentRetriever = contentRetriever;
         _blogPostService = blogPostService;
         _urlRetriever = urlRetriever;
         _blogTagService = blogTagService;
         _preferredLanguageRetriever = preferredLanguageRetriever;
-        _luceneBlogSearchService = luceneBlogSearchService;
     }
 
     public async Task<IViewComponentResult> InvokeAsync(RoutedWebPage page, HomePageTemplateProperties props)
@@ -72,7 +67,7 @@ public class HomePageViewComponent : ViewComponent
                 Url: topUrl,
                 Filename: BlogPostViewModel.FilenameFromUrl(topUrl),
                 PublishedOn: top.BlogPostDate,
-                ReadingMinutes: GetReadingMinutes(topUrl, top.BaseContentShortDescription),
+                ReadingMinutes: top.GetEffectiveReadingMinutes(),
                 Tags: topTags);
 
             foreach (var post in allPosts.Skip(1).Take(RecentPostCount))
@@ -85,7 +80,7 @@ public class HomePageViewComponent : ViewComponent
                     Url: url,
                     Filename: BlogPostViewModel.FilenameFromUrl(url),
                     PublishedOn: post.BlogPostDate,
-                    ReadingMinutes: GetReadingMinutes(url, post.BaseContentShortDescription),
+                    ReadingMinutes: post.GetEffectiveReadingMinutes(),
                     Tags: tags));
             }
         }
@@ -126,13 +121,4 @@ public class HomePageViewComponent : ViewComponent
         var tags = await _blogTagService.GetTagsByGuids(guids, languageName);
         return tags.Select(t => new BlogTagViewModel(t.Name, t.Title, 0)).ToList();
     }
-
-    /// <summary>
-    /// Reading time in minutes, read from the <c>BlogPosts</c> Lucene index (computed there from
-    /// the full post body); falls back to a summary-based estimate if the post hasn't been
-    /// indexed yet.
-    /// </summary>
-    private int GetReadingMinutes(string relativeUrl, string? summary) =>
-        _luceneBlogSearchService.GetReadingMinutes(relativeUrl.ToAbsolutePath())
-            ?? ReadingTimeEstimator.EstimateMinutes(summary);
 }


### PR DESCRIPTION
## Summary
- Follow-up to #235. That PR fixed reading-time accuracy by computing it from the full Lucene-indexed body, but introduced a real production regression: home page (9 lookups) went from ~75-190ms to 700-800ms, blog detail (1 lookup) to 500-700ms. Root cause confirmed from `Kentico.Xperience.Lucene.Core`'s `DefaultLuceneSearchService.UseSearcher` source — it opens a brand-new `DirectoryReader` from disk on every single call, no caching/reuse.
- Reading time is now a normal field on `BlogPost` (`BlogPostReadingMinutes`) — visible in the admin form, editable by the editor, default `0`. No more live index lookups on any render path.
- Centralized the "field if set, otherwise summary estimate" rule into one `BlogPost.GetEffectiveReadingMinutes()` extension, used consistently by `BlogPostViewModel`, `HomePageViewComponent`, and now `BlogPostSearchIndexingStrategy` too (the index used to compute its own value independently — now reads the same field, since the original reason to keep them separate, a race against an async publish-time write, no longer applies now that the field is just a normal editor-set field).
- Adds `PageBuilderTextExtractor` — reads a post's raw Page Builder JSON (`ContentItemCommonDataVisualBuilderWidgets`) and extracts plain text generically (no per-widget-type parsing) without needing the page to be live. Verified against two real posts within 1 minute of the previous crawl-based numbers. Not wired up to anything yet — groundwork for a follow-up "Regenerate" action on the admin field, so editors don't have to guess the number by hand.

## Test plan
- [x] `dotnet build` on full solution — clean, 0 warnings/errors
- [x] Verified locally: home/listing/detail/"Keep reading" cards all read the field with graceful fallback for un-backfilled posts
- [x] Verified the field is visible and editable in the admin UI (Content type field updated via Management API: visible, captioned, tooltip)
- [x] Verified `PageBuilderTextExtractor` + `ReadingTimeEstimator` against two real posts, results within 1 minute of previously-trusted values
- [ ] Backfill existing posts' reading-minutes values (manual, or via the future Regenerate action) — tracked as follow-up, not blocking this PR