### PR TITLE
fix(ci): exclude Lucene index assembly version item from CI serialization

### DIFF
--- a/.claude/skills/update-xperience/SKILL.md
+++ b/.claude/skills/update-xperience/SKILL.md
@@ -166,7 +166,7 @@ When everything is working:
 - **Nullable Reference Types**: This project has nullable reference types enabled - ensure any code changes respect this
 - **Minimal Changes**: Keep changes focused on Kentico packages only - don't bump unrelated dependencies
 - **Documentation**: Always use the Kentico docs MCP server for authoritative information about APIs and changes
-- **Lucene Package**: This project uses `Kentico.Xperience.Lucene` — the `kenticolucene.luceneindexassemblyversionitem` object type should be listed under `<ExcludedObjectTypes>` in `src/Goldfinch.Web/App_Data/CIRepository/repository.config` — it is per-environment runtime state (which assembly version built the local index) and must not flow through CI. If a file for it appears under `App_Data/CIRepository/@global/` during the update, add the exclusion and re-run `--kxp-ci-store`
+- **Lucene Package**: This project uses `Kentico.Xperience.Lucene` — the `kenticolucene.luceneindexassemblyversionitem` object type is excluded under `<ExcludedObjectTypes>` in `src/Goldfinch.Web/App_Data/CIRepository/repository.config` because it is per-environment runtime state (which assembly version built the local index) and must not flow through CI. If a file for it ever appears under `App_Data/CIRepository/@global/` during an update, check the exclusion is still in place and re-run `--kxp-ci-store`
 
 ## Project-Specific Context
 

--- a/.gitignore
+++ b/.gitignore
@@ -367,7 +367,9 @@ ConnectionStrings\.json
 # Ignore Vite dist folder
 src/Goldfinch.Web/wwwroot/SiteFiles/dist
 
-# Ensure CIRepository is fully committed
+# Ensure CIRepository is fully committed.
+# Runtime-state object types (e.g. kenticolucene.luceneindexassemblyversionitem) are
+# excluded via ExcludedObjectTypes in App_Data/CIRepository/repository.config, not gitignored.
 !src/Goldfinch.Web/App_Data/CIRepository/**/*.*
 
 # Local assets are restored via dotnet run --kxp-ci-restore, not committed

--- a/src/Goldfinch.Web/App_Data/CIRepository/repository.config
+++ b/src/Goldfinch.Web/App_Data/CIRepository/repository.config
@@ -26,6 +26,9 @@
          Only remove the exclusion if you agree to make setting values available within the file system used by the application
          and any connected systems. -->
 		<ObjectType>cms.settingskey</ObjectType>
+		<!-- Records which assembly version built each environment's local Lucene index —
+         per-environment runtime state that must not flow through CI. -->
+		<ObjectType>kenticolucene.luceneindexassemblyversionitem</ObjectType>
 		<!-- <ObjectType>ObjectTypeX</ObjectType> -->
 		<!-- <ObjectType>ObjectTypeY</ObjectType> -->
 	</ExcludedObjectTypes>


### PR DESCRIPTION
## Summary

Closes #238.

Adds `kenticolucene.luceneindexassemblyversionitem` to `<ExcludedObjectTypes>` in `src/Goldfinch.Web/App_Data/CIRepository/repository.config`, exactly as the issue prescribes. The object type records which assembly version built each environment's local Lucene index — per-environment runtime state that must not flow through CI.

- With the exclusion, `--kxp-ci-store` never writes the file and `--kxp-ci-restore` never touches the DB row, so each environment keeps its own marker and indexes rebuild only when they should
- No file for the type exists in the CI repository yet, so no `--kxp-ci-store` resync is required — the exclusion just prevents it from ever being serialized
- Updates the `update-xperience` skill's Lucene note to reflect the exclusion being in place
- Documents in `.gitignore` (next to the CIRepository force-include) why runtime-state object types are excluded via `repository.config` rather than gitignored, mirroring the baseline template guidance

The Lucene configuration objects (index definition, included paths, languages, content types) remain tracked in CI, unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)