### PR TITLE
build(sln): update to Xperience v31.6.2

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -7,12 +7,12 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="coverlet.collector" Version="10.0.1" />
-    <PackageVersion Include="Kentico.Xperience.Admin" Version="31.6.1" />
-    <PackageVersion Include="Kentico.Xperience.AzureStorage" Version="31.6.1" />
-    <PackageVersion Include="Kentico.Xperience.Lucene" Version="15.0.3" />
-    <PackageVersion Include="Kentico.Xperience.ManagementApi" Version="31.6.1-preview" />
+    <PackageVersion Include="Kentico.Xperience.Admin" Version="31.6.2" />
+    <PackageVersion Include="Kentico.Xperience.AzureStorage" Version="31.6.2" />
+    <PackageVersion Include="Kentico.Xperience.Lucene" Version="15.0.4" />
+    <PackageVersion Include="Kentico.Xperience.ManagementApi" Version="31.6.2-preview" />
     <PackageVersion Include="Kentico.Xperience.MiniProfiler" Version="3.0.0" />
-    <PackageVersion Include="Kentico.Xperience.WebApp" Version="31.6.1" />
+    <PackageVersion Include="Kentico.Xperience.WebApp" Version="31.6.2" />
     <PackageVersion Include="Lucene.Net.Highlighter" Version="4.8.0-beta00018" />
     <PackageVersion Include="AngleSharp" Version="0.17.1" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />

--- a/src/Goldfinch.Admin/Client/package-lock.json
+++ b/src/Goldfinch.Admin/Client/package-lock.json
@@ -8,8 +8,8 @@
       "name": "goldfinch-web-admin",
       "version": "1.0.0",
       "dependencies": {
-        "@kentico/xperience-admin-base": "^31.6.1",
-        "@kentico/xperience-admin-components": "^31.6.1",
+        "@kentico/xperience-admin-base": "^31.6.2",
+        "@kentico/xperience-admin-components": "^31.6.2",
         "react": "^18.3.1",
         "react-dom": "^18.3.1"
       },
@@ -19,7 +19,7 @@
         "@babel/preset-env": "^8.0.2",
         "@babel/preset-react": "^8.0.1",
         "@babel/preset-typescript": "^8.0.1",
-        "@kentico/xperience-webpack-config": "^31.6.1",
+        "@kentico/xperience-webpack-config": "^31.6.2",
         "@types/react": "^18.3.1",
         "@types/react-dom": "^18.3.1",
         "babel-loader": "^10.0.0",
@@ -4624,12 +4624,13 @@
       "license": "Apache-2.0"
     },
     "node_modules/@kentico/xperience-admin-base": {
-      "version": "31.6.1",
-      "resolved": "https://registry.npmjs.org/@kentico/xperience-admin-base/-/xperience-admin-base-31.6.1.tgz",
-      "integrity": "sha512-Ft5ETD10DrSZ+iYzCy6K9Vq+2KQ5tFszYFoPeWJESWwAm6geNnZQpXMZqtQuYUbuzmviTKAOpTiLnyzFu2C0Fg==",
+      "version": "31.6.2",
+      "resolved": "https://registry.npmjs.org/@kentico/xperience-admin-base/-/xperience-admin-base-31.6.2.tgz",
+      "integrity": "sha512-gUUMaPLXPrCMm4+XbsdL4tviqFXAo2w6Io8f8yk+G3roWj45w3KcJZIo2iFr3UBfEfFP+VXPh4nqq20PuPkwug==",
+      "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",
-        "@kentico/xperience-admin-components": "31.6.1",
+        "@kentico/xperience-admin-components": "31.6.2",
         "@react-aria/focus": "3.22.1",
         "@react-aria/i18n": "3.13.1",
         "@react-aria/visually-hidden": "3.9.1",
@@ -4656,9 +4657,10 @@
       }
     },
     "node_modules/@kentico/xperience-admin-components": {
-      "version": "31.6.1",
-      "resolved": "https://registry.npmjs.org/@kentico/xperience-admin-components/-/xperience-admin-components-31.6.1.tgz",
-      "integrity": "sha512-1EKlGRrVxUFmDn2vBFUfdewf/DVdxJZRWbYcLrirF1KeShEX+yf2Os2Rt81EDYNVOm9ZMjBROHBwRk8mpmDWpQ==",
+      "version": "31.6.2",
+      "resolved": "https://registry.npmjs.org/@kentico/xperience-admin-components/-/xperience-admin-components-31.6.2.tgz",
+      "integrity": "sha512-coLRtM70qHBuzCtNfu5uJAeXOKgDwHcQNYrG3XDO+V1BBM2IxyOekplNaBHUGrFWK1fuNq3Y9xE7Xy7ye7mzZw==",
+      "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@amcharts/amcharts5": "5.19.0",
         "@codemirror/lang-css": "6.3.1",
@@ -4697,10 +4699,11 @@
       }
     },
     "node_modules/@kentico/xperience-webpack-config": {
-      "version": "31.6.1",
-      "resolved": "https://registry.npmjs.org/@kentico/xperience-webpack-config/-/xperience-webpack-config-31.6.1.tgz",
-      "integrity": "sha512-SIEK2SneQIUpYi8eB9NX99q31C21etAtW6keLmGFz2X/JKPnUj6vTcCvrjCUknzKABldQsAcPzKT9chvxgAYhg==",
+      "version": "31.6.2",
+      "resolved": "https://registry.npmjs.org/@kentico/xperience-webpack-config/-/xperience-webpack-config-31.6.2.tgz",
+      "integrity": "sha512-7i6uUMoa+pX5V0IGyKDy+L6h0xyaSl6iddmurUKa9AyTa9jRNicbPh5OIdFf5VxtHssqE/fnAeV1n8A2duFsaQ==",
       "dev": true,
+      "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "systemjs-webpack-interop": "2.3.7"
       }

