### PR TITLE
feat(admin): add Regenerate button for reading-minutes field

### DIFF
--- a/src/Goldfinch.Admin/Client/babel.config.json
+++ b/src/Goldfinch.Admin/Client/babel.config.json
@@ -1,7 +1,7 @@
 {
     "presets": [
       "@babel/preset-env",
-      "@babel/preset-react",
+      ["@babel/preset-react", { "development": false }],
       "@babel/preset-typescript"
     ],
     "plugins": [

--- a/src/Goldfinch.Admin/Client/package-lock.json
+++ b/src/Goldfinch.Admin/Client/package-lock.json
@@ -10,8 +10,8 @@
       "dependencies": {
         "@kentico/xperience-admin-base": "^31.6.0",
         "@kentico/xperience-admin-components": "^31.6.0",
-        "react": "^19.1.1",
-        "react-dom": "^19.1.1"
+        "react": "^18.3.1",
+        "react-dom": "^18.3.1"
       },
       "devDependencies": {
         "@babel/core": "^8.0.1",
@@ -20,8 +20,8 @@
         "@babel/preset-react": "^8.0.1",
         "@babel/preset-typescript": "^8.0.1",
         "@kentico/xperience-webpack-config": "^31.6.0",
-        "@types/react": "^19.1.16",
-        "@types/react-dom": "^19.1.9",
+        "@types/react": "^18.3.1",
+        "@types/react-dom": "^18.3.1",
         "babel-loader": "^10.0.0",
         "webpack": "5.108.3",
         "webpack-cli": "^7.0.2",
@@ -5297,6 +5297,12 @@
       "integrity": "sha512-9Zw2KoDpi+T4PZz2G6pO2xArE0m/GSMTW1MIxF2s8ZY8x9XDO6fv9um0ydRGvcbkFLlaq8yNK6eZxnmMZtDgWQ==",
       "license": "MIT"
     },
+    "node_modules/@types/prop-types": {
+      "version": "15.7.15",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
+      "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
+      "license": "MIT"
+    },
     "node_modules/@types/qs": {
       "version": "6.9.11",
       "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.11.tgz",
@@ -5310,22 +5316,23 @@
       "dev": true
     },
     "node_modules/@types/react": {
-      "version": "19.2.17",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.17.tgz",
-      "integrity": "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==",
+      "version": "18.3.31",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.31.tgz",
+      "integrity": "sha512-vfEqpXTvwT91yhmwdfouStN2hSKwTvyRs8qpLfADyrq/kxDw0hZM7Wk9Ug1FELj8hIby+S/+kQCSRFF32nv2Qw==",
       "license": "MIT",
       "dependencies": {
+        "@types/prop-types": "*",
         "csstype": "^3.2.2"
       }
     },
     "node_modules/@types/react-dom": {
-      "version": "19.2.3",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
-      "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
+      "version": "18.3.7",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
+      "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
-        "@types/react": "^19.2.0"
+        "@types/react": "^18.0.0"
       }
     },
     "node_modules/@types/react-transition-group": {
@@ -10338,10 +10345,13 @@
       "license": "MIT"
     },
     "node_modules/react": {
-      "version": "19.2.7",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.2.7.tgz",
-      "integrity": "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==",
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      },
       "engines": {
         "node": ">=0.10.0"
       }
@@ -10486,15 +10496,16 @@
       }
     },
     "node_modules/react-dom": {
-      "version": "19.2.7",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.7.tgz",
-      "integrity": "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==",
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
+      "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
       "dependencies": {
-        "scheduler": "^0.27.0"
+        "loose-envify": "^1.1.0",
+        "scheduler": "^0.23.2"
       },
       "peerDependencies": {
-        "react": "^19.2.7"
+        "react": "^18.3.1"
       }
     },
     "node_modules/react-froala-wysiwyg": {
@@ -11049,10 +11060,13 @@
       }
     },
     "node_modules/scheduler": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
