### PR TITLE
build(scripts): toggle CI via official CLI commands in Update-Xperience.ps1

### DIFF
--- a/.claude/skills/update-xperience/SKILL.md
+++ b/.claude/skills/update-xperience/SKILL.md
@@ -25,14 +25,14 @@ Follow these steps systematically to ensure a complete and correct update:
 
 ### 1. Run the Update Script
 
-Execute the `Update-Xperience.ps1` PowerShell script to automate mechanical tasks:
+Execute the `Update-Xperience.ps1` PowerShell script to automate mechanical tasks. **Run from the repo root**:
 
 ```powershell
 # For latest version
 .\scripts\Update-Xperience.ps1
 
 # For specific version
-.\scripts\Update-Xperience.ps1 -TargetVersion "30.0.0"
+.\scripts\Update-Xperience.ps1 -TargetVersion "31.0.0"
 
 # Dry run to preview changes
 .\scripts\Update-Xperience.ps1 -DryRun
@@ -47,28 +47,38 @@ Execute the `Update-Xperience.ps1` PowerShell script to automate mechanical task
 The script will:
 - Validate prerequisites (Directory.Packages.props exists, clean git state, feature branch)
 - Check current Kentico package versions in Directory.Packages.props
-- Ensure CI (CMSEnableCI) is enabled, then clear `CI_FileMetadata` and run `--kxp-ci-restore` to apply CI XML files to the database **before any package updates** (assembly and DB are still on the same version at this point). CI is always expected to be enabled for this project, so it is enabled unconditionally — this self-heals a DB left disabled by a previously interrupted run.
-- Disable CI before the package update so `dotnet restore` doesn't trigger CI side-effects
-- Update Kentico.Xperience.* packages in Directory.Packages.props and run `dotnet restore` (preserves Kentico.Xperience.MiniProfiler which has independent versioning)
+- Ensure CI is enabled via the official CLI (`--kxp-ci-status` / `--kxp-ci-enable`, self-healing a DB left disabled by a previously interrupted run), clear `CI_FileMetadata`, and run `--kxp-ci-restore` to apply CI XML files to the database **before any package updates** (assembly and DB are still on the same version at this point)
+- Disable CI via `--kxp-ci-disable` for the duration of the package update
+- Update Kentico.Xperience.* packages in Directory.Packages.props and run `dotnet restore` (preserves Kentico.Xperience.MiniProfiler which has independent versioning; resolves each package's version individually against NuGet with preview fallback)
 - Update @kentico/* npm packages in admin client only (not custom frontend dependencies)
 - Run `npm audit fix` for security vulnerabilities
 - Build the solution with the new packages
 - Run `dotnet run --kxp-update --skip-confirmation` for database migrations
-- Re-enable CI (always left enabled at the end)
+- Re-enable CI via `--kxp-ci-enable` — the script **always leaves CI enabled** at the end, even if the update fails
 - Run `dotnet run --kxp-ci-store` to serialize updated objects
 - Check for CI repository changes
 
-### 2. Review Breaking Changes
+### 2. Review Release Notes and Flag Manual Steps
 
-Use the Kentico docs MCP server to research any breaking changes:
+Use the Kentico docs MCP server to research the release notes for the target version. Search for:
+- "Xperience by Kentico X.X.X release notes"
+- "Xperience by Kentico X.X.X upgrade"
+- "Xperience by Kentico X.X.X migration"
 
-- Search for release notes for the target version
-- Look for migration guides and breaking changes documentation
-- Pay special attention to:
-  - Deprecated APIs and their replacements
-  - New recommended patterns
-  - Required code changes
-  - Configuration changes
+For each relevant release between the old and new version, review:
+- **Breaking changes**: Deprecated/removed APIs, method signature changes, renamed types, namespace moves
+- **Required code changes**: New patterns the project must adopt
+- **Configuration changes**: New or changed `appsettings.json` keys
+- **Manual upgrade steps**: Steps that `--kxp-update` does NOT handle automatically — these are often listed under "Manual steps", "Refresh notes", or "Upgrade guide" sections in the docs
+
+**Important**: Explicitly call out any manual steps to the user before proceeding. For example:
+- Database schema changes that need manual SQL
+- New required service registrations in `Program.cs`/`ServiceConfiguration.cs`
+- Content type or channel configuration changes required in the admin UI
+- New required NuGet packages to add
+- CI repository files that need manual editing
+
+Present any found manual steps as a checklist for the user to action.
 
 ### 3. Fix Compilation Errors
 
@@ -82,24 +92,52 @@ If the build fails:
   - Removed or renamed types
   - New required parameters
 
-### 4. Manual Testing Checklist
+**Common issue — NU1605 package downgrade errors**: After a Kentico update, the build may fail with errors like:
+```
+error NU1605: Detected package downgrade: SomePackage from X.Y.Z to A.B.C
+  Goldfinch.Web -> Kentico.Xperience.WebApp 31.5.1 -> SomePackage (>= X.Y.Z)
+  Goldfinch.Web -> SomePackage (>= A.B.C)
+```
+This means a package is pinned in `Directory.Packages.props` at a lower version than Kentico now requires. Check whether the project actually uses that package's API in code (`Grep` for its namespace). If not used directly, **remove it from both `Directory.Packages.props` and all `.csproj` files** — it's a transitive dependency that Kentico should own. If it is used directly, bump the version in `Directory.Packages.props` to the required minimum.
+
+### 4. Handle CI Store Asset Failures
+
+The CI store may fail with an error like:
+```
+Could not find a part of the path '...\assets\contentitems\...\filename.svg'
+```
+This means a content item has an asset (image/file) that exists in the database but not in the local `assets/` folder — typically because an asset was uploaded to the CMS but `--kxp-ci-store` was never run and committed afterwards.
+
+**Understanding the assets/CI relationship:**
+- `assets/contentitems/` is the runtime folder for uploaded files — gitignored
+- The CI repository (`App_Data/CIRepository`) stores the binary files alongside their XML metadata — tracked in git
+- `--kxp-ci-restore` populates `assets/` from the CI repository; `--kxp-ci-store` reads from `assets/` to serialize into the CI repository
+
+**Resolution options (in order of preference):**
+1. **Use the real file**: Find the original file (check Downloads/recent files), copy it to the exact path shown in the error, then re-run `--kxp-ci-store`.
+2. **Use an existing similar file as a placeholder**: Copy a suitable file from elsewhere in the CI repository to the missing path, re-run `--kxp-ci-store`. The correct file can be committed separately later.
+3. **Don't let it muddy the update**: If the failure causes the CI store to wipe existing CI image entries, restore those entries with `git checkout HEAD -- <path>` to keep the update PR clean. Address the missing asset separately.
+
+The root cause is always the same: an asset was uploaded without committing the CI store output. After fixing, always run `--kxp-ci-store` and commit after uploading new assets.
+
+### 5. Manual Testing Checklist
 
 After the build succeeds, recommend the user test these critical areas locally:
 - Homepage loads correctly
 - Blog listing page works
 - Blog detail pages render with images
 - Navigation and header work
-- Admin interface is accessible
+- Admin interface is accessible (`https://localhost:52623/admin`)
 - Page builder widgets function correctly
 
