### PR TITLE
build(sln): update to Xperience v31.6.1

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -7,12 +7,12 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="coverlet.collector" Version="10.0.1" />
-    <PackageVersion Include="Kentico.Xperience.Admin" Version="31.6.0" />
-    <PackageVersion Include="Kentico.Xperience.AzureStorage" Version="31.6.0" />
+    <PackageVersion Include="Kentico.Xperience.Admin" Version="31.6.1" />
+    <PackageVersion Include="Kentico.Xperience.AzureStorage" Version="31.6.1" />
     <PackageVersion Include="Kentico.Xperience.Lucene" Version="15.0.3" />
-    <PackageVersion Include="Kentico.Xperience.ManagementApi" Version="31.6.0-preview" />
+    <PackageVersion Include="Kentico.Xperience.ManagementApi" Version="31.6.1-preview" />
     <PackageVersion Include="Kentico.Xperience.MiniProfiler" Version="3.0.0" />
-    <PackageVersion Include="Kentico.Xperience.WebApp" Version="31.6.0" />
+    <PackageVersion Include="Kentico.Xperience.WebApp" Version="31.6.1" />
     <PackageVersion Include="Lucene.Net.Highlighter" Version="4.8.0-beta00018" />
     <PackageVersion Include="AngleSharp" Version="0.17.1" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />

--- a/src/Goldfinch.Admin/Client/package-lock.json
+++ b/src/Goldfinch.Admin/Client/package-lock.json
@@ -8,8 +8,8 @@
       "name": "goldfinch-web-admin",
       "version": "1.0.0",
       "dependencies": {
-        "@kentico/xperience-admin-base": "^31.6.0",
-        "@kentico/xperience-admin-components": "^31.6.0",
+        "@kentico/xperience-admin-base": "^31.6.1",
+        "@kentico/xperience-admin-components": "^31.6.1",
         "react": "^18.3.1",
         "react-dom": "^18.3.1"
       },
@@ -19,7 +19,7 @@
         "@babel/preset-env": "^8.0.2",
         "@babel/preset-react": "^8.0.1",
         "@babel/preset-typescript": "^8.0.1",
-        "@kentico/xperience-webpack-config": "^31.6.0",
+        "@kentico/xperience-webpack-config": "^31.6.1",
         "@types/react": "^18.3.1",
         "@types/react-dom": "^18.3.1",
         "babel-loader": "^10.0.0",