-      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
-      "license": "MIT"
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
+      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      }
     },
     "node_modules/schema-utils": {
       "version": "4.3.3",

--- a/src/Goldfinch.Admin/Client/package.json
+++ b/src/Goldfinch.Admin/Client/package.json
@@ -13,8 +13,8 @@
   "dependencies": {
     "@kentico/xperience-admin-base": "^31.6.0",
     "@kentico/xperience-admin-components": "^31.6.0",
-    "react": "^19.1.1",
-    "react-dom": "^19.1.1"
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1"
   },
   "devDependencies": {
     "@babel/core": "^8.0.1",
@@ -23,8 +23,8 @@
     "@babel/preset-react": "^8.0.1",
     "@babel/preset-typescript": "^8.0.1",
     "@kentico/xperience-webpack-config": "^31.6.0",
-    "@types/react": "^19.1.16",
-    "@types/react-dom": "^19.1.9",
+    "@types/react": "^18.3.1",
+    "@types/react-dom": "^18.3.1",
     "babel-loader": "^10.0.0",
     "webpack": "5.108.3",
     "webpack-cli": "^7.0.2",

--- a/src/Goldfinch.Admin/Client/src/entry.tsx
+++ b/src/Goldfinch.Admin/Client/src/entry.tsx
@@ -1,1 +1,2 @@
 // Exposes components from the module. All added components need to be exported.
+export * from './form-components/ReadingMinutesFormComponent';

--- a/src/Goldfinch.Admin/Client/src/form-components/ReadingMinutesFormComponent.tsx
+++ b/src/Goldfinch.Admin/Client/src/form-components/ReadingMinutesFormComponent.tsx
@@ -1,0 +1,63 @@
+import React, { useState } from 'react';
+import { type FormComponentProps, useFormComponentCommandProvider } from '@kentico/xperience-admin-base';
+import { Button, ButtonColor, FormEditMode, FormItemWrapper, Input } from '@kentico/xperience-admin-components';
+
+const REGENERATE_COMMAND_NAME = 'Regenerate';
+
+/**
+ * Registered under ClientComponentName "@goldfinch/web-admin/ReadingMinutes".
+ * Kentico automatically appends "FormComponent" when resolving the export.
+ */
+export const ReadingMinutesFormComponent = (props: FormComponentProps<number>) => {
+  const { executeCommand } = useFormComponentCommandProvider();
+  const [isRegenerating, setIsRegenerating] = useState(false);
+
+  const isDisabled = props.editMode === FormEditMode.Disabled || props.editMode === FormEditMode.ReadOnly;
+
+  const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const parsed = Number(event.target.value);
+    props.onChange?.(Number.isFinite(parsed) ? parsed : 0);
+  };
+
+  const handleRegenerate = async () => {
+    setIsRegenerating(true);
+    try {
+      const minutes = await executeCommand<number>(props, REGENERATE_COMMAND_NAME);
+      if (typeof minutes === 'number') {
+        props.onChange?.(minutes);
+      }
+    } finally {
+      setIsRegenerating(false);
+    }
+  };
+
+  return (
+    <FormItemWrapper
+      id={props.name}
+      label={props.label}
+      markAsRequired={props.required}
+      editMode={props.editMode}
+      invalid={props.invalid}
+      validationMessage={props.validationMessage}
+      statusText={props.statusText}
+      explanationText={props.explanationText}
+    >
+      <div style={{ display: 'flex', gap: '8px', alignItems: 'center' }}>
+        <Input
+          id={props.name}
+          type="number"
+          value={(props.value ?? 0).toString()}
+          onChange={handleChange}
+          disabled={isDisabled}
+        />
+        <Button
+          label="Regenerate"
+          color={ButtonColor.Secondary}
+          inProgress={isRegenerating}
+          disabled={isDisabled}
+          onClick={handleRegenerate}
+        />
+      </div>
+    </FormItemWrapper>
+  );
+};

--- a/src/Goldfinch.Admin/FormComponents/ReadingMinutes/ReadingMinutesClientProperties.cs
+++ b/src/Goldfinch.Admin/FormComponents/ReadingMinutes/ReadingMinutesClientProperties.cs
@@ -1,0 +1,7 @@
+using Kentico.Xperience.Admin.Base.Forms;
+
+namespace Goldfinch.Admin.FormComponents.ReadingMinutes;
+
+public class ReadingMinutesClientProperties : FormComponentClientProperties<int>
+{
+}

--- a/src/Goldfinch.Admin/FormComponents/ReadingMinutes/ReadingMinutesFormComponent.cs
+++ b/src/Goldfinch.Admin/FormComponents/ReadingMinutes/ReadingMinutesFormComponent.cs
@@ -1,0 +1,46 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Goldfinch.Admin.FormComponents.ReadingMinutes;
+using Goldfinch.Core.BlogPosts;
+using Kentico.Xperience.Admin.Base;
+using Kentico.Xperience.Admin.Base.Forms;
+
+[assembly: RegisterFormComponent(
+    ReadingMinutesFormComponent.IDENTIFIER,
+    typeof(ReadingMinutesFormComponent),
+    "Reading time (with regenerate)")]
+
+namespace Goldfinch.Admin.FormComponents.ReadingMinutes;
+
+/// <summary>
+/// Number input for <c>BlogPostReadingMinutes</c> with a "Regenerate" button that recomputes the
+/// value from the post's current Page Builder content (see <see cref="IBlogPostReadingMinutesRegenerator"/>),
+/// so editors don't have to estimate the number by hand.
+/// </summary>
+public class ReadingMinutesFormComponent : FormComponent<ReadingMinutesClientProperties, int>
+{
+    public const string IDENTIFIER = "Goldfinch.ReadingMinutesFormComponent";
+
+    private readonly IBlogPostReadingMinutesRegenerator _regenerator;
+
+    public ReadingMinutesFormComponent(IBlogPostReadingMinutesRegenerator regenerator)
+    {
+        _regenerator = regenerator;
+    }
+
+    public override string ClientComponentName => "@goldfinch/web-admin/ReadingMinutes";
+
+    [FormComponentCommand]
+    public async Task<ICommandResponse<int>> Regenerate(CancellationToken cancellationToken)
+    {
+        if (FormContext is not IContentItemFormContextBase context)
+        {
+            throw new InvalidOperationException("The reading-minutes form component can only be used in a content item form context.");
+        }
+
+        var minutes = await _regenerator.RegenerateAsync(context.ItemId, context.LanguageName, cancellationToken);
+
+        return ResponseFrom(minutes);
+    }
+}

--- a/src/Goldfinch.Core/BlogPosts/BlogPostReadingMinutesRegenerator.cs
+++ b/src/Goldfinch.Core/BlogPosts/BlogPostReadingMinutesRegenerator.cs
@@ -1,0 +1,45 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using CMS.ContentEngine.Internal;
+using CMS.DataEngine;
+using Goldfinch.Core.Search;
+
+namespace Goldfinch.Core.BlogPosts;
+
+/// <inheritdoc cref="IBlogPostReadingMinutesRegenerator"/>
+public class BlogPostReadingMinutesRegenerator : IBlogPostReadingMinutesRegenerator
+{
+    private readonly IInfoProvider<ContentItemInfo> _contentItemInfoProvider;
+    private readonly IContentItemDataInfoRetriever _contentItemDataInfoRetriever;
+    private readonly IContentLanguageRetriever _contentLanguageRetriever;
+
+    public BlogPostReadingMinutesRegenerator(
+        IInfoProvider<ContentItemInfo> contentItemInfoProvider,
+        IContentItemDataInfoRetriever contentItemDataInfoRetriever,
+        IContentLanguageRetriever contentLanguageRetriever)
+    {
+        _contentItemInfoProvider = contentItemInfoProvider;
+        _contentItemDataInfoRetriever = contentItemDataInfoRetriever;
+        _contentLanguageRetriever = contentLanguageRetriever;
+    }
+
+    public async Task<int> RegenerateAsync(int contentItemId, string languageName, CancellationToken cancellationToken = default)
+    {
+        var contentItem = await _contentItemInfoProvider.GetAsync(contentItemId, cancellationToken)
+            ?? throw new InvalidOperationException($"Content item {contentItemId} was not found.");
+
+        var language = await _contentLanguageRetriever.GetContentLanguageOrThrow(languageName, cancellationToken);
+
+        // isLatest: true picks up the draft currently being edited, falling back to the published
+        // version once there's no pending draft — matches what the editor sees on screen.
+        var data = await _contentItemDataInfoRetriever.GetContentItemData(
+            contentItem, language.ContentLanguageID, isLatest: true, cancellationToken);
+
+        data.TryGetValue(nameof(ContentItemCommonDataInfo.ContentItemCommonDataVisualBuilderWidgets), out var widgetsValue);
+
+        var body = PageBuilderTextExtractor.ExtractText(widgetsValue as string);
+
+        return ReadingTimeEstimator.EstimateMinutes(body);
+    }
+}

--- a/src/Goldfinch.Core/BlogPosts/IBlogPostReadingMinutesRegenerator.cs
+++ b/src/Goldfinch.Core/BlogPosts/IBlogPostReadingMinutesRegenerator.cs
@@ -1,0 +1,17 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Goldfinch.Core.BlogPosts;
+
+/// <summary>
+/// Recomputes <see cref="ContentTypes.BlogPost.BlogPostReadingMinutes"/> from a post's current
+/// Page Builder content, for the admin "Regenerate" form component.
+/// </summary>
+public interface IBlogPostReadingMinutesRegenerator
+{
+    /// <summary>
+    /// Computes the reading-minutes estimate for the given content item's latest version (the
+    /// draft being edited, if one exists, otherwise the published version).
+    /// </summary>
+    Task<int> RegenerateAsync(int contentItemId, string languageName, CancellationToken cancellationToken = default);
+}

--- a/src/Goldfinch.Core/ServiceConfiguration.cs
+++ b/src/Goldfinch.Core/ServiceConfiguration.cs
@@ -16,6 +16,7 @@ public static class ServiceConfiguration
             .AddSingleton<IBreadcrumbService, BreadcrumbService>()
             .AddSingleton<IBlogPostService, BlogPostService>()
             .AddSingleton<IBlogTagService, BlogTagService>()
+            .AddSingleton<IBlogPostReadingMinutesRegenerator, BlogPostReadingMinutesRegenerator>()
             .AddScoped<IErrorPageService, ErrorPageService>()
             .AddSingleton<IPublicSpeakingService, PublicSpeakingService>()
             .AddSingleton<ISitemapService, SitemapService>()

--- a/src/Goldfinch.Web/App_Data/CIRepository/@global/cms.contenttype/goldfinch.blogpost.xml
+++ b/src/Goldfinch.Web/App_Data/CIRepository/@global/cms.contenttype/goldfinch.blogpost.xml
@@ -50,8 +50,7 @@
           <fielddescriptionashtml>False</fielddescriptionashtml>
         </properties>
         <settings>
-          <controlname>Kentico.Administration.NumberInput</controlname>
-          <WatermarkText>e.g. 5</WatermarkText>
+          <controlname>Goldfinch.ReadingMinutesFormComponent</controlname>
         </settings>
       </field>
     </form>

--- a/src/Goldfinch.Web/App_Data/CIRepository/Goldfinch/cms.contentitemcommondata/creatingacustommod..bykentico-zekjic3s@8c964a8458/3e42a82e-c3b7-4205-8a01-fb44f01a230b_en@e4917a7ee6.xml
+++ b/src/Goldfinch.Web/App_Data/CIRepository/Goldfinch/cms.contentitemcommondata/creatingacustommod..bykentico-zekjic3s@8c964a8458/3e42a82e-c3b7-4205-8a01-fb44f01a230b_en@e4917a7ee6.xml
@@ -16,7 +16,7 @@
   </ContentItemCommonDataContentLanguageID>
   <ContentItemCommonDataGUID>3e42a82e-c3b7-4205-8a01-fb44f01a230b</ContentItemCommonDataGUID>
   <ContentItemCommonDataIsLatest>True</ContentItemCommonDataIsLatest>
-  <ContentItemCommonDataLastPublishedWhen>2026-06-09 19:28:33Z</ContentItemCommonDataLastPublishedWhen>
+  <ContentItemCommonDataLastPublishedWhen>2026-06-30 23:02:16Z</ContentItemCommonDataLastPublishedWhen>
   <ContentItemCommonDataVersionStatus>2</ContentItemCommonDataVersionStatus>
   <ContentItemCommonDataVisualBuilderTemplateConfiguration />
   <ContentItemCommonDataVisualBuilderWidgets>
@@ -908,7 +908,7 @@
   <ContentItemReferences>
     <cms.contentitemreference>
       <ContentItemReferenceGroupGUID>303068e2-4728-40fe-a3ff-0c9279204c59</ContentItemReferenceGroupGUID>
-      <ContentItemReferenceGUID>b280979f-ff33-4de6-8410-ad983a9f8d95</ContentItemReferenceGUID>
+      <ContentItemReferenceGUID>785a4a32-1713-4161-9c02-590e5e6e0245</ContentItemReferenceGUID>
       <ContentItemReferenceSourceCommonDataID>
         <GUID>3e42a82e-c3b7-4205-8a01-fb44f01a230b</GUID>
         <ObjectType>cms.contentitemcommondata</ObjectType>
@@ -921,7 +921,7 @@
     </cms.contentitemreference>
     <cms.contentitemreference>
       <ContentItemReferenceGroupGUID>147f2441-929c-40a7-aa54-1a690414fd2c</ContentItemReferenceGroupGUID>
-      <ContentItemReferenceGUID>fd78e652-b238-46dc-b82f-adb74b8166be</ContentItemReferenceGUID>
+      <ContentItemReferenceGUID>6c943449-46d3-4c57-9776-7207b9a4464c</ContentItemReferenceGUID>
       <ContentItemReferenceSourceCommonDataID>
         <GUID>3e42a82e-c3b7-4205-8a01-fb44f01a230b</GUID>
         <ObjectType>cms.contentitemcommondata</ObjectType>
@@ -934,7 +934,7 @@
     </cms.contentitemreference>
     <cms.contentitemreference>
       <ContentItemReferenceGroupGUID>0c4b18bb-c57a-4b98-b2b7-2c5e6b3d84d5</ContentItemReferenceGroupGUID>
-      <ContentItemReferenceGUID>eae085ab-0ee2-4f1c-86eb-c61a4c6f6c88</ContentItemReferenceGUID>
+      <ContentItemReferenceGUID>46ce2c87-d85f-40d7-b59a-9c593b4a31c7</ContentItemReferenceGUID>
       <ContentItemReferenceSourceCommonDataID>
         <GUID>3e42a82e-c3b7-4205-8a01-fb44f01a230b</GUID>
         <ObjectType>cms.contentitemcommondata</ObjectType>
@@ -947,7 +947,7 @@
     </cms.contentitemreference>
     <cms.contentitemreference>
       <ContentItemReferenceGroupGUID>9f16f32f-cf1b-428b-8054-4dbc86064b99</ContentItemReferenceGroupGUID>
-      <ContentItemReferenceGUID>84fdf1b9-8e9f-4594-aba1-f0228c185b5c</ContentItemReferenceGUID>
+      <ContentItemReferenceGUID>4218ad5c-f498-4b45-8a04-d7fffada716e</ContentItemReferenceGUID>
       <ContentItemReferenceSourceCommonDataID>
         <GUID>3e42a82e-c3b7-4205-8a01-fb44f01a230b</GUID>
         <ObjectType>cms.contentitemcommondata</ObjectType>
@@ -960,7 +960,7 @@
     </cms.contentitemreference>
     <cms.contentitemreference>
       <ContentItemReferenceGroupGUID>138a9da8-854d-4fba-b16b-78b57e0d9b3b</ContentItemReferenceGroupGUID>
-      <ContentItemReferenceGUID>94767573-a0ec-47a2-ace8-75532319dac5</ContentItemReferenceGUID>
+      <ContentItemReferenceGUID>aec7a368-2fcb-435d-9bd3-ed61120c1197</ContentItemReferenceGUID>
       <ContentItemReferenceSourceCommonDataID>
         <GUID>3e42a82e-c3b7-4205-8a01-fb44f01a230b</GUID>
         <ObjectType>cms.contentitemcommondata</ObjectType>
@@ -973,7 +973,7 @@
     </cms.contentitemreference>
     <cms.contentitemreference>
       <ContentItemReferenceGroupGUID>52491390-f9f3-457f-9bb6-91868a91a8e5</ContentItemReferenceGroupGUID>
-      <ContentItemReferenceGUID>5da22c58-97de-4d95-9dd8-2525b7cd7670</ContentItemReferenceGUID>
+      <ContentItemReferenceGUID>461a4ac5-af7c-4f97-9414-c62d11548851</ContentItemReferenceGUID>
       <ContentItemReferenceSourceCommonDataID>
         <GUID>3e42a82e-c3b7-4205-8a01-fb44f01a230b</GUID>
         <ObjectType>cms.contentitemcommondata</ObjectType>

--- a/src/Goldfinch.Web/App_Data/CIRepository/Goldfinch/cms.contentitemcommondata/settingupazurekeyv..erience13-ytfw3kll@626658a663/0cbd0d7b-450f-411f-b3d6-f0d7ee79374f_en@b8e9879cd5.xml
+++ b/src/Goldfinch.Web/App_Data/CIRepository/Goldfinch/cms.contentitemcommondata/settingupazurekeyv..erience13-ytfw3kll@626658a663/0cbd0d7b-450f-411f-b3d6-f0d7ee79374f_en@b8e9879cd5.xml
@@ -16,7 +16,7 @@
   </ContentItemCommonDataContentLanguageID>
   <ContentItemCommonDataGUID>0cbd0d7b-450f-411f-b3d6-f0d7ee79374f</ContentItemCommonDataGUID>
   <ContentItemCommonDataIsLatest>True</ContentItemCommonDataIsLatest>
-  <ContentItemCommonDataLastPublishedWhen>2026-06-30 21:48:28Z</ContentItemCommonDataLastPublishedWhen>
+  <ContentItemCommonDataLastPublishedWhen>2026-06-30 23:02:25Z</ContentItemCommonDataLastPublishedWhen>
   <ContentItemCommonDataVersionStatus>2</ContentItemCommonDataVersionStatus>
   <ContentItemCommonDataVisualBuilderTemplateConfiguration />
   <ContentItemCommonDataVisualBuilderWidgets>
@@ -323,7 +323,7 @@
   <ContentItemReferences>
     <cms.contentitemreference>
       <ContentItemReferenceGroupGUID>f151233e-6d89-4b39-bff0-f8e822e96875</ContentItemReferenceGroupGUID>
-      <ContentItemReferenceGUID>a582c6d9-c022-4e6c-a4b2-53d29b46f5de</ContentItemReferenceGUID>
+      <ContentItemReferenceGUID>9efb1668-c6c1-4ba6-bbde-17e80120d78b</ContentItemReferenceGUID>
       <ContentItemReferenceSourceCommonDataID>
         <GUID>0cbd0d7b-450f-411f-b3d6-f0d7ee79374f</GUID>
         <ObjectType>cms.contentitemcommondata</ObjectType>

--- a/src/Goldfinch.Web/App_Data/CIRepository/Goldfinch/contentitemdata.goldfinch.blogpost/creatingacustommod..01-fb44f01a230b_en@5229a44d65/c7e4eda5-5ef1-4830-81b6-a7c5422ba111.xml
+++ b/src/Goldfinch.Web/App_Data/CIRepository/Goldfinch/contentitemdata.goldfinch.blogpost/creatingacustommod..01-fb44f01a230b_en@5229a44d65/c7e4eda5-5ef1-4830-81b6-a7c5422ba111.xml
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <contentitemdata.goldfinch.blogpost>
   <BlogPostDate>2023-08-03 23:00:00Z</BlogPostDate>
+  <BlogPostReadingMinutes>13</BlogPostReadingMinutes>
   <BlogPostTags>
     <![CDATA[[{"Identifier":"60aba381-f44d-447f-b03f-a231d16ff797"}]]]>
   </BlogPostTags>


### PR DESCRIPTION
## Summary
- Adds a custom Kentico Admin UI form component for `BlogPostReadingMinutes` with a "Regenerate" button — editors no longer have to guess the value by hand. It recomputes the estimate from the post's current Page Builder content (via `IContentItemDataInfoRetriever` + `PageBuilderTextExtractor`), without crawling the live URL, so it works on unpublished drafts too.
- Pins `react`/`react-dom` in the admin client to `18.3.1` to match the Admin shell's actual host React version, and explicitly forces Babel's production JSX transform (`@babel/preset-react` `development: false`) — `webpack-cli` 7 no longer auto-sets `NODE_ENV` for `--mode=production` the way v5 does, which only became visible once this client shipped its first real JSX component.
- Backfills two real posts' `BlogPostReadingMinutes` as a side effect of verifying the button live (content-data CI XML).

## Test plan
- [x] `dotnet build` (full solution) — clean
- [x] `npm run build` (admin client) — clean, confirmed production bundle uses `react/jsx-runtime` (not the broken `jsx-dev-runtime`)
- [x] Verified live in both Proxy (dev) and Embedded (production-equivalent) admin client modes
- [x] Clicked Regenerate on a post with an unset value (0 → 13) and one with an existing value (6 → 6, matching the prior crawl-based estimate) — zero console errors in both
- [ ] Backfill the remaining ~22 existing posts via the new button (manual, follow-up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)