-### 5. Review CI Repository Changes
+### 6. Review CI Repository Changes
 
 The `App_Data/CIRepository/` folder contains serialized Kentico objects that must be committed:
 - Check `git status src/Goldfinch.Web/App_Data/CIRepository/`
 - Review what changed
 - These changes are expected and should be committed with the update
 
-### 6. Commit and Create PR
+### 7. Commit and Create PR
 
 When everything is working:
 - Stage all changes: Directory.Packages.props, package-lock.json files, CI repository files, and any code fixes
@@ -123,11 +161,12 @@ When everything is working:
 - **Preserved Packages**: Kentico.Xperience.MiniProfiler has independent versioning and won't be automatically updated
 - **CI Always Enabled**: CI is always expected to be enabled for this project. The script enables CI unconditionally at the start (self-healing a DB left disabled by a previously interrupted run) and always leaves it enabled at the end — it never skips the CI steps based on the current `CMSEnableCI` value
 - **CI Restore First**: The script clears `CI_FileMetadata` and runs `--kxp-ci-restore` **before the NuGet package update**. This is critical — the assembly and DB must be on the same version for CI restore to run, and it must happen before the migration so `--kxp-ci-store` serialises the CI XML state, not stale seed-DB state (which would roll back fields on custom content types)
-- **CI Toggle**: The script disables CI before the NuGet update and re-enables it after `--kxp-update` (per Kentico best practices)
+- **CI Toggle**: All CI state management (status/enable/disable) uses the official CLI commands (`--kxp-ci-enable` / `--kxp-ci-disable` / `--kxp-ci-status`, available from Xperience 31.6.0) — no direct SQL. The always-leave-CI-enabled safety net also uses the CLI; if the update broke badly enough that `dotnet run` cannot execute, the script reports it so CI can be re-enabled manually. The only remaining SQL is the `CI_FileMetadata` clear, which has no CLI equivalent
 - **CI Repository**: Changes to `App_Data/CIRepository/` are expected and necessary after CI store operation
 - **Nullable Reference Types**: This project has nullable reference types enabled - ensure any code changes respect this
 - **Minimal Changes**: Keep changes focused on Kentico packages only - don't bump unrelated dependencies
 - **Documentation**: Always use the Kentico docs MCP server for authoritative information about APIs and changes
