### PR TITLE
Add BlogPostExcerpt field for on-page standfirst / GEO overview

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,14 @@
+{
+  "mcpServers": {
+    "xperience-management-api": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["@kentico/management-api-mcp@latest"],
+      "env": {
+        "MANAGEMENT_API_URL": "https://localhost:52623/kentico-api/management",
+        "MANAGEMENT_API_SECRET": "HelloThisIsMySuperSuperSecretApiKey",
+        "NODE_TLS_REJECT_UNAUTHORIZED": "0"
+      }
+    }
+  }
+}

--- a/src/Goldfinch.Core/ContentTypes/PageContentTypes/Goldfinch/BlogPost/BlogPost.generated.cs
+++ b/src/Goldfinch.Core/ContentTypes/PageContentTypes/Goldfinch/BlogPost/BlogPost.generated.cs
@@ -36,6 +36,12 @@ namespace Goldfinch.Core.ContentTypes
 
 
 		/// <summary>
+		/// BlogPostExcerpt.
+		/// </summary>
+		public string BlogPostExcerpt { get; set; }
+
+
+		/// <summary>
 		/// BlogPostDate.
 		/// </summary>
 		public DateTime BlogPostDate { get; set; }

--- a/src/Goldfinch.Web/App_Data/CIRepository/@global/cms.contenttype/goldfinch.blogpost.xml
+++ b/src/Goldfinch.Web/App_Data/CIRepository/@global/cms.contenttype/goldfinch.blogpost.xml
@@ -11,6 +11,26 @@
       <schema guid="c5126ac7-4df1-481c-b978-987e59554cda" name="c5126ac7-4df1-481c-b978-987e59554cda">
         <properties />
       </schema>
+      <field allowempty="true" column="BlogPostExcerpt" columntype="longtext" enabled="true" guid="576f4290-d604-4012-839d-67a95eb0fcca" visible="true">
+        <properties>
+          <explanationtext>
+            <![CDATA[Optional. A self-contained 40–60 word overview shown under the title and used by search / AI answer engines. State specifics — what the post covers, what actually happened, and the key takeaway — naming real tools and outcomes rather than abstract phrases ("explores how AI helped"). Leave empty to fall back to the short description.]]>
+          </explanationtext>
+          <explanationtextashtml>False</explanationtextashtml>
+          <fieldcaption>Excerpt</fieldcaption>
+          <fielddescription>
+            <![CDATA[Optional. A self-contained 40–60 word overview shown under the title and used by search / AI answer engines. State specifics — what the post covers, what actually happened, and the key takeaway — naming real tools and outcomes rather than abstract phrases ("explores how AI helped"). Leave empty to fall back to the short description.]]>
+          </fielddescription>
+          <fielddescriptionashtml>False</fielddescriptionashtml>
+          <includeincontentgeneration>True</includeincontentgeneration>
+        </properties>
+        <settings>
+          <controlname>Kentico.Administration.TextArea</controlname>
+          <CopyButtonVisible>False</CopyButtonVisible>
+          <MaxRowsNumber>5</MaxRowsNumber>
+          <MinRowsNumber>3</MinRowsNumber>
+        </settings>
+      </field>
       <field column="BlogPostDate" columnprecision="0" columntype="date" enabled="true" guid="5297ab96-9ac0-4a56-a398-646ee2249bd4" visible="true">
         <properties>
           <explanationtextashtml>False</explanationtextashtml>

--- a/src/Goldfinch.Web/Features/BlogDetail/BlogDetail.cshtml
+++ b/src/Goldfinch.Web/Features/BlogDetail/BlogDetail.cshtml
@@ -49,9 +49,9 @@
                 <span class="clock"><icon name="clock" size="12" /> @Model.ReadingMinutes min read</span>
             </div>
             <h1>@Model.Title</h1>
-            @if (!string.IsNullOrWhiteSpace(Model.Summary))
+            @if (!string.IsNullOrWhiteSpace(Model.Excerpt))
             {
-                <p class="post-summary">@Model.Summary</p>
+                <p class="post-summary">@Model.Excerpt</p>
             }
 
             <div class="post-body">

--- a/src/Goldfinch.Web/Features/BlogDetail/BlogPostViewModel.cs
+++ b/src/Goldfinch.Web/Features/BlogDetail/BlogPostViewModel.cs
@@ -15,6 +15,13 @@ public class BlogPostViewModel
 
     public required string Summary { get; set; }
 
+    /// <summary>
+    /// On-page standfirst / GEO overview. Falls back to the short description when the
+    /// BlogPostExcerpt field is empty. Used only by the detail page — the card and meta
+    /// description keep using Summary (BaseContentShortDescription).
+    /// </summary>
+    public string Excerpt { get; set; } = string.Empty;
+
     public required string Url { get; set; }
 
     public DateTime BlogPostDate { get; set; }
@@ -42,6 +49,9 @@ public class BlogPostViewModel
         {
             Title = blogPost.BaseContentTitle,
             Summary = blogPost.BaseContentShortDescription,
+            Excerpt = string.IsNullOrWhiteSpace(blogPost.BlogPostExcerpt)
+                ? blogPost.BaseContentShortDescription
+                : blogPost.BlogPostExcerpt,
             BlogPostDate = blogPost.BlogPostDate,
             Url = url,
             Filename = FilenameFromUrl(url),


### PR DESCRIPTION
## What

Adds a dedicated `BlogPostExcerpt` field (Long text) to `Goldfinch.BlogPost`, rendered in the post-detail **standfirst** slot (under the H1). Falls back to `BaseContentShortDescription` when empty.

## Why

The short description was wearing four hats (on-page lede, listing card teaser, RSS/JSON-LD description, meta/OG description). Those want a tight ~155-char string; the on-page lede wants room for a fuller, concrete overview that search and AI answer engines (GEO) can lift. One field cannot be both — so the excerpt splits out the lede.

## Scope

- **Standfirst** now renders `Excerpt`.
- **Unchanged (still use short description):** listing card, RSS `<description>`, JSON-LD `BlogPosting.Description`, and `<meta name="description">` / `og:description`.
- Zero regression: posts without an excerpt render exactly as before.

Field is placed directly after Title + Short Description in the form, and is authored with 40–60-word guidance in its explanation text.

## Changes

- Content type field added (CI-serialised) + regenerated `BlogPost.generated.cs`
- `BlogPostViewModel.Excerpt` with fallback
- `BlogDetail.cshtml` standfirst switched to `Excerpt`

## Verification

Built clean (0 warnings, nullable-as-errors). Verified live: fallback renders short description; a populated excerpt renders in the standfirst while card + meta description stay on the short description.

🤖 Generated with [Claude Code](https://claude.com/claude-code)