@@ -4248,13 +4248,12 @@
       "license": "Apache-2.0"
     },
     "node_modules/@kentico/xperience-admin-base": {
-      "version": "31.6.0",
-      "resolved": "https://registry.npmjs.org/@kentico/xperience-admin-base/-/xperience-admin-base-31.6.0.tgz",
-      "integrity": "sha512-iBfx9yt+UeE90D9Q3k/5cEI7F3qDrRWQIqHd4t2zc01idFEyhXVMv0I0IFCvPGJVo3tBfozluRSSAVFInYUx2g==",
-      "license": "SEE LICENSE IN LICENSE.txt",
+      "version": "31.6.1",
+      "resolved": "https://registry.npmjs.org/@kentico/xperience-admin-base/-/xperience-admin-base-31.6.1.tgz",
+      "integrity": "sha512-Ft5ETD10DrSZ+iYzCy6K9Vq+2KQ5tFszYFoPeWJESWwAm6geNnZQpXMZqtQuYUbuzmviTKAOpTiLnyzFu2C0Fg==",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",
-        "@kentico/xperience-admin-components": "31.6.0",
+        "@kentico/xperience-admin-components": "31.6.1",
         "@react-aria/focus": "3.22.1",
         "@react-aria/i18n": "3.13.1",
         "@react-aria/visually-hidden": "3.9.1",
@@ -4281,10 +4280,9 @@
       }
     },
     "node_modules/@kentico/xperience-admin-components": {
-      "version": "31.6.0",
-      "resolved": "https://registry.npmjs.org/@kentico/xperience-admin-components/-/xperience-admin-components-31.6.0.tgz",
-      "integrity": "sha512-97/iEnIzaNq5oxAYJUKD0Fx6Q9tZ+x4CNL2rfmU6jHsZ4ldYg5jztXpp6u1iXtVaFlGHOqpxXVnjL9FOAW1RXQ==",
-      "license": "SEE LICENSE IN LICENSE.txt",
+      "version": "31.6.1",
+      "resolved": "https://registry.npmjs.org/@kentico/xperience-admin-components/-/xperience-admin-components-31.6.1.tgz",
+      "integrity": "sha512-1EKlGRrVxUFmDn2vBFUfdewf/DVdxJZRWbYcLrirF1KeShEX+yf2Os2Rt81EDYNVOm9ZMjBROHBwRk8mpmDWpQ==",
       "dependencies": {
         "@amcharts/amcharts5": "5.19.0",
         "@codemirror/lang-css": "6.3.1",
@@ -4323,11 +4321,10 @@
       }
     },
     "node_modules/@kentico/xperience-webpack-config": {
-      "version": "31.6.0",
-      "resolved": "https://registry.npmjs.org/@kentico/xperience-webpack-config/-/xperience-webpack-config-31.6.0.tgz",
-      "integrity": "sha512-OSTTjJshS5fk2cFaBXWunBl/V2k+UowumvtlyIonnvmPPBS91Cp8upBdiXEt22roXTFAgYPPc6xZryMHBy0EzQ==",
+      "version": "31.6.1",
+      "resolved": "https://registry.npmjs.org/@kentico/xperience-webpack-config/-/xperience-webpack-config-31.6.1.tgz",
+      "integrity": "sha512-SIEK2SneQIUpYi8eB9NX99q31C21etAtW6keLmGFz2X/JKPnUj6vTcCvrjCUknzKABldQsAcPzKT9chvxgAYhg==",
       "dev": true,
-      "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "systemjs-webpack-interop": "2.3.7"
       }
@@ -12390,11 +12387,10 @@
       }
     },
     "node_modules/webpack-dev-server": {
-      "version": "5.2.5",
-      "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-5.2.5.tgz",
-      "integrity": "sha512-4wZtCquSuv9CKX8oybo+mqxtxZqWz47uM1Ch94lxowBztOhWCbhqvRbfC/mODOwxgV2brY+JGZpHq58/SuVFYg==",
+      "version": "5.2.6",
+      "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-5.2.6.tgz",
+      "integrity": "sha512-HNLRmamRvVavZQ+avceZifmv8hmdUjg43t6MI4SqJDwFdW7RPQwH5vzGhDRZSX59SgfbeHhLnq3g+uooWo7pVw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@types/bonjour": "^3.5.13",
         "@types/connect-history-api-fallback": "^1.5.4",
@@ -12414,7 +12410,7 @@
         "graceful-fs": "^4.2.6",
         "http-proxy-middleware": "^2.0.9",
         "ipaddr.js": "^2.1.0",
-        "launch-editor": "^2.6.1",
+        "launch-editor": "^2.14.1",
         "open": "^10.0.3",
         "p-retry": "^6.2.0",
         "schema-utils": "^4.2.0",

--- a/src/Goldfinch.Admin/Client/package.json
+++ b/src/Goldfinch.Admin/Client/package.json
@@ -11,8 +11,8 @@
     "build": "webpack --mode=production"
   },
   "dependencies": {
-    "@kentico/xperience-admin-base": "^31.6.0",
-    "@kentico/xperience-admin-components": "^31.6.0",
+    "@kentico/xperience-admin-base": "^31.6.1",
+    "@kentico/xperience-admin-components": "^31.6.1",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"
   },
@@ -22,7 +22,7 @@
     "@babel/preset-env": "^8.0.2",
     "@babel/preset-react": "^8.0.1",
     "@babel/preset-typescript": "^8.0.1",
-    "@kentico/xperience-webpack-config": "^31.6.0",
+    "@kentico/xperience-webpack-config": "^31.6.1",
     "@types/react": "^18.3.1",
     "@types/react-dom": "^18.3.1",
     "babel-loader": "^10.0.0",