+- **Lucene Package**: This project uses `Kentico.Xperience.Lucene` — the `kenticolucene.luceneindexassemblyversionitem` object type should be listed under `<ExcludedObjectTypes>` in `src/Goldfinch.Web/App_Data/CIRepository/repository.config` — it is per-environment runtime state (which assembly version built the local index) and must not flow through CI. If a file for it appears under `App_Data/CIRepository/@global/` during the update, add the exclusion and re-run `--kxp-ci-store`
 
 ## Project-Specific Context
 

--- a/scripts/Update-Xperience.ps1
+++ b/scripts/Update-Xperience.ps1
@@ -2,7 +2,8 @@
 # Automates the process of updating Xperience by Kentico packages:
 # - Kentico.Xperience.* NuGet packages via Directory.Packages.props
 # - @kentico/* npm packages in Admin Client only
-# - Handles CMSEnableCI toggle during update
+# - Toggles CI via the official CLI commands (--kxp-ci-enable/-disable/-status, requires
+#   the project to start on Xperience 31.6.0+)
 # - Runs CI store after update
 
 [CmdletBinding()]
@@ -62,65 +63,8 @@ function Get-ConnectionString {
     return $connectionStringsJson.ConnectionStrings.CMSConnectionString
 }
 
-function Execute-SqlCommand {
-    param(
-        [string]$ConnectionString,
-        [string]$CommandText
-    )
-
-    $connection = New-Object System.Data.SqlClient.SqlConnection($ConnectionString)
-
-    try {
-        $connection.Open()
-        $command = New-Object System.Data.SqlClient.SqlCommand($CommandText, $connection)
-        $transaction = $connection.BeginTransaction()
-        $command.Transaction = $transaction
-
-        try {
-            $rowsAffected = $command.ExecuteNonQuery()
-            Write-Host "  SQL Command: $CommandText" -ForegroundColor Gray
-            Write-Host "  Rows affected: $rowsAffected" -ForegroundColor Gray
-
-            if ($rowsAffected -ne 1) {
-                throw "Expected 1 row to be affected, but $rowsAffected rows were affected"
-            }
-
-            $transaction.Commit()
-            return $true
-        }
-        catch {
-            $transaction.Rollback()
-            Write-ErrorMessage "SQL command failed: $($_.Exception.Message)"
-            return $false
-        }
-    }
-    finally {
-        $connection.Close()
-    }
-}
-
-function Execute-SqlQuery {
-    param(
-        [string]$ConnectionString,
-        [string]$CommandText
-    )
-
-    $connection = New-Object System.Data.SqlClient.SqlConnection($ConnectionString)
-
-    try {
-        $connection.Open()
-        $command = New-Object System.Data.SqlClient.SqlCommand($CommandText, $connection)
-        $dataAdapter = New-Object System.Data.SqlClient.SqlDataAdapter($command)
-        $dataset = New-Object System.Data.Dataset
-        $dataAdapter.Fill($dataset)
-
-        return $dataset
-    }
-    finally {
-        $connection.Close()
-    }
-}
-
+# The only remaining SQL access — used by Clear-CIFileMetadata, which has no CLI equivalent.
+# All CI state management (status/enable/disable) goes through the official CLI commands.
 function Execute-SqlNonQuery {
     param(
         [string]$ConnectionString,
@@ -399,32 +343,30 @@ function Update-NpmPackages {
 
 #region CI Management
 
-function Get-CIEnabled {
-    param([string]$ConnectionString)
+# Reads the CI state via the official CLI (--kxp-ci-status, Xperience 31.6.0+).
+# Must be called from the Web project directory. -AllowBuild lets the first CLI call
+# of a run build the project; subsequent calls should rely on --no-build.
+function Get-CIEnabledCli {
+    param([switch]$AllowBuild)
 
-    try {
-        $query = "SELECT KeyValue FROM CMS_SettingsKey WHERE KeyName = N'CMSEnableCI'"
-        $dataset = Execute-SqlQuery -ConnectionString $ConnectionString -CommandText $query
+    $runArgs = @("run")
+    if (-not $AllowBuild) { $runArgs += "--no-build" }
+    $runArgs += @("--", "--kxp-ci-status", "--format", "json")
 
-        $value = $dataset.Tables[0].Rows[0][0]
-        return ($value -eq 'True')
+    $output = & dotnet @runArgs 2>&1
+
+    if ($LASTEXITCODE -ne 0) {
+        throw "Failed to read CI status via --kxp-ci-status (exit code $LASTEXITCODE). Output:`n$($output -join "`n")"
     }
-    catch {
-        Write-ErrorMessage "Failed to check CI status: $_"
-        return $false
+
+    # dotnet run prints launch-settings info before the JSON result - find the JSON line
+    $json = $output | Where-Object { "$_" -match '^\s*\{' } | Select-Object -Last 1
+
+    if (-not $json) {
+        throw "No JSON output found from --kxp-ci-status. Output:`n$($output -join "`n")"
     }
-}
 
-function Set-CIEnabled {
-    param(
-        [string]$ConnectionString,
-        [bool]$Enabled
-    )
-
-    $value = if ($Enabled) { "True" } else { "False" }
-    $command = "UPDATE CMS_SettingsKey SET KeyValue = N'$value' WHERE KeyName = N'CMSEnableCI'"
-
-    return Execute-SqlCommand -ConnectionString $ConnectionString -CommandText $command
+    return [bool](ConvertFrom-Json "$json").enabled
 }
 
 function Clear-CIFileMetadata {
@@ -459,44 +401,49 @@ function Invoke-CIPreRestore {
         $script:connectionString = Get-ConnectionString
         Write-Success "Connection string retrieved"
 
-        # CI is always enabled for this project. Enable it unconditionally so the pre-restore
-        # syncs the DB from the repo CI XML before migration, even if a prior run left it off.
-        Write-Host "Ensuring CI is enabled..." -ForegroundColor Gray
-        if (Get-CIEnabled -ConnectionString $script:connectionString) {
-            Write-Host "CI is already enabled" -ForegroundColor Gray
-        } else {
-            $success = Set-CIEnabled -ConnectionString $script:connectionString -Enabled $true
-            if (-not $success) {
-                throw "Failed to enable CI. Cannot proceed with update."
-            }
-            Write-Success "CI enabled"
-        }
-
-        Write-Host "`nClearing CI_FileMetadata before restore..." -ForegroundColor Yellow
-        Clear-CIFileMetadata -ConnectionString $script:connectionString
-
         Push-Location "src/Goldfinch.Web"
         try {
+            # CI is always enabled for this project. Enable it unconditionally so the pre-restore
+            # syncs the DB from the repo CI XML before migration, even if a prior run left it off.
+            # The status check is the first CLI call of the run, so it is allowed to build;
+            # every dotnet run after it uses --no-build.
+            Write-Host "Checking CI status (--kxp-ci-status)..." -ForegroundColor Gray
+            if (Get-CIEnabledCli -AllowBuild) {
+                Write-Host "CI is already enabled" -ForegroundColor Gray
+            } else {
+                Write-Host "Enabling CI (--kxp-ci-enable)..." -ForegroundColor Yellow
+                & dotnet run --no-build -- --kxp-ci-enable
+
+                if ($LASTEXITCODE -ne 0) {
+                    throw "Failed to enable CI (exit code $LASTEXITCODE). Cannot proceed with update."
+                }
+
+                Write-Success "CI enabled"
+            }
+
+            Write-Host "`nClearing CI_FileMetadata before restore..." -ForegroundColor Yellow
+            Clear-CIFileMetadata -ConnectionString $script:connectionString
+
             Write-Host "`nRestoring CI objects before package update..." -ForegroundColor Yellow
-            & dotnet run --kxp-ci-restore
+            & dotnet run --no-build --kxp-ci-restore
 
             if ($LASTEXITCODE -eq 0) {
                 Write-Success "CI restore completed"
             } else {
                 throw "CI restore failed with exit code $LASTEXITCODE"
             }
+
+            Write-Host "`nDisabling CI before package update (--kxp-ci-disable)..." -ForegroundColor Yellow
+            & dotnet run --no-build -- --kxp-ci-disable
+
+            if ($LASTEXITCODE -ne 0) {
+                throw "Failed to disable CI (exit code $LASTEXITCODE). Cannot proceed with update."
+            }
+
+            Write-Success "CI disabled"
         } finally {
             Pop-Location
         }
-
-        Write-Host "`nDisabling CI before package update..." -ForegroundColor Yellow
-        $success = Set-CIEnabled -ConnectionString $script:connectionString -Enabled $false
-
-        if (-not $success) {
-            throw "Failed to disable CI. Cannot proceed with update."
-        }
-
-        Write-Success "CI disabled"
     } catch {
         Write-ErrorMessage "Failed during CI pre-restore: $_"
         throw
@@ -541,19 +488,19 @@ function Invoke-KenticoUpdate {
         }
 
         # Re-enable CI and store (CI is always enabled for this project)
-        Write-Host "`nRe-enabling CI..." -ForegroundColor Yellow
-        $success = Set-CIEnabled -ConnectionString $script:connectionString -Enabled $true
-
-        if (-not $success) {
-            Write-ErrorMessage "Failed to re-enable CI"
-            return
-        }
-
-        Write-Success "CI re-enabled"
-
-        Write-Host "`nStoring CI objects..." -ForegroundColor Gray
         Push-Location "src/Goldfinch.Web"
         try {
+            Write-Host "`nRe-enabling CI (--kxp-ci-enable)..." -ForegroundColor Yellow
+            & dotnet run --no-build -- --kxp-ci-enable
+
+            if ($LASTEXITCODE -ne 0) {
+                Write-ErrorMessage "Failed to re-enable CI"
+                return
+            }
+
+            Write-Success "CI re-enabled"
+
+            Write-Host "`nStoring CI objects..." -ForegroundColor Gray
             & dotnet run --no-build --kxp-ci-store
 
             if ($LASTEXITCODE -eq 0) {
@@ -568,18 +515,25 @@ function Invoke-KenticoUpdate {
     } catch {
         Write-ErrorMessage "Failed to run Kentico update: $_"
     } finally {
-        # Always leave CI enabled — runs whether the update succeeded or failed
-        if ($null -ne $script:connectionString) {
-            try {
-                $currentCIState = Get-CIEnabled -ConnectionString $script:connectionString
-                if (-not $currentCIState) {
-                    Write-Host "`nEnsuring CI is re-enabled..." -ForegroundColor Yellow
-                    Set-CIEnabled -ConnectionString $script:connectionString -Enabled $true | Out-Null
-                    Write-Success "CI re-enabled"
+        # Always leave CI enabled — runs whether the update succeeded or failed. If the update
+        # broke badly enough that dotnet run cannot execute, this reports the failure so CI can
+        # be re-enabled manually.
+        Push-Location "src/Goldfinch.Web"
+        try {
+            if (-not (Get-CIEnabledCli)) {
+                Write-Host "`nEnsuring CI is re-enabled (--kxp-ci-enable)..." -ForegroundColor Yellow
+                & dotnet run --no-build -- --kxp-ci-enable
+
+                if ($LASTEXITCODE -ne 0) {
+                    throw "kxp-ci-enable failed with exit code $LASTEXITCODE"
                 }
-            } catch {
-                Write-ErrorMessage "Could not verify or restore CI state. Please check CI is enabled in the Kentico admin before proceeding."
+
+                Write-Success "CI re-enabled"
             }
+        } catch {
+            Write-ErrorMessage "Could not verify or restore CI state. Please check CI is enabled in the Kentico admin before proceeding."
+        } finally {
+            Pop-Location
         }
     }
 }


### PR DESCRIPTION
## Summary

Closes #229.

Replaces the raw-SQL `CMSEnableCI` toggling in `scripts/Update-Xperience.ps1` with the official CLI commands added in Xperience 31.6.0:

- `Get-CIEnabled`/`Set-CIEnabled` (SQL) → `Get-CIEnabledCli` (`dotnet run -- --kxp-ci-status --format json`) plus direct `--kxp-ci-enable` / `--kxp-ci-disable` calls with exit-code checks (fail-fast behaviour preserved)
- Removed `Execute-SqlCommand` / `Execute-SqlQuery`; `Execute-SqlNonQuery` remains only for the `CI_FileMetadata` clear, which has no CLI equivalent
- First CLI call of a run builds the project; every subsequent `dotnet run` uses `--no-build` (including `--kxp-ci-restore`, which previously rebuilt each time)
- Always-leave-CI-enabled safety net now verifies state via the CLI and reports for manual intervention if `dotnet run` itself cannot execute

Also ports SKILL.md improvements from the baseline template: expanded release-notes/manual-steps review, NU1605 downgrade guidance, CI store asset-failure handling, and the Lucene `luceneindexassemblyversionitem` CI exclusion note.

## Testing

- Script passes the PowerShell parser (no syntax errors)
- Runtime path will get its first real exercise on the next Xperience update; the project is already on 31.6.0 so the CLI commands are available

🤖 Generated with [Claude Code](https://claude.com/claude-code)