### PR TITLE
fix(mobile): prevent iOS focus-zoom on search and Ask inputs

### DIFF
--- a/src/Goldfinch.Web/wwwroot/sitefiles/src/global.css
+++ b/src/Goldfinch.Web/wwwroot/sitefiles/src/global.css
@@ -3014,3 +3014,14 @@ mark {
     display: none;
   }
 }
+
+/* iOS Safari auto-zooms the page when a focused text input has a font-size below 16px. Bump the
+   typeable inputs to 16px on touch devices only (pointer: coarse), so the zoom doesn't fire —
+   desktop keeps its smaller, deliberate sizing. */
+@media (pointer: coarse) {
+  .ask__input,
+  .palette-input,
+  .blog-toolbar input {
+    font-size: 16px;
+  }
+}


### PR DESCRIPTION
## Problem

On iOS Safari, tapping the ⌘K command-palette search, the blog-toolbar search, or the "Ask" modal input **zooms the page in**. This is iOS's built-in behaviour: it auto-zooms whenever a focused text input has a `font-size` below **16px**. Those three inputs sit at 13.5–15px.

## Fix

Bump the three typeable inputs to `16px` under `@media (pointer: coarse)`:

```css
@media (pointer: coarse) {
  .ask__input,
  .palette-input,
  .blog-toolbar input { font-size: 16px; }
}
```

- **Touch devices only** (`pointer: coarse`) — covers iPhone, iPad, and Android, which plain `max-width` breakpoints would miss (e.g. iPad portrait).
- **Desktop is untouched** — mouse pointers stay `fine`, so the deliberate 13.5/14/15px sizing is preserved there.
- No viewport `maximum-scale` hack (which would break pinch-zoom / accessibility).

## Testing

- Front-end bundle rebuilds cleanly. Verify on an actual iPhone: focusing each input should no longer zoom.

🤖 Generated with [Claude Code](https://claude.com/claude-code)