--- a/src/Goldfinch.Admin/Client/package.json
+++ b/src/Goldfinch.Admin/Client/package.json
@@ -11,8 +11,8 @@
     "build": "webpack --mode=production"
   },
   "dependencies": {
-    "@kentico/xperience-admin-base": "^31.6.1",
-    "@kentico/xperience-admin-components": "^31.6.1",
+    "@kentico/xperience-admin-base": "^31.6.2",
+    "@kentico/xperience-admin-components": "^31.6.2",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"
   },
@@ -22,7 +22,7 @@
     "@babel/preset-env": "^8.0.2",
     "@babel/preset-react": "^8.0.1",
     "@babel/preset-typescript": "^8.0.1",
-    "@kentico/xperience-webpack-config": "^31.6.1",
+    "@kentico/xperience-webpack-config": "^31.6.2",
     "@types/react": "^18.3.1",
     "@types/react-dom": "^18.3.1",
     "babel-loader": "^10.0.0",

--- a/src/Goldfinch.Admin/packages.lock.json
+++ b/src/Goldfinch.Admin/packages.lock.json
@@ -4,13 +4,13 @@
     "net10.0": {
       "Kentico.Xperience.Admin": {
         "type": "Direct",
-        "requested": "[31.6.1, )",
-        "resolved": "31.6.1",
-        "contentHash": "JU8z6ircJfEgP2MHQCOVrxiRsaZVOvqBJCsEifk17pU/4oD705dZyIyeuNHa7VUl7Il5w/T+RlShXn6rFddUmA==",
+        "requested": "[31.6.2, )",
+        "resolved": "31.6.2",
+        "contentHash": "s1giGPJFgyupjm87FLSsoeZuLq05xT57M8/5qfBzVR+qicnc71hnCrf6S0eTEHD2tAPRVJ4NeuLOMcQzM3F5wQ==",
         "dependencies": {
           "Azure.AI.OpenAI": "2.1.0",
           "Kentico.Aira.Client": "6.1.0",
-          "Kentico.Xperience.WebApp": "[31.6.1]",
+          "Kentico.Xperience.WebApp": "[31.6.2]",
           "Microsoft.Agents.AI": "1.10.0",
           "Microsoft.Agents.AI.OpenAI": "1.10.0",
           "Microsoft.AspNetCore.SpaServices.Extensions": "8.0.28",
@@ -21,15 +21,15 @@
       },
       "Kentico.Xperience.WebApp": {
         "type": "Direct",
-        "requested": "[31.6.1, )",
-        "resolved": "31.6.1",
-        "contentHash": "q8FAYRgWADj0wW+J9VWwm8gU/IkGiWwfWhSHFXCmGttGiqCiYY7Fi+YykSEYNZjZNtKlvLG6BQFQzH4FsiQ9Xw==",
+        "requested": "[31.6.2, )",
+        "resolved": "31.6.2",
+        "contentHash": "eGBMt5ZIfvqBMExFEwJFW+tTx1OLgIep9ETxOOYqsu3Us45DLDYy7VxwdzrPDEJAL8sdQM87BEkZXS/xTktXRQ==",
         "dependencies": {
           "CommandLineParser": "2.9.1",
           "HotChocolate.AspNetCore": "15.1.16",
           "HotChocolate.Data": "15.1.16",
           "HtmlSanitizer": "9.0.892",
-          "Kentico.Xperience.Core": "[31.6.1]",
+          "Kentico.Xperience.Core": "[31.6.2]",
           "Microsoft.Extensions.FileProviders.Embedded": "8.0.28"
         }
       },
@@ -426,8 +426,8 @@
       },
       "Kentico.Xperience.Core": {
         "type": "Transitive",
-        "resolved": "31.6.1",
-        "contentHash": "RTRALxYej5oU9hw5uePLwrqTdHLBXmlDkdpSsBMEd2mZQba+TupjczfheTt0j0uKyALeuXSY3IyGjxMNurbLng==",
+        "resolved": "31.6.2",
+        "contentHash": "TZZ+lUIF5Q33zL4pTi3BFngNlSUbaORNqR52IOFFg7GlaQRlRED6ghsPLN9m5pA3OaP6ow9VS8wA2S9jySy38g==",
         "dependencies": {
           "AngleSharp": "0.17.1",
           "Kentico.Aira.Client": "6.1.0",
@@ -443,17 +443,17 @@
       },
       "Kentico.Xperience.Lucene.Admin": {
         "type": "Transitive",
-        "resolved": "15.0.3",
-        "contentHash": "q2AyXL+nDnQMtlgDWhAc3pLbH5VpY2Z2+b71lu/wzA70wrNJka3vJ6/caj/UZKHgqfEtvgj6CsJ37AGz6P/jVw==",
+        "resolved": "15.0.4",
+        "contentHash": "0cr43vMldc84jPzbbS3UfJy0+fgrTyMPqxx12s3uq0AD1YJv4r6mmUWlFvvwWBpdsiYN2+a733XFgQwF/oVA2A==",
         "dependencies": {
           "Kentico.Xperience.Admin": "31.0.0",
-          "Kentico.Xperience.Lucene.Core": "15.0.3"
+          "Kentico.Xperience.Lucene.Core": "15.0.4"
         }
       },
       "Kentico.Xperience.Lucene.Core": {
         "type": "Transitive",
-        "resolved": "15.0.3",
-        "contentHash": "VGQ83QOfNwm9tJVDnUgJTFopx6SEzPTlxZ9ouNkziQpxEIjcy/tj//54H/vjTFsUGzXFOJSErOPqLTUGlE3Qww==",
+        "resolved": "15.0.4",
+        "contentHash": "ti0l2y+wBJXYzz5HL/Bh/ibmzIZfyFclSch4vCJLOdfprn9fOxTy5fEiJplT6AK1tENCk9MUzWSZg5bXt9OQkQ==",
         "dependencies": {
           "Kentico.Xperience.Core": "31.0.0",
           "Lucene.Net": "4.8.0-beta00017",
@@ -868,9 +868,9 @@
         "type": "Project",
         "dependencies": {
           "AngleSharp": "[0.17.1, )",
-          "Kentico.Xperience.Admin": "[31.6.1, )",
-          "Kentico.Xperience.Lucene": "[15.0.3, )",
-          "Kentico.Xperience.WebApp": "[31.6.1, )",
+          "Kentico.Xperience.Admin": "[31.6.2, )",
+          "Kentico.Xperience.Lucene": "[15.0.4, )",
+          "Kentico.Xperience.WebApp": "[31.6.2, )",
           "Lucene.Net.Highlighter": "[4.8.0-beta00018, )",
           "Sidio.Sitemap.AspNetCore": "[3.1.1, )"
         }
@@ -883,12 +883,12 @@
       },
       "Kentico.Xperience.Lucene": {
         "type": "CentralTransitive",
-        "requested": "[15.0.3, )",
-        "resolved": "15.0.3",
-        "contentHash": "xihyGfQ59suos8OBXosEev/oIPHlcPd5CXuDE6a/mAAUyN9Vi3Mnw2qGYJ1czF6WaflvUpesnfpYSqDj079PsQ==",
+        "requested": "[15.0.4, )",
+        "resolved": "15.0.4",
+        "contentHash": "E7OofKBeqB3ygMs5d+bDpw8Y9RBy9I/wZi19qoRLF0vN4HgXXZNxjXchrtHKzorrL9j6SNVMlJ5L/uSnVTD+Fw==",
         "dependencies": {
-          "Kentico.Xperience.Lucene.Admin": "15.0.3",
-          "Kentico.Xperience.Lucene.Core": "15.0.3"
+          "Kentico.Xperience.Lucene.Admin": "15.0.4",
+          "Kentico.Xperience.Lucene.Core": "15.0.4"
         }
       },
       "Lucene.Net.Highlighter": {

--- a/src/Goldfinch.Core/packages.lock.json
+++ b/src/Goldfinch.Core/packages.lock.json
@@ -10,13 +10,13 @@
       },
       "Kentico.Xperience.Admin": {
         "type": "Direct",
-        "requested": "[31.6.1, )",
-        "resolved": "31.6.1",
-        "contentHash": "JU8z6ircJfEgP2MHQCOVrxiRsaZVOvqBJCsEifk17pU/4oD705dZyIyeuNHa7VUl7Il5w/T+RlShXn6rFddUmA==",
+        "requested": "[31.6.2, )",
+        "resolved": "31.6.2",
+        "contentHash": "s1giGPJFgyupjm87FLSsoeZuLq05xT57M8/5qfBzVR+qicnc71hnCrf6S0eTEHD2tAPRVJ4NeuLOMcQzM3F5wQ==",
         "dependencies": {
           "Azure.AI.OpenAI": "2.1.0",
           "Kentico.Aira.Client": "6.1.0",
-          "Kentico.Xperience.WebApp": "[31.6.1]",
+          "Kentico.Xperience.WebApp": "[31.6.2]",
           "Microsoft.Agents.AI": "1.10.0",
           "Microsoft.Agents.AI.OpenAI": "1.10.0",
           "Microsoft.AspNetCore.SpaServices.Extensions": "8.0.28",
@@ -27,25 +27,25 @@
       },
       "Kentico.Xperience.Lucene": {
         "type": "Direct",
-        "requested": "[15.0.3, )",
-        "resolved": "15.0.3",
-        "contentHash": "xihyGfQ59suos8OBXosEev/oIPHlcPd5CXuDE6a/mAAUyN9Vi3Mnw2qGYJ1czF6WaflvUpesnfpYSqDj079PsQ==",
+        "requested": "[15.0.4, )",
+        "resolved": "15.0.4",
+        "contentHash": "E7OofKBeqB3ygMs5d+bDpw8Y9RBy9I/wZi19qoRLF0vN4HgXXZNxjXchrtHKzorrL9j6SNVMlJ5L/uSnVTD+Fw==",
         "dependencies": {
-          "Kentico.Xperience.Lucene.Admin": "15.0.3",
-          "Kentico.Xperience.Lucene.Core": "15.0.3"
+          "Kentico.Xperience.Lucene.Admin": "15.0.4",
+          "Kentico.Xperience.Lucene.Core": "15.0.4"
         }
       },
       "Kentico.Xperience.WebApp": {
         "type": "Direct",
-        "requested": "[31.6.1, )",
-        "resolved": "31.6.1",
-        "contentHash": "q8FAYRgWADj0wW+J9VWwm8gU/IkGiWwfWhSHFXCmGttGiqCiYY7Fi+YykSEYNZjZNtKlvLG6BQFQzH4FsiQ9Xw==",
+        "requested": "[31.6.2, )",
+        "resolved": "31.6.2",
+        "contentHash": "eGBMt5ZIfvqBMExFEwJFW+tTx1OLgIep9ETxOOYqsu3Us45DLDYy7VxwdzrPDEJAL8sdQM87BEkZXS/xTktXRQ==",
         "dependencies": {
           "CommandLineParser": "2.9.1",
           "HotChocolate.AspNetCore": "15.1.16",
           "HotChocolate.Data": "15.1.16",
           "HtmlSanitizer": "9.0.892",
-          "Kentico.Xperience.Core": "[31.6.1]",
+          "Kentico.Xperience.Core": "[31.6.2]",
           "Microsoft.AspNetCore.Components": "8.0.28",
           "Microsoft.Extensions.Caching.Memory": "9.0.17",
           "Microsoft.Extensions.FileProviders.Embedded": "8.0.28"
@@ -487,8 +487,8 @@
       },
       "Kentico.Xperience.Core": {
         "type": "Transitive",
-        "resolved": "31.6.1",
-        "contentHash": "RTRALxYej5oU9hw5uePLwrqTdHLBXmlDkdpSsBMEd2mZQba+TupjczfheTt0j0uKyALeuXSY3IyGjxMNurbLng==",
+        "resolved": "31.6.2",
+        "contentHash": "TZZ+lUIF5Q33zL4pTi3BFngNlSUbaORNqR52IOFFg7GlaQRlRED6ghsPLN9m5pA3OaP6ow9VS8wA2S9jySy38g==",
         "dependencies": {
           "AngleSharp": "0.17.1",
           "Kentico.Aira.Client": "6.1.0",
@@ -512,17 +512,17 @@
       },
       "Kentico.Xperience.Lucene.Admin": {
         "type": "Transitive",
-        "resolved": "15.0.3",
-        "contentHash": "q2AyXL+nDnQMtlgDWhAc3pLbH5VpY2Z2+b71lu/wzA70wrNJka3vJ6/caj/UZKHgqfEtvgj6CsJ37AGz6P/jVw==",
+        "resolved": "15.0.4",
+        "contentHash": "0cr43vMldc84jPzbbS3UfJy0+fgrTyMPqxx12s3uq0AD1YJv4r6mmUWlFvvwWBpdsiYN2+a733XFgQwF/oVA2A==",
         "dependencies": {
           "Kentico.Xperience.Admin": "31.0.0",
-          "Kentico.Xperience.Lucene.Core": "15.0.3"
+          "Kentico.Xperience.Lucene.Core": "15.0.4"
         }
       },
       "Kentico.Xperience.Lucene.Core": {
         "type": "Transitive",
-        "resolved": "15.0.3",
-        "contentHash": "VGQ83QOfNwm9tJVDnUgJTFopx6SEzPTlxZ9ouNkziQpxEIjcy/tj//54H/vjTFsUGzXFOJSErOPqLTUGlE3Qww==",
+        "resolved": "15.0.4",
+        "contentHash": "ti0l2y+wBJXYzz5HL/Bh/ibmzIZfyFclSch4vCJLOdfprn9fOxTy5fEiJplT6AK1tENCk9MUzWSZg5bXt9OQkQ==",
         "dependencies": {
           "Kentico.Xperience.Core": "31.0.0",
           "Lucene.Net": "4.8.0-beta00017",

--- a/src/Goldfinch.Web/Goldfinch.Web.csproj
+++ b/src/Goldfinch.Web/Goldfinch.Web.csproj
@@ -2,8 +2,7 @@
 	<ItemGroup>
 		<PackageReference Include="Kentico.Xperience.Admin" />
 		<PackageReference Include="Kentico.Xperience.AzureStorage" />
-		<!-- Local-development-only tool; excluded from Release builds so it never ships to production. See Program.cs (#if DEBUG). -->
-		<PackageReference Include="Kentico.Xperience.ManagementApi" Condition="'$(Configuration)' == 'Debug'" />
+		<PackageReference Include="Kentico.Xperience.ManagementApi" />
 		<PackageReference Include="Kentico.Xperience.MiniProfiler" />
 		<PackageReference Include="Kentico.Xperience.WebApp" />
 		<PackageReference Include="Schema.NET" />

--- a/src/Goldfinch.Web/Program.cs
+++ b/src/Goldfinch.Web/Program.cs
@@ -10,9 +10,7 @@ using Kentico.Membership;
 using Kentico.PageBuilder.Web.Mvc;
 using Kentico.Web.Mvc;
 using Kentico.Xperience.Admin.Base;
-#if DEBUG
 using Kentico.Xperience.ManagementApi;
-#endif
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Routing;
@@ -104,19 +102,13 @@ if (env.IsDevelopment())
         options.PopupRenderPosition = RenderPosition.BottomLeft;
     });
 
-#if DEBUG
-    // The Management API is a local-development-only tool and must never ship to production
-    // (per Kentico's own guidance). The Kentico.Xperience.ManagementApi package is referenced
-    // only in Debug builds (see Goldfinch.Web.csproj), so this call, the using directive, and the
-    // UseKenticoManagementApi() middleware below are all compiled out of Release builds. This keeps
-    // the assembly — and its auto-initialising ManagementApiModule — out of the production
-    // deployment entirely, which also avoids the 31.6.0-preview startup crash where the module
-    // resolves IOpenApiReferenceRegister even when the API was never enabled.
+    // The Management API is a local-development-only tool (per Kentico's guidance) and must never
+    // be enabled in production, so it is registered only under the IsDevelopment() guard. The
+    // matching UseKenticoManagementApi() middleware below is guarded the same way.
     builder.Services.AddKenticoManagementApi(options =>
     {
         options.Secret = "HelloThisIsMySuperSuperSecretApiKey";
     });
-#endif
 }
 else
 {
@@ -144,12 +136,10 @@ app.UseStaticFiles();
 
 app.UseAuthentication();
 
-#if DEBUG
 if (builder.Environment.IsDevelopment())
 {
     app.UseKenticoManagementApi();
 }
-#endif
 
 app.UseKentico();
 

--- a/src/Goldfinch.Web/packages.lock.json
+++ b/src/Goldfinch.Web/packages.lock.json
@@ -4,13 +4,13 @@
     "net10.0": {
       "Kentico.Xperience.Admin": {
         "type": "Direct",
-        "requested": "[31.6.1, )",
-        "resolved": "31.6.1",
-        "contentHash": "JU8z6ircJfEgP2MHQCOVrxiRsaZVOvqBJCsEifk17pU/4oD705dZyIyeuNHa7VUl7Il5w/T+RlShXn6rFddUmA==",
+        "requested": "[31.6.2, )",
+        "resolved": "31.6.2",
+        "contentHash": "s1giGPJFgyupjm87FLSsoeZuLq05xT57M8/5qfBzVR+qicnc71hnCrf6S0eTEHD2tAPRVJ4NeuLOMcQzM3F5wQ==",
         "dependencies": {
           "Azure.AI.OpenAI": "2.1.0",
           "Kentico.Aira.Client": "6.1.0",
-          "Kentico.Xperience.WebApp": "[31.6.1]",
+          "Kentico.Xperience.WebApp": "[31.6.2]",
           "Microsoft.Agents.AI": "1.10.0",
           "Microsoft.Agents.AI.OpenAI": "1.10.0",
           "Microsoft.AspNetCore.SpaServices.Extensions": "8.0.28",
@@ -21,26 +21,26 @@
       },
       "Kentico.Xperience.AzureStorage": {
         "type": "Direct",
-        "requested": "[31.6.1, )",
-        "resolved": "31.6.1",
-        "contentHash": "JG+RMohNDhX+KZN5qymNgWaQDYOQQ0DT+zTUv0W73wIfHid1ESIVJpp8Mo0tvtDk88dy6fPmP87etRS/fJqEiA==",
+        "requested": "[31.6.2, )",
+        "resolved": "31.6.2",
+        "contentHash": "1xeFfOEpJOO+tfXT+XtkrDQXIiGWCbF/5A5RiOiOa/iUCrFGv3PmqGd3qkrzHWOzBuyaH8AYeF8OLY+lF1R7Ow==",
         "dependencies": {
           "Azure.Storage.Blobs": "12.29.0",
-          "Kentico.Xperience.Core": "31.6.1",
+          "Kentico.Xperience.Core": "31.6.2",
           "Newtonsoft.Json": "13.0.4",
           "System.IO.Hashing": "10.0.9"
         }
       },
       "Kentico.Xperience.ManagementApi": {
         "type": "Direct",
-        "requested": "[31.6.1-preview, )",
-        "resolved": "31.6.1-preview",
-        "contentHash": "d13o7Fp0HsvRI0wxSx+cGQfVEAkv4T8i96mfNAJtSFsQFIp694Gg4jChl1mscyf4shtQt4E66BORwWGeqPe7fQ==",
+        "requested": "[31.6.2-preview, )",
+        "resolved": "31.6.2-preview",
+        "contentHash": "ZbitII56Ho5FzF8M58uv+qT/42jtl/s6bMhH5xFCnW08J7mYUlSnF/iYzTU4uWEx55P3GM6x+3Og0MIOvNu/cA==",
         "dependencies": {
           "Asp.Versioning.Mvc": "8.1.1",
           "Asp.Versioning.Mvc.ApiExplorer": "8.1.1",
-          "Kentico.Xperience.Admin": "31.6.1",
-          "Kentico.Xperience.Core": "31.6.1",
+          "Kentico.Xperience.Admin": "31.6.2",
+          "Kentico.Xperience.Core": "31.6.2",
           "NJsonSchema": "11.6.1",
           "Swashbuckle.AspNetCore": "9.0.6",
           "Vogen": "8.0.5"
@@ -59,15 +59,15 @@
       },
       "Kentico.Xperience.WebApp": {
         "type": "Direct",
-        "requested": "[31.6.1, )",
-        "resolved": "31.6.1",
-        "contentHash": "q8FAYRgWADj0wW+J9VWwm8gU/IkGiWwfWhSHFXCmGttGiqCiYY7Fi+YykSEYNZjZNtKlvLG6BQFQzH4FsiQ9Xw==",
+        "requested": "[31.6.2, )",
+        "resolved": "31.6.2",
+        "contentHash": "eGBMt5ZIfvqBMExFEwJFW+tTx1OLgIep9ETxOOYqsu3Us45DLDYy7VxwdzrPDEJAL8sdQM87BEkZXS/xTktXRQ==",
         "dependencies": {
           "CommandLineParser": "2.9.1",
           "HotChocolate.AspNetCore": "15.1.16",
           "HotChocolate.Data": "15.1.16",
           "HtmlSanitizer": "9.0.892",
-          "Kentico.Xperience.Core": "[31.6.1]",
+          "Kentico.Xperience.Core": "[31.6.2]",
           "Microsoft.Extensions.FileProviders.Embedded": "8.0.28"
         }
       },
@@ -544,8 +544,8 @@
       },
       "Kentico.Xperience.Core": {
         "type": "Transitive",
-        "resolved": "31.6.1",
-        "contentHash": "RTRALxYej5oU9hw5uePLwrqTdHLBXmlDkdpSsBMEd2mZQba+TupjczfheTt0j0uKyALeuXSY3IyGjxMNurbLng==",
+        "resolved": "31.6.2",
+        "contentHash": "TZZ+lUIF5Q33zL4pTi3BFngNlSUbaORNqR52IOFFg7GlaQRlRED6ghsPLN9m5pA3OaP6ow9VS8wA2S9jySy38g==",
         "dependencies": {
           "AngleSharp": "0.17.1",
           "Kentico.Aira.Client": "6.1.0",
@@ -561,17 +561,17 @@
       },
       "Kentico.Xperience.Lucene.Admin": {
         "type": "Transitive",
-        "resolved": "15.0.3",
-        "contentHash": "q2AyXL+nDnQMtlgDWhAc3pLbH5VpY2Z2+b71lu/wzA70wrNJka3vJ6/caj/UZKHgqfEtvgj6CsJ37AGz6P/jVw==",
+        "resolved": "15.0.4",
+        "contentHash": "0cr43vMldc84jPzbbS3UfJy0+fgrTyMPqxx12s3uq0AD1YJv4r6mmUWlFvvwWBpdsiYN2+a733XFgQwF/oVA2A==",
         "dependencies": {
           "Kentico.Xperience.Admin": "31.0.0",
-          "Kentico.Xperience.Lucene.Core": "15.0.3"
+          "Kentico.Xperience.Lucene.Core": "15.0.4"
         }
       },
       "Kentico.Xperience.Lucene.Core": {
         "type": "Transitive",
-        "resolved": "15.0.3",
-        "contentHash": "VGQ83QOfNwm9tJVDnUgJTFopx6SEzPTlxZ9ouNkziQpxEIjcy/tj//54H/vjTFsUGzXFOJSErOPqLTUGlE3Qww==",
+        "resolved": "15.0.4",
+        "contentHash": "ti0l2y+wBJXYzz5HL/Bh/ibmzIZfyFclSch4vCJLOdfprn9fOxTy5fEiJplT6AK1tENCk9MUzWSZg5bXt9OQkQ==",
         "dependencies": {
           "Kentico.Xperience.Core": "31.0.0",
           "Lucene.Net": "4.8.0-beta00017",
@@ -1071,17 +1071,17 @@
         "type": "Project",
         "dependencies": {
           "Goldfinch.Core": "[1.0.0, )",
-          "Kentico.Xperience.Admin": "[31.6.1, )",
-          "Kentico.Xperience.WebApp": "[31.6.1, )"
+          "Kentico.Xperience.Admin": "[31.6.2, )",
+          "Kentico.Xperience.WebApp": "[31.6.2, )"
         }
       },
       "goldfinch.core": {
         "type": "Project",
         "dependencies": {
           "AngleSharp": "[0.17.1, )",
-          "Kentico.Xperience.Admin": "[31.6.1, )",
-          "Kentico.Xperience.Lucene": "[15.0.3, )",
-          "Kentico.Xperience.WebApp": "[31.6.1, )",
+          "Kentico.Xperience.Admin": "[31.6.2, )",
+          "Kentico.Xperience.Lucene": "[15.0.4, )",
+          "Kentico.Xperience.WebApp": "[31.6.2, )",
           "Lucene.Net.Highlighter": "[4.8.0-beta00018, )",
           "Sidio.Sitemap.AspNetCore": "[3.1.1, )"
         }
@@ -1094,12 +1094,12 @@
       },
       "Kentico.Xperience.Lucene": {
         "type": "CentralTransitive",
-        "requested": "[15.0.3, )",
-        "resolved": "15.0.3",
-        "contentHash": "xihyGfQ59suos8OBXosEev/oIPHlcPd5CXuDE6a/mAAUyN9Vi3Mnw2qGYJ1czF6WaflvUpesnfpYSqDj079PsQ==",
+        "requested": "[15.0.4, )",
+        "resolved": "15.0.4",
+        "contentHash": "E7OofKBeqB3ygMs5d+bDpw8Y9RBy9I/wZi19qoRLF0vN4HgXXZNxjXchrtHKzorrL9j6SNVMlJ5L/uSnVTD+Fw==",
         "dependencies": {
-          "Kentico.Xperience.Lucene.Admin": "15.0.3",
-          "Kentico.Xperience.Lucene.Core": "15.0.3"
+          "Kentico.Xperience.Lucene.Admin": "15.0.4",
+          "Kentico.Xperience.Lucene.Core": "15.0.4"
         }
       },
       "Lucene.Net.Highlighter": {


### PR DESCRIPTION
## Summary

Two related changes:

1. **Update Xperience by Kentico 31.6.1 → 31.6.2** (hotfix, 9 July 2026), including a security advisory fix.
2. **Revert the Management API production-build workaround** (PR #230) now that 31.6.2 ships the framework fix. Closes #231.

## 1. Xperience update

- Bumped `Kentico.Xperience.*` packages in `Directory.Packages.props`:
  - `Admin`, `AzureStorage`, `WebApp`, `ManagementApi` (preview): 31.6.1 → 31.6.2
  - `Lucene`: 15.0.3 → 15.0.4
  - `MiniProfiler` preserved (independent versioning)
- Bumped `@kentico/*` npm packages in the admin client (31.6.1 → 31.6.2)
- Applied database migrations via `--kxp-update`
- Serialized CI objects via `--kxp-ci-store` — **no CI repository changes**

## 2. Management API fix (closes #231)

The 31.6.2 changelog fixes the exact bug we reported (Kentico ticket 0009527833): *"An error (InvalidOperationException) occurred on application startup if the project had the ManagementApi package installed, but didn't call `AddKenticoManagementApi()`."* This is what crashed production after the 31.6.0 update (exit 134 / SIGABRT), worked around in PR #230.

Now that the framework fix has shipped, this reverts the workaround back to Kentico's documented pattern:

- `Goldfinch.Web.csproj` — restore the unconditional `Kentico.Xperience.ManagementApi` package reference (drop the `Debug`-only `Condition`).
- `Program.cs` — remove the `#if DEBUG` guards around the `using`, `AddKenticoManagementApi()`, and `UseKenticoManagementApi()`. The API stays dev-only via the runtime `if (IsDevelopment())` guard (both registration and middleware), matching the [docs](https://docs.kentico.com/documentation/developers-and-admins/api/management-api/configure-management-mcp-server#enable-the-management-api).

**Trade-off:** the `ManagementApi` assembly now ships to production again (previously excluded from Release builds), but stays wired-off by the `IsDevelopment()` checks, and the fixed module no longer throws when the API is disabled. This was the open decision point in #231 — we've chosen the simpler, docs-aligned runtime guard over the build-configuration exclusion.

## Testing

- ✅ `dotnet build` (Debug **and** Release) — 0 warnings, 0 errors
- ✅ Confirmed `Kentico.Xperience.ManagementApi.dll` is present in Release output again (expected)
- ✅ `--kxp-update` migration completed; CI restore/store round-tripped with no diffs

Recommended local smoke test before merge: homepage, blog list/detail (with images), navigation, admin UI, page builder widgets, and confirm the Management API MCP still works locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)