--- a/src/Goldfinch.Admin/packages.lock.json
+++ b/src/Goldfinch.Admin/packages.lock.json
@@ -4,13 +4,13 @@
     "net10.0": {
       "Kentico.Xperience.Admin": {
         "type": "Direct",
-        "requested": "[31.6.0, )",
-        "resolved": "31.6.0",
-        "contentHash": "oZwvRnUtAYu3mJ55gY4BSiJidWVQKaXa1qmIFZpdsBKzdiUNgRvJ1Glp4EB2d3LSKbPMBXKltOTgBv+8IlSUsw==",
+        "requested": "[31.6.1, )",
+        "resolved": "31.6.1",
+        "contentHash": "JU8z6ircJfEgP2MHQCOVrxiRsaZVOvqBJCsEifk17pU/4oD705dZyIyeuNHa7VUl7Il5w/T+RlShXn6rFddUmA==",
         "dependencies": {
           "Azure.AI.OpenAI": "2.1.0",
           "Kentico.Aira.Client": "6.1.0",
-          "Kentico.Xperience.WebApp": "[31.6.0]",
+          "Kentico.Xperience.WebApp": "[31.6.1]",
           "Microsoft.Agents.AI": "1.10.0",
           "Microsoft.Agents.AI.OpenAI": "1.10.0",
           "Microsoft.AspNetCore.SpaServices.Extensions": "8.0.28",
@@ -21,15 +21,15 @@
       },
       "Kentico.Xperience.WebApp": {
         "type": "Direct",
-        "requested": "[31.6.0, )",
-        "resolved": "31.6.0",
-        "contentHash": "ly3L4ZeGQSBbIIlbbCx3OZsWKMVgSUsGKWqd7WGPWjhvgci4C1YuPkW2ORR42d/aqcNM5pXOl17zSiKJawQ+Iw==",
+        "requested": "[31.6.1, )",
+        "resolved": "31.6.1",
+        "contentHash": "q8FAYRgWADj0wW+J9VWwm8gU/IkGiWwfWhSHFXCmGttGiqCiYY7Fi+YykSEYNZjZNtKlvLG6BQFQzH4FsiQ9Xw==",
         "dependencies": {
           "CommandLineParser": "2.9.1",
           "HotChocolate.AspNetCore": "15.1.16",
           "HotChocolate.Data": "15.1.16",
           "HtmlSanitizer": "9.0.892",
-          "Kentico.Xperience.Core": "[31.6.0]",
+          "Kentico.Xperience.Core": "[31.6.1]",
           "Microsoft.Extensions.FileProviders.Embedded": "8.0.28"
         }
       },
@@ -426,8 +426,8 @@
       },
       "Kentico.Xperience.Core": {
         "type": "Transitive",
-        "resolved": "31.6.0",
-        "contentHash": "v+9Iq6ZCZbQYevXg2+AIC4UvZ2xkwb2elgFuJJNdgitDahjVRfGIfWW39sytYDIVY8+Hx9CldiiiKrmmF0yPng==",
+        "resolved": "31.6.1",
+        "contentHash": "RTRALxYej5oU9hw5uePLwrqTdHLBXmlDkdpSsBMEd2mZQba+TupjczfheTt0j0uKyALeuXSY3IyGjxMNurbLng==",
         "dependencies": {
           "AngleSharp": "0.17.1",
           "Kentico.Aira.Client": "6.1.0",
@@ -463,8 +463,8 @@
       },
       "Lucene.Net": {
         "type": "Transitive",
-        "resolved": "4.8.0-beta00017",
-        "contentHash": "7LLWS9nNwx01AyE/KXMh+qdAlzDkRANE8407AO/wEmLL1InzVKFwfsRdRmwg4ILOMFui4xZ1Y54eqvzo3Tf9Vw==",
+        "resolved": "4.8.0-beta00018",
+        "contentHash": "iBkkpkDbAHjpZ0dnukFnWnjxSNmsRHOSxrYBBKbtcYJZ8PQRrKsqGGyNm8xmh4ORvsJ1WM7i5A9whiyA8WhNrQ==",
         "dependencies": {
           "J2N": "[2.1.0, 3.0.0)"
         }
@@ -505,18 +505,18 @@
       },
       "Lucene.Net.Memory": {
         "type": "Transitive",
-        "resolved": "4.8.0-beta00017",
-        "contentHash": "T4uG0k1iGzXXRRlmsFTtRPhnc2Ef1wlh68TxO2dN8qLW7AXX9qsIjOuN64+IXAPUkysvvks8psoU6epi642MUw==",
+        "resolved": "4.8.0-beta00018",
+        "contentHash": "FDdqAkKC33y/YTkx4uH5oci3OkNOdyyX0MWI/agSFn+7WlMxlj6CvH3tX+5fpi8Hf7EBqWjdP9hr26u4Kb4UNA==",
         "dependencies": {
-          "Lucene.Net": "4.8.0-beta00017"
+          "Lucene.Net": "4.8.0-beta00018"
         }
       },
       "Lucene.Net.Queries": {
         "type": "Transitive",
-        "resolved": "4.8.0-beta00017",
-        "contentHash": "RVpZCfa/7pgvytFw64zLqinvZPQt4TojvcFghdAA5vhnpSs5GTbtciPIxFH3wwH3f2dYJywiqYKo1h3JBCXRBA==",
+        "resolved": "4.8.0-beta00018",
+        "contentHash": "cS+Ea3m4ZcCId9MgYfgAs6UNiYfxykpNIZlf7nRPH/7zOa+TePX5ATM+0FLQu54bAkgWVAwV1T269PD0oQsToQ==",
         "dependencies": {
-          "Lucene.Net": "4.8.0-beta00017"
+          "Lucene.Net": "4.8.0-beta00018"
         }
       },
       "Magick.NET-Q8-AnyCPU": {
@@ -868,10 +868,10 @@
         "type": "Project",
         "dependencies": {
           "AngleSharp": "[0.17.1, )",
-          "Kentico.Xperience.Admin": "[31.6.0, )",
+          "Kentico.Xperience.Admin": "[31.6.1, )",
           "Kentico.Xperience.Lucene": "[15.0.3, )",
-          "Kentico.Xperience.WebApp": "[31.6.0, )",
-          "Lucene.Net.Highlighter": "[4.8.0-beta00017, )",
+          "Kentico.Xperience.WebApp": "[31.6.1, )",
+          "Lucene.Net.Highlighter": "[4.8.0-beta00018, )",
           "Sidio.Sitemap.AspNetCore": "[3.1.1, )"
         }
       },
@@ -893,12 +893,12 @@
       },
       "Lucene.Net.Highlighter": {
         "type": "CentralTransitive",
-        "requested": "[4.8.0-beta00017, )",
-        "resolved": "4.8.0-beta00017",
-        "contentHash": "Mqm+KlBHhNO+jhmSkC1xD88qSAWEcFu7vGt7utpoZZn9RGD5TVXavJHNLXYjvj9O5NQtDAjeKZ0T9toVCY0REw==",
+        "requested": "[4.8.0-beta00018, )",
+        "resolved": "4.8.0-beta00018",
+        "contentHash": "6Sddu/12UlwVHnjw9YLoP4G+8FkiNJG9J+fOfGDVSYFs1QvYfBYj7es4yf2XTsQdXn0WimB06v/adr0CcJl9CQ==",
         "dependencies": {
-          "Lucene.Net.Memory": "4.8.0-beta00017",
-          "Lucene.Net.Queries": "4.8.0-beta00017"
+          "Lucene.Net.Memory": "4.8.0-beta00018",
+          "Lucene.Net.Queries": "4.8.0-beta00018"
         }
       },
       "Sidio.Sitemap.AspNetCore": {

--- a/src/Goldfinch.Core/packages.lock.json
+++ b/src/Goldfinch.Core/packages.lock.json
@@ -10,13 +10,13 @@
       },
       "Kentico.Xperience.Admin": {
         "type": "Direct",
-        "requested": "[31.6.0, )",
-        "resolved": "31.6.0",
-        "contentHash": "oZwvRnUtAYu3mJ55gY4BSiJidWVQKaXa1qmIFZpdsBKzdiUNgRvJ1Glp4EB2d3LSKbPMBXKltOTgBv+8IlSUsw==",
+        "requested": "[31.6.1, )",
+        "resolved": "31.6.1",
+        "contentHash": "JU8z6ircJfEgP2MHQCOVrxiRsaZVOvqBJCsEifk17pU/4oD705dZyIyeuNHa7VUl7Il5w/T+RlShXn6rFddUmA==",
         "dependencies": {
           "Azure.AI.OpenAI": "2.1.0",
           "Kentico.Aira.Client": "6.1.0",
-          "Kentico.Xperience.WebApp": "[31.6.0]",
+          "Kentico.Xperience.WebApp": "[31.6.1]",
           "Microsoft.Agents.AI": "1.10.0",
           "Microsoft.Agents.AI.OpenAI": "1.10.0",
           "Microsoft.AspNetCore.SpaServices.Extensions": "8.0.28",
@@ -37,15 +37,15 @@
       },
       "Kentico.Xperience.WebApp": {
         "type": "Direct",
-        "requested": "[31.6.0, )",
-        "resolved": "31.6.0",
-        "contentHash": "ly3L4ZeGQSBbIIlbbCx3OZsWKMVgSUsGKWqd7WGPWjhvgci4C1YuPkW2ORR42d/aqcNM5pXOl17zSiKJawQ+Iw==",
+        "requested": "[31.6.1, )",
+        "resolved": "31.6.1",
+        "contentHash": "q8FAYRgWADj0wW+J9VWwm8gU/IkGiWwfWhSHFXCmGttGiqCiYY7Fi+YykSEYNZjZNtKlvLG6BQFQzH4FsiQ9Xw==",
         "dependencies": {
           "CommandLineParser": "2.9.1",
           "HotChocolate.AspNetCore": "15.1.16",
           "HotChocolate.Data": "15.1.16",
           "HtmlSanitizer": "9.0.892",
-          "Kentico.Xperience.Core": "[31.6.0]",
+          "Kentico.Xperience.Core": "[31.6.1]",
           "Microsoft.AspNetCore.Components": "8.0.28",
           "Microsoft.Extensions.Caching.Memory": "9.0.17",
           "Microsoft.Extensions.FileProviders.Embedded": "8.0.28"
@@ -487,8 +487,8 @@
       },
       "Kentico.Xperience.Core": {
         "type": "Transitive",
-        "resolved": "31.6.0",
-        "contentHash": "v+9Iq6ZCZbQYevXg2+AIC4UvZ2xkwb2elgFuJJNdgitDahjVRfGIfWW39sytYDIVY8+Hx9CldiiiKrmmF0yPng==",
+        "resolved": "31.6.1",
+        "contentHash": "RTRALxYej5oU9hw5uePLwrqTdHLBXmlDkdpSsBMEd2mZQba+TupjczfheTt0j0uKyALeuXSY3IyGjxMNurbLng==",
         "dependencies": {
           "AngleSharp": "0.17.1",
           "Kentico.Aira.Client": "6.1.0",

--- a/src/Goldfinch.Web/packages.lock.json
+++ b/src/Goldfinch.Web/packages.lock.json
@@ -4,13 +4,13 @@
     "net10.0": {
       "Kentico.Xperience.Admin": {
         "type": "Direct",
-        "requested": "[31.6.0, )",
-        "resolved": "31.6.0",
-        "contentHash": "oZwvRnUtAYu3mJ55gY4BSiJidWVQKaXa1qmIFZpdsBKzdiUNgRvJ1Glp4EB2d3LSKbPMBXKltOTgBv+8IlSUsw==",
+        "requested": "[31.6.1, )",
+        "resolved": "31.6.1",
+        "contentHash": "JU8z6ircJfEgP2MHQCOVrxiRsaZVOvqBJCsEifk17pU/4oD705dZyIyeuNHa7VUl7Il5w/T+RlShXn6rFddUmA==",
         "dependencies": {
           "Azure.AI.OpenAI": "2.1.0",
           "Kentico.Aira.Client": "6.1.0",
-          "Kentico.Xperience.WebApp": "[31.6.0]",
+          "Kentico.Xperience.WebApp": "[31.6.1]",
           "Microsoft.Agents.AI": "1.10.0",
           "Microsoft.Agents.AI.OpenAI": "1.10.0",
           "Microsoft.AspNetCore.SpaServices.Extensions": "8.0.28",
@@ -21,26 +21,26 @@
       },
       "Kentico.Xperience.AzureStorage": {
         "type": "Direct",
-        "requested": "[31.6.0, )",
-        "resolved": "31.6.0",
-        "contentHash": "1bHCXk02rJD/XQ6U3vmWsmAS2v09SX71P3yAnJTp0hUoGlJakBbxTIoTz5Ml+vlYYYecK3X+RjqjlPZTPebqQQ==",
+        "requested": "[31.6.1, )",
+        "resolved": "31.6.1",
+        "contentHash": "JG+RMohNDhX+KZN5qymNgWaQDYOQQ0DT+zTUv0W73wIfHid1ESIVJpp8Mo0tvtDk88dy6fPmP87etRS/fJqEiA==",
         "dependencies": {
           "Azure.Storage.Blobs": "12.29.0",
-          "Kentico.Xperience.Core": "31.6.0",
+          "Kentico.Xperience.Core": "31.6.1",
           "Newtonsoft.Json": "13.0.4",
           "System.IO.Hashing": "10.0.9"
         }
       },
       "Kentico.Xperience.ManagementApi": {
         "type": "Direct",
-        "requested": "[31.6.0-preview, )",
-        "resolved": "31.6.0-preview",
-        "contentHash": "wktyyefDS0cplrBP235qYiHSE0qwqPj1TMTu+NYWbjYRF2QLHR/FZrkU0Rb9GUwJApAG6PePXJ1qYp2E4Y031Q==",
+        "requested": "[31.6.1-preview, )",
+        "resolved": "31.6.1-preview",
+        "contentHash": "d13o7Fp0HsvRI0wxSx+cGQfVEAkv4T8i96mfNAJtSFsQFIp694Gg4jChl1mscyf4shtQt4E66BORwWGeqPe7fQ==",
         "dependencies": {
           "Asp.Versioning.Mvc": "8.1.1",
           "Asp.Versioning.Mvc.ApiExplorer": "8.1.1",
-          "Kentico.Xperience.Admin": "31.6.0",
-          "Kentico.Xperience.Core": "31.6.0",
+          "Kentico.Xperience.Admin": "31.6.1",
+          "Kentico.Xperience.Core": "31.6.1",
           "NJsonSchema": "11.6.1",
           "Swashbuckle.AspNetCore": "9.0.6",
           "Vogen": "8.0.5"
@@ -59,15 +59,15 @@
       },
       "Kentico.Xperience.WebApp": {
         "type": "Direct",
-        "requested": "[31.6.0, )",
-        "resolved": "31.6.0",
-        "contentHash": "ly3L4ZeGQSBbIIlbbCx3OZsWKMVgSUsGKWqd7WGPWjhvgci4C1YuPkW2ORR42d/aqcNM5pXOl17zSiKJawQ+Iw==",
+        "requested": "[31.6.1, )",
+        "resolved": "31.6.1",
+        "contentHash": "q8FAYRgWADj0wW+J9VWwm8gU/IkGiWwfWhSHFXCmGttGiqCiYY7Fi+YykSEYNZjZNtKlvLG6BQFQzH4FsiQ9Xw==",
         "dependencies": {
           "CommandLineParser": "2.9.1",
           "HotChocolate.AspNetCore": "15.1.16",
           "HotChocolate.Data": "15.1.16",
           "HtmlSanitizer": "9.0.892",
-          "Kentico.Xperience.Core": "[31.6.0]",
+          "Kentico.Xperience.Core": "[31.6.1]",
           "Microsoft.Extensions.FileProviders.Embedded": "8.0.28"
         }
       },
@@ -544,8 +544,8 @@
       },
       "Kentico.Xperience.Core": {
         "type": "Transitive",
-        "resolved": "31.6.0",
-        "contentHash": "v+9Iq6ZCZbQYevXg2+AIC4UvZ2xkwb2elgFuJJNdgitDahjVRfGIfWW39sytYDIVY8+Hx9CldiiiKrmmF0yPng==",
+        "resolved": "31.6.1",
+        "contentHash": "RTRALxYej5oU9hw5uePLwrqTdHLBXmlDkdpSsBMEd2mZQba+TupjczfheTt0j0uKyALeuXSY3IyGjxMNurbLng==",
         "dependencies": {
           "AngleSharp": "0.17.1",
           "Kentico.Aira.Client": "6.1.0",
@@ -581,8 +581,8 @@
       },
       "Lucene.Net": {
         "type": "Transitive",
-        "resolved": "4.8.0-beta00017",
-        "contentHash": "7LLWS9nNwx01AyE/KXMh+qdAlzDkRANE8407AO/wEmLL1InzVKFwfsRdRmwg4ILOMFui4xZ1Y54eqvzo3Tf9Vw==",
+        "resolved": "4.8.0-beta00018",
+        "contentHash": "iBkkpkDbAHjpZ0dnukFnWnjxSNmsRHOSxrYBBKbtcYJZ8PQRrKsqGGyNm8xmh4ORvsJ1WM7i5A9whiyA8WhNrQ==",
         "dependencies": {
           "J2N": "[2.1.0, 3.0.0)"
         }
@@ -623,18 +623,18 @@
       },
       "Lucene.Net.Memory": {
         "type": "Transitive",
-        "resolved": "4.8.0-beta00017",
-        "contentHash": "T4uG0k1iGzXXRRlmsFTtRPhnc2Ef1wlh68TxO2dN8qLW7AXX9qsIjOuN64+IXAPUkysvvks8psoU6epi642MUw==",
+        "resolved": "4.8.0-beta00018",
+        "contentHash": "FDdqAkKC33y/YTkx4uH5oci3OkNOdyyX0MWI/agSFn+7WlMxlj6CvH3tX+5fpi8Hf7EBqWjdP9hr26u4Kb4UNA==",
         "dependencies": {
-          "Lucene.Net": "4.8.0-beta00017"
+          "Lucene.Net": "4.8.0-beta00018"
         }
       },
       "Lucene.Net.Queries": {
         "type": "Transitive",
-        "resolved": "4.8.0-beta00017",
-        "contentHash": "RVpZCfa/7pgvytFw64zLqinvZPQt4TojvcFghdAA5vhnpSs5GTbtciPIxFH3wwH3f2dYJywiqYKo1h3JBCXRBA==",
+        "resolved": "4.8.0-beta00018",
+        "contentHash": "cS+Ea3m4ZcCId9MgYfgAs6UNiYfxykpNIZlf7nRPH/7zOa+TePX5ATM+0FLQu54bAkgWVAwV1T269PD0oQsToQ==",
         "dependencies": {
-          "Lucene.Net": "4.8.0-beta00017"
+          "Lucene.Net": "4.8.0-beta00018"
         }
       },
       "Magick.NET-Q8-AnyCPU": {
@@ -1071,18 +1071,18 @@
         "type": "Project",
         "dependencies": {
           "Goldfinch.Core": "[1.0.0, )",
-          "Kentico.Xperience.Admin": "[31.6.0, )",
-          "Kentico.Xperience.WebApp": "[31.6.0, )"
+          "Kentico.Xperience.Admin": "[31.6.1, )",
+          "Kentico.Xperience.WebApp": "[31.6.1, )"
         }
       },
       "goldfinch.core": {
         "type": "Project",
         "dependencies": {
           "AngleSharp": "[0.17.1, )",
-          "Kentico.Xperience.Admin": "[31.6.0, )",
+          "Kentico.Xperience.Admin": "[31.6.1, )",
           "Kentico.Xperience.Lucene": "[15.0.3, )",
-          "Kentico.Xperience.WebApp": "[31.6.0, )",
-          "Lucene.Net.Highlighter": "[4.8.0-beta00017, )",
+          "Kentico.Xperience.WebApp": "[31.6.1, )",
+          "Lucene.Net.Highlighter": "[4.8.0-beta00018, )",
           "Sidio.Sitemap.AspNetCore": "[3.1.1, )"
         }
       },
@@ -1104,12 +1104,12 @@
       },
       "Lucene.Net.Highlighter": {
         "type": "CentralTransitive",
-        "requested": "[4.8.0-beta00017, )",
-        "resolved": "4.8.0-beta00017",
-        "contentHash": "Mqm+KlBHhNO+jhmSkC1xD88qSAWEcFu7vGt7utpoZZn9RGD5TVXavJHNLXYjvj9O5NQtDAjeKZ0T9toVCY0REw==",
+        "requested": "[4.8.0-beta00018, )",
+        "resolved": "4.8.0-beta00018",
+        "contentHash": "6Sddu/12UlwVHnjw9YLoP4G+8FkiNJG9J+fOfGDVSYFs1QvYfBYj7es4yf2XTsQdXn0WimB06v/adr0CcJl9CQ==",
         "dependencies": {
-          "Lucene.Net.Memory": "4.8.0-beta00017",
-          "Lucene.Net.Queries": "4.8.0-beta00017"
+          "Lucene.Net.Memory": "4.8.0-beta00018",
+          "Lucene.Net.Queries": "4.8.0-beta00018"
         }
       }
     }


### PR DESCRIPTION
## Summary

Updates Xperience by Kentico from 31.6.0 to **31.6.1** (hotfix released 2 July 2026) via `scripts/Update-Xperience.ps1`.

> **Note:** this branch is stacked on #240 (Lucene CI exclusion) so the exclusion was active during the update's CI store/restore cycles — merge #240 first and this PR reduces to just the update commit.

### Package changes

- `Kentico.Xperience.Admin`, `Kentico.Xperience.AzureStorage`, `Kentico.Xperience.WebApp`: 31.6.0 → 31.6.1
- `Kentico.Xperience.ManagementApi`: 31.6.0-preview → 31.6.1-preview
- `@kentico/xperience-admin-base`, `@kentico/xperience-admin-components`, `@kentico/xperience-webpack-config`: 31.6.0 → 31.6.1
- `Kentico.Xperience.Lucene` (15.0.3) and `Kentico.Xperience.MiniProfiler` (3.0.0) unchanged — independent versioning
- `npm audit fix`: webpack-dev-server 5.2.5 → 5.2.6

### Release notes (31.6.1 hotfix)

No breaking changes and no manual steps. Fixes: mobile workflow side panel covered by nav bar, selector min/max validation messages, CD multi-line field line-endings (LF→CRLF) breaking content sync, and a spurious event-log warning from the Management MCP server when adding Page Builder widgets to published pages.

### Update run

- CI pre-restore, `--kxp-update` migration, and `--kxp-ci-store` all completed successfully
- **No CI repository changes** after the store — expected for a hotfix
- First real-world run of the CLI-based CI toggling from #239: `--kxp-ci-status`/`--kxp-ci-enable`/`--kxp-ci-disable` all worked as designed
- Solution builds cleanly with the new packages

### Manual testing checklist

- [ ] Homepage loads correctly
- [ ] Blog listing page works
- [ ] Blog detail pages render with images
- [ ] Navigation and header work
- [ ] Admin interface accessible (https://localhost:52623/admin)
- [ ] Page builder widgets function correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)