### PR TITLE
build(sln): update to Xperience v31.8.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -7,14 +7,14 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="coverlet.collector" Version="10.0.1" />
-    <PackageVersion Include="Kentico.Xperience.Admin" Version="31.7.2" />
-    <PackageVersion Include="Kentico.Xperience.AzureStorage" Version="31.7.2" />
+    <PackageVersion Include="Kentico.Xperience.Admin" Version="31.8.0" />
+    <PackageVersion Include="Kentico.Xperience.AzureStorage" Version="31.8.0" />
     <PackageVersion Include="Kentico.Xperience.Lucene" Version="15.0.5" />
-    <PackageVersion Include="Kentico.Xperience.ManagementApi" Version="31.7.2-preview" />
+    <PackageVersion Include="Kentico.Xperience.ManagementApi" Version="31.8.0-preview" />
     <PackageVersion Include="Kentico.Xperience.MiniProfiler" Version="3.0.0" />
-    <PackageVersion Include="Kentico.Xperience.WebApp" Version="31.7.2" />
+    <PackageVersion Include="Kentico.Xperience.WebApp" Version="31.8.0" />
     <PackageVersion Include="Lucene.Net.Highlighter" Version="4.8.0-beta00018" />
-    <PackageVersion Include="AngleSharp" Version="1.6.0" />
+    <PackageVersion Include="AngleSharp" Version="1.7.1" />
     <PackageVersion Include="OpenAI" Version="2.12.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
     <PackageVersion Include="Microsoft.Playwright" Version="1.61.0" />

--- a/src/Goldfinch.Admin/Client/package-lock.json
+++ b/src/Goldfinch.Admin/Client/package-lock.json
@@ -8,8 +8,8 @@
       "name": "goldfinch-web-admin",
       "version": "1.0.0",
       "dependencies": {
-        "@kentico/xperience-admin-base": "^31.7.2",
-        "@kentico/xperience-admin-components": "^31.7.2",
+        "@kentico/xperience-admin-base": "^31.8.0",
+        "@kentico/xperience-admin-components": "^31.8.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1"
       },
@@ -19,7 +19,7 @@
         "@babel/preset-env": "^8.0.2",
         "@babel/preset-react": "^8.0.1",
         "@babel/preset-typescript": "^8.0.1",
-        "@kentico/xperience-webpack-config": "^31.7.2",
+        "@kentico/xperience-webpack-config": "^31.8.0",
         "@types/react": "^18.3.1",
         "@types/react-dom": "^18.3.1",
         "babel-loader": "^10.0.0",
@@ -32,9 +32,9 @@
       }
     },
     "node_modules/@amcharts/amcharts5": {
-      "version": "5.19.1",
-      "resolved": "https://registry.npmjs.org/@amcharts/amcharts5/-/amcharts5-5.19.1.tgz",
-      "integrity": "sha512-r1PX1UUzeVIKWiIh3v+lrE8XPLtM/J8TMDEp9gFh20jgr9ufVYaNKfQWjNGzpdhfnwV1ZVWSpXCZjO5S5egyag==",
+      "version": "5.20.1",
+      "resolved": "https://registry.npmjs.org/@amcharts/amcharts5/-/amcharts5-5.20.1.tgz",
+      "integrity": "sha512-1zOy94kD1rfqAv34w9ujqRnBx4PPLo1PuvW1WxW2+plA5/wFtBY8nx93+pGGy9Exdbnd5hLAxwe1WIjfiOVUEg==",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@types/d3": "^7.0.0",
@@ -3726,9 +3726,9 @@
       }
     },
     "node_modules/@codemirror/lang-html": {
-      "version": "6.4.11",
-      "resolved": "https://registry.npmjs.org/@codemirror/lang-html/-/lang-html-6.4.11.tgz",
-      "integrity": "sha512-9NsXp7Nwp891pQchI7gPdTwBuSuT3K65NGTHWHNJ55HjYcHLllr0rbIZNdOzas9ztc1EUVBlHou85FFZS4BNnw==",
+      "version": "6.4.12",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-html/-/lang-html-6.4.12.tgz",
+      "integrity": "sha512-pw2ReWKUqSkbvh76RAT4NYxiogRu+PWkR2ukAwO9uOgrm8uipkzjtKKtNpyeAQwHOqxEeSvAXZ6vr3AfyB9y/w==",
       "license": "MIT",
       "dependencies": {
         "@codemirror/autocomplete": "^6.0.0",
@@ -4106,9 +4106,9 @@
       }
     },
     "node_modules/@internationalized/date": {
-      "version": "3.12.2",
-      "resolved": "https://registry.npmjs.org/@internationalized/date/-/date-3.12.2.tgz",
-      "integrity": "sha512-FY1Y+H64NDs+HAF6omlnWxm3mEpfgaCSWtL5l551ZZfImA+kGjPFgrnJrGjH6lfmLL0g8Z/mBu1R3kufeCp6Jw==",
+      "version": "3.12.3",
+      "resolved": "https://registry.npmjs.org/@internationalized/date/-/date-3.12.3.tgz",
+      "integrity": "sha512-fuLX+3ZKLsxI73y8b01EG/WjHb6gE6weCqlfawPO27kBWGMh9G1yH6Csv1uU7/cac9H2GHmOMt6CjmuQ1aia4Q==",
       "license": "Apache-2.0",
       "dependencies": {
         "@swc/helpers": "^0.5.0"
@@ -4134,9 +4134,9 @@
       }
     },
     "node_modules/@internationalized/string": {
-      "version": "3.2.9",
-      "resolved": "https://registry.npmjs.org/@internationalized/string/-/string-3.2.9.tgz",
-      "integrity": "sha512-kzP/M/mbQxODlmOt4bIQZ2SBVUWUSqMLXooXixnX7noche8WHaQcA+nwFN1K2KCF/cp+LDUhcJsCicwkvhD1pg==",
+      "version": "3.2.10",
+      "resolved": "https://registry.npmjs.org/@internationalized/string/-/string-3.2.10.tgz",
+      "integrity": "sha512-PDx6//vHSpRnHfxqMqto11zQvhsaU74O3mKv2F/0eicGZcl9NLjQmGlbHz/LsJh5tLKp4A4L7ZVTzN1/MmMTvA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@swc/helpers": "^0.5.0"
@@ -4617,24 +4617,18 @@
         "tslib": "2"
       }
     },
-    "node_modules/@juggle/resize-observer": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/@juggle/resize-observer/-/resize-observer-3.4.0.tgz",
-      "integrity": "sha512-dfLbk+PwWvFzSxwk3n5ySL0hfBog779o8h68wK/7/APo/7cgyWp5jcXockbxdk5kFRkbeXWm4Fbi9FrdN381sA==",
-      "license": "Apache-2.0"
-    },
     "node_modules/@kentico/xperience-admin-base": {
-      "version": "31.7.2",
-      "resolved": "https://registry.npmjs.org/@kentico/xperience-admin-base/-/xperience-admin-base-31.7.2.tgz",
-      "integrity": "sha512-XHPmFGm1xfuQe/DE/gx6XHBL7IXUyrDUAACuvkFDJEyRA7YzLvSlk4vJXRjoh5bN6WCmbeaRATRtSpKHZtBmcg==",
+      "version": "31.8.0",
+      "resolved": "https://registry.npmjs.org/@kentico/xperience-admin-base/-/xperience-admin-base-31.8.0.tgz",
+      "integrity": "sha512-DopVcY7/0fXte/arwIusBRbLUBL6CtywQeN5tYvVaxezxVH55Si6Pw3UZ6Qf+NQrkC1opBR3MwHIJkIy5qIZOQ==",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "@hello-pangea/dnd": "18.0.1",
-        "@kentico/xperience-admin-components": "31.7.2",
+        "@kentico/xperience-admin-components": "31.8.0",
         "@react-aria/focus": "3.22.1",
         "@react-aria/i18n": "3.13.1",
         "@react-aria/visually-hidden": "3.9.1",
-        "@tanstack/react-virtual": "3.14.5",
+        "@tanstack/react-virtual": "3.14.9",
         "classnames": "2.5.1",
         "date-fns": "4.4.0",
         "i18next": "26.3.6",
@@ -4644,27 +4638,27 @@
         "react-dnd": "16.0.1",
         "react-dnd-html5-backend": "16.0.1",
         "react-dom": "18.3.1",
-        "react-i18next": "17.0.9",
+        "react-i18next": "17.0.11",
         "react-image-crop": "11.1.2",
         "react-markdown": "10.1.0",
-        "react-router-dom": "6.30.4",
+        "react-router-dom": "7.18.2",
         "react-select": "5.10.2",
         "react-select-async-paginate": "0.7.11",
         "remark-gfm": "4.0.1",
         "use-debounce": "10.1.1",
-        "use-resize-observer": "9.1.0",
+        "use-resize-observer": "10.0.0",
         "uuid": "14.0.1"
       }
     },
     "node_modules/@kentico/xperience-admin-components": {
-      "version": "31.7.2",
-      "resolved": "https://registry.npmjs.org/@kentico/xperience-admin-components/-/xperience-admin-components-31.7.2.tgz",
-      "integrity": "sha512-iBCLMHCXMP5KUt7zKeHIkHu0Ea3LikG2Cj/mlYaJ6f9bW+gqJ++G/sIu67qF7SUk5vbhWEMIc2yvCsYZhCGFlQ==",
+      "version": "31.8.0",
+      "resolved": "https://registry.npmjs.org/@kentico/xperience-admin-components/-/xperience-admin-components-31.8.0.tgz",
+      "integrity": "sha512-cDvfYOLph9tpQy2SnBXw0tUGDOdKwqZDRw0OvuFhb6B0h8L3b4It6hmYH3eLPDyf/toJiMkD/do3H9s1C7ouzg==",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
-        "@amcharts/amcharts5": "5.19.1",
+        "@amcharts/amcharts5": "5.20.1",
         "@codemirror/lang-css": "6.3.1",
-        "@codemirror/lang-html": "6.4.11",
+        "@codemirror/lang-html": "6.4.12",
         "@codemirror/lang-javascript": "6.2.5",
         "@codemirror/lang-sql": "6.10.0",
         "@codemirror/lang-xml": "6.1.0",
@@ -4684,24 +4678,24 @@
         "froala-editor": "5.0.1",
         "i18next": "26.3.6",
         "react": "18.3.1",
-        "react-aria-components": "1.19.0",
+        "react-aria-components": "1.20.0",
         "react-datepicker": "8.10.0",
         "react-dnd": "16.0.1",
         "react-dnd-html5-backend": "16.0.1",
         "react-dom": "18.3.1",
         "react-froala-wysiwyg": "5.0.1",
-        "react-i18next": "17.0.9",
+        "react-i18next": "17.0.11",
         "react-modal": "3.16.3",
-        "react-router-dom": "6.30.4",
+        "react-router-dom": "7.18.2",
         "react-textarea-autosize": "8.5.9",
         "use-debounce": "10.1.1",
-        "use-resize-observer": "9.1.0"
+        "use-resize-observer": "10.0.0"
       }
     },
     "node_modules/@kentico/xperience-webpack-config": {
-      "version": "31.7.2",
-      "resolved": "https://registry.npmjs.org/@kentico/xperience-webpack-config/-/xperience-webpack-config-31.7.2.tgz",
-      "integrity": "sha512-/MzCzb+6YcA4+bil2eTe/eed2zie93kni8OQEe6DtgaKPhjuZqE7Sf5bq34x0jie2nhs/VQds5jU4y/MjhlwoQ==",
+      "version": "31.8.0",
+      "resolved": "https://registry.npmjs.org/@kentico/xperience-webpack-config/-/xperience-webpack-config-31.8.0.tgz",
+      "integrity": "sha512-RMh7WdTLCLfUNJ1ttAOB4SfeVKFRLnWektxESd57s7mT0AkxtXNbImEXqLAazf4mNnbMQyNYMPjM2Q5PqN1Lqg==",
       "dev": true,
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
@@ -4722,9 +4716,9 @@
       "license": "MIT"
     },
     "node_modules/@lezer/css": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@lezer/css/-/css-1.3.0.tgz",
-      "integrity": "sha512-pBL7hup88KbI7hXnZV3PQsn43DHy6TWyzuyk2AO9UyoXcDltvIdqWKE1dLL/45JVZ+YZkHe1WVHqO6wugZZWcw==",
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/@lezer/css/-/css-1.3.6.tgz",
+      "integrity": "sha512-YJE78Wcg+zX8f10hiHWQ4Az48Qr/c13eId0VtRQYLBpxHDmDeSrXIlkbl+fJGW42rWC/uoUco9mhBZeVWP/A1g==",
       "license": "MIT",
       "dependencies": {
         "@lezer/common": "^1.2.0",
@@ -4742,9 +4736,9 @@
       }
     },
     "node_modules/@lezer/html": {
-      "version": "1.3.12",
-      "resolved": "https://registry.npmjs.org/@lezer/html/-/html-1.3.12.tgz",
-      "integrity": "sha512-RJ7eRWdaJe3bsiiLLHjCFT1JMk8m1YP9kaUbvu2rMLEoOnke9mcTVDyfOslsln0LtujdWespjJ39w6zo+RsQYw==",
+      "version": "1.3.13",
+      "resolved": "https://registry.npmjs.org/@lezer/html/-/html-1.3.13.tgz",
+      "integrity": "sha512-oI7n6NJml729m7pjm9lvLvmXbdoMoi2f+1pwSDJkl9d68zGr7a9Btz8NdHTGQZtW2DA25ybeuv/SyDb9D5tseg==",
       "license": "MIT",
       "dependencies": {
         "@lezer/common": "^1.2.0",
@@ -5145,21 +5139,12 @@
       }
     },
     "node_modules/@react-types/shared": {
-      "version": "3.36.0",
-      "resolved": "https://registry.npmjs.org/@react-types/shared/-/shared-3.36.0.tgz",
-      "integrity": "sha512-DkP/H0C2YjjS7gZWKNqOmU8a16qHPjQNdzMwmTq9SzplM6Iw0kVMTZ0OIoe6FOgGqa+FwMsE2QbPjh/n3g/jXQ==",
+      "version": "3.36.1",
+      "resolved": "https://registry.npmjs.org/@react-types/shared/-/shared-3.36.1.tgz",
+      "integrity": "sha512-AzsuD9OfxTOZMMvTRhlN3oHBwOmFN7tDh27LzqmHt4+uOgPhJT7ZM7/kVs/8/o0WxayMUIk3hBmCFRHv1FUoag==",
       "license": "Apache-2.0",
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
-      }
-    },
-    "node_modules/@remix-run/router": {
-      "version": "1.23.3",
-      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.3.tgz",
-      "integrity": "sha512-4An71tdz9X8+3sI4Qqqd2LWd9vS39J7sqd9EU4Scw7TJE/qB10Flv/UuqbPVgfQV9XoK8Np6jNquZitnZq5i+Q==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.0.0"
       }
     },
     "node_modules/@seznam/compose-react-refs": {
@@ -5178,12 +5163,12 @@
       }
     },
     "node_modules/@tanstack/react-virtual": {
-      "version": "3.14.5",
-      "resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.14.5.tgz",
-      "integrity": "sha512-4EKRXh7zBLkbKbFmG3AUVkircuHd+7OdT1pocJSepxtfBd3qnrJgJ5rtPkRYyo9fmyVb2+pI2xPy5oYvMLQy6A==",
+      "version": "3.14.9",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.14.9.tgz",
+      "integrity": "sha512-qZyr0FZDP8rDC4WBhsryIZmAd9bveJvFGUJJtskWaew6/0dTRS6wZxnR6VQ5bY2KwL3LjerrHqQLk3a0GKcPXQ==",
       "license": "MIT",
       "dependencies": {
-        "@tanstack/virtual-core": "3.17.3"
+        "@tanstack/virtual-core": "3.17.7"
       },
       "funding": {
         "type": "github",
@@ -5195,9 +5180,9 @@
       }
     },
     "node_modules/@tanstack/virtual-core": {
-      "version": "3.17.3",
-      "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.17.3.tgz",
-      "integrity": "sha512-8Np/TFELpI0ySuJoVmjvOrQYXH/8sTX0Biv9szhFhY39xOdAAY+smrMxjxOum/ux3eM8MUJQsEJ0/R0UpvC8dw==",
+      "version": "3.17.7",
+      "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.17.7.tgz",
+      "integrity": "sha512-bp+v10y65sp2H7WpWfIMyxTNfl8ZVfxFTLRjPIFRryi6FV/J33z4IS53WO4pTk36KlvJ4iLiQz+oaydDC1xbcA==",
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -5487,9 +5472,9 @@
       "license": "MIT"
     },
     "node_modules/@types/d3-shape": {
-      "version": "3.1.8",
-      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
-      "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-kVd74ta9eof3eJOvbNd1vGKS/XERRyQbT26Og63hIsvDO84cjD5gEOhsXf26w3FSoNlPVz84DOFcKv/oou+fMw==",
       "license": "MIT",
       "dependencies": {
         "@types/d3-path": "*"
@@ -8129,12 +8114,12 @@
       }
     },
     "node_modules/html-parse-stringify": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/html-parse-stringify/-/html-parse-stringify-3.1.0.tgz",
-      "integrity": "sha512-E0oAXcELOtsXe+BmpJ2EZyedbldPpriV5vICzEuo6xjC/D1lDukOI7KrpfQGF2Qc4wWEy0nk3bFORS2K5ZAhFQ==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/html-parse-stringify/-/html-parse-stringify-4.0.1.tgz",
+      "integrity": "sha512-0zHsZJrK7S3K2aucXWL6ycoYJ/iNtIcFHC/nYQgFklPtrv5LpJctIiSCroWZWeuoXvuyFdzp6KzjJQ+OT5MfFw==",
       "license": "MIT",
-      "dependencies": {
-        "void-elements": "3.1.0"
+      "funding": {
+        "url": "https://locize.com"
       }
     },
     "node_modules/html-url-attributes": {
@@ -10439,19 +10424,19 @@
       }
     },
     "node_modules/react-aria": {
-      "version": "3.50.0",
-      "resolved": "https://registry.npmjs.org/react-aria/-/react-aria-3.50.0.tgz",
-      "integrity": "sha512-S0Os6QZk33fzUAKu1QLT9afoUaCBt1ZNdoiq0n2YMVgKIdNIQS8zxiZ8O9hYE6QyDkHKjD6q39LQZ+qaSAIgjw==",
+      "version": "3.51.0",
+      "resolved": "https://registry.npmjs.org/react-aria/-/react-aria-3.51.0.tgz",
+      "integrity": "sha512-AyWLw0XR38cFPwBu/ErgGaVrc5dupLEKmRlMXTGvFKOtbaGRQ2+yQJkjVhpdHhoRhU4+G+tJDFeHDTS8tK3bfQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@internationalized/date": "^3.12.2",
+        "@internationalized/date": "^3.12.3",
         "@internationalized/number": "^3.6.7",
-        "@internationalized/string": "^3.2.9",
-        "@react-types/shared": "^3.36.0",
+        "@internationalized/string": "^3.2.10",
+        "@react-types/shared": "^3.36.1",
         "@swc/helpers": "^0.5.0",
         "aria-hidden": "^1.2.3",
         "clsx": "^2.0.0",
-        "react-stately": "3.48.0",
+        "react-stately": "3.49.0",
         "use-sync-external-store": "^1.6.0"
       },
       "peerDependencies": {
@@ -10460,17 +10445,18 @@
       }
     },
     "node_modules/react-aria-components": {
-      "version": "1.19.0",
-      "resolved": "https://registry.npmjs.org/react-aria-components/-/react-aria-components-1.19.0.tgz",
-      "integrity": "sha512-2smSS5nqJ8cGYMQezuUXveZm7eMyHCqTN6mDpylQBYLYbdF5dxCCuW1DHn1VKLe1DybSfPvX/cZtJlDmvFfn8A==",
+      "version": "1.20.0",
+      "resolved": "https://registry.npmjs.org/react-aria-components/-/react-aria-components-1.20.0.tgz",
+      "integrity": "sha512-BMbpIgoV9aELeBrB0Y120NgoigHb5OdcJwc+4e7uSnbTbamea6lo+gqcc4LAxzMaK3Jf+7LI1oCDE6yANsmxIQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@internationalized/date": "^3.12.2",
-        "@react-types/shared": "^3.36.0",
+        "@internationalized/date": "^3.12.3",
+        "@internationalized/string": "^3.2.10",
+        "@react-types/shared": "^3.36.1",
         "@swc/helpers": "^0.5.0",
         "client-only": "^0.0.1",
-        "react-aria": "3.50.0",
-        "react-stately": "3.48.0"
+        "react-aria": "3.51.0",
+        "react-stately": "3.49.0"
       },
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
@@ -10567,13 +10553,13 @@
       }
     },
     "node_modules/react-i18next": {
-      "version": "17.0.9",
-      "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-17.0.9.tgz",
-      "integrity": "sha512-buLzOSqHtXxjf+qgSrLWNTXVZ1jSwO6kUv3uJqSP1roGBPgNnbhFm7OmdVwWcgf2gIbUyP0J333uPyx+Btsi3w==",
+      "version": "17.0.11",
+      "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-17.0.11.tgz",
+      "integrity": "sha512-cDtkXgxjuFTWUH6V+aQn1Ve5vDiUztCNPWW5GtSHDccsgRXO1nE6QFWCEmc1KAutrb3OUv87wFShJL5RhUwPXg==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.29.2",
-        "html-parse-stringify": "^3.0.1",
+        "html-parse-stringify": "^4.0.1",
         "use-sync-external-store": "^1.6.0"
       },
       "peerDependencies": {
@@ -10681,35 +10667,54 @@
       }
     },
     "node_modules/react-router": {
-      "version": "6.30.4",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.4.tgz",
-      "integrity": "sha512-SVUsDe+DybHM/WmYKIVYhZh1o5Dcuf16yM6WjG02Q9XVFMZIJyHYhwrr6bFBXZkVP6z69kNkMyBCujt8FaFLJA==",
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.18.2.tgz",
+      "integrity": "sha512-aUVMjFm3GAPTTZL7oYr5E7ETiqfQCHRLH+B+5afnICvf0r7kkK4eR6SMuwbSTJw/7t+12khT/Kahij49fqOCIg==",
       "license": "MIT",
       "dependencies": {
-        "@remix-run/router": "1.23.3"
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "react": ">=16.8"
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
       }
     },
     "node_modules/react-router-dom": {
-      "version": "6.30.4",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.4.tgz",
-      "integrity": "sha512-q4HvNl+mmDdkS0g+MqiBZNteQJCuimWoOyHMy4T/RQLAn9Z29+E91QXRaxOujeMl2HTzRSS0KFPd7lxX3PjV0Q==",
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.18.2.tgz",
+      "integrity": "sha512-AIKJ/jgGlFb3EbfCXk5Gzshiwt+l3mqbCrNjmEWMMjqQxNJ3svBa6bgzFyCC2Sw3RA0VWF1kg3uQf2OFhxb8hw==",
       "license": "MIT",
       "dependencies": {
-        "@remix-run/router": "1.23.3",
-        "react-router": "6.30.4"
+        "react-router": "7.18.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
+    "node_modules/react-router/node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/react-select": {
@@ -10752,15 +10757,15 @@
       }
     },
     "node_modules/react-stately": {
-      "version": "3.48.0",
-      "resolved": "https://registry.npmjs.org/react-stately/-/react-stately-3.48.0.tgz",
-      "integrity": "sha512-ImicSAG+lTotAe5izcs1fz49Zk48w7pDusqYg04WaPhCoej8BJ24soMu3iLXIrsi273s4P1gZrYGrqReMfgEEA==",
+      "version": "3.49.0",
+      "resolved": "https://registry.npmjs.org/react-stately/-/react-stately-3.49.0.tgz",
+      "integrity": "sha512-13iNq2KzBrRAzxRc+n53hgROfIistiYY/sPtIhCw1qUB7/kmo+X1xEU2uiS5zcCIrc55AUPwoHqOIIpKWSwB9A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@internationalized/date": "^3.12.2",
+        "@internationalized/date": "^3.12.3",
         "@internationalized/number": "^3.6.7",
-        "@internationalized/string": "^3.2.9",
-        "@react-types/shared": "^3.36.0",
+        "@internationalized/string": "^3.2.10",
+        "@react-types/shared": "^3.36.1",
         "@swc/helpers": "^0.5.0",
         "use-sync-external-store": "^1.6.0"
       },
@@ -11333,6 +11338,12 @@
         "type": "opencollective",
         "url": "https://opencollective.com/express"
       }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
+      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
+      "license": "MIT"
     },
     "node_modules/setprototypeof": {
       "version": "1.2.0",
@@ -12161,16 +12172,12 @@
       }
     },
     "node_modules/use-resize-observer": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/use-resize-observer/-/use-resize-observer-9.1.0.tgz",
-      "integrity": "sha512-R25VqO9Wb3asSD4eqtcxk8sJalvIOYBqS8MNZlpDSQ4l4xMQxC/J7Id9HoTqPq8FwULIn0PVW+OAqF2dyYbjow==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/use-resize-observer/-/use-resize-observer-10.0.0.tgz",
+      "integrity": "sha512-bR6D9uOoNB51isaK3yFs12+0Ue81jwHawsvdIyOIq5o+4ekmHn4U207IlBf3zc0fLHckhXLQtFl8moEOKcGGAQ==",
       "license": "MIT",
-      "dependencies": {
-        "@juggle/resize-observer": "^3.3.1"
-      },
       "peerDependencies": {
-        "react": "16.8.0 - 18",
-        "react-dom": "16.8.0 - 18"
+        "react": ">=18.2"
       }
     },
     "node_modules/use-sync-external-store": {
@@ -12230,15 +12237,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/void-elements": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-3.1.0.tgz",
-      "integrity": "sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/w3c-keyname": {

--- a/src/Goldfinch.Admin/Client/package.json
+++ b/src/Goldfinch.Admin/Client/package.json
@@ -11,8 +11,8 @@
     "build": "webpack --mode=production"
   },
   "dependencies": {
-    "@kentico/xperience-admin-base": "^31.7.2",
-    "@kentico/xperience-admin-components": "^31.7.2",
+    "@kentico/xperience-admin-base": "^31.8.0",
+    "@kentico/xperience-admin-components": "^31.8.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"
   },
@@ -22,7 +22,7 @@
     "@babel/preset-env": "^8.0.2",
     "@babel/preset-react": "^8.0.1",
     "@babel/preset-typescript": "^8.0.1",
-    "@kentico/xperience-webpack-config": "^31.7.2",
+    "@kentico/xperience-webpack-config": "^31.8.0",
     "@types/react": "^18.3.1",
     "@types/react-dom": "^18.3.1",
     "babel-loader": "^10.0.0",

--- a/src/Goldfinch.Admin/packages.lock.json
+++ b/src/Goldfinch.Admin/packages.lock.json
@@ -4,39 +4,40 @@
     "net10.0": {
       "Kentico.Xperience.Admin": {
         "type": "Direct",
-        "requested": "[31.7.2, )",
-        "resolved": "31.7.2",
-        "contentHash": "gb+E5l+uSUmYKZoqQkT90xG0OhoL2Zey6zpHby7fdRXIdJ2UjmKJfTfguaNmqkSDej4EFa8WNm7SqatK7bJxcw==",
+        "requested": "[31.8.0, )",
+        "resolved": "31.8.0",
+        "contentHash": "3qs1T88jnoIeLuJWQgGgAhBjnv7dten2r8mgynTawm3wo0wyr0dQe3df26zgrrFPW0fqak0H788pWN6YuwpDvg==",
         "dependencies": {
           "Azure.AI.OpenAI": "2.1.0",
           "Kentico.Aira.Client": "6.1.0",
-          "Kentico.Xperience.WebApp": "[31.7.2]",
-          "Microsoft.Agents.AI": "1.13.0",
-          "Microsoft.Agents.AI.OpenAI": "1.13.0",
-          "Microsoft.AspNetCore.SpaServices.Extensions": "8.0.28",
-          "Microsoft.Extensions.AI": "10.7.0",
-          "Microsoft.Extensions.FileProviders.Embedded": "8.0.28",
+          "Kentico.Xperience.WebApp": "[31.8.0]",
+          "Microsoft.Agents.AI": "1.17.0",
+          "Microsoft.Agents.AI.OpenAI": "1.17.0",
+          "Microsoft.Agents.AI.Workflows": "1.17.0",
+          "Microsoft.AspNetCore.SpaServices.Extensions": "8.0.29",
+          "Microsoft.Extensions.AI": "10.8.3",
+          "Microsoft.Extensions.FileProviders.Embedded": "8.0.29",
           "NJsonSchema": "11.6.1"
         }
       },
       "Kentico.Xperience.WebApp": {
         "type": "Direct",
-        "requested": "[31.7.2, )",
-        "resolved": "31.7.2",
-        "contentHash": "vqkul3ZYBza+jjfOYXz0hkys1kalIfugeA/oqtZ8c5TruVi9XgSR6YxKTD6xeQGhYmUYUZUzc/Phxuxw5qmkAg==",
+        "requested": "[31.8.0, )",
+        "resolved": "31.8.0",
+        "contentHash": "8B1piJ2FLl8z7KIPNLpTrXUpjtbs+5Gn4Np5JXEGUVifDhsqkZJ7UKt3XqHXRnToCrlktQfr1rimmZj3PDSL1w==",
         "dependencies": {
           "CommandLineParser": "2.9.1",
           "HotChocolate.AspNetCore": "15.1.17",
           "HotChocolate.Data": "15.1.17",
-          "HtmlSanitizer": "9.1.973",
-          "Kentico.Xperience.Core": "[31.7.2]",
-          "Microsoft.Extensions.FileProviders.Embedded": "8.0.28"
+          "HtmlSanitizer": "9.2.995",
+          "Kentico.Xperience.Core": "[31.8.0]",
+          "Microsoft.Extensions.FileProviders.Embedded": "8.0.29"
         }
       },
       "AngleSharp.Css": {
         "type": "Transitive",
-        "resolved": "1.0.0",
-        "contentHash": "yMpYcNkI/ZHTt+qZMczhHEAHZV0AZf75nqJ5LqERFXvJGOFLJjwr0eqaYXqYlt9JPojOd+OkZLlGbnsmKjmh+g==",
+        "resolved": "1.0.1",
+        "contentHash": "6S13xNHH+SUGPZd6EO1MhkuDbpEnFroUM6A8DZpLJHQnLRTvtBJb3Ydu65s618E4gWF9FSWmM5jhKk4RIfwT2A==",
         "dependencies": {
           "AngleSharp": "[1.5.0, 2.0.0)"
         }
@@ -396,18 +397,13 @@
           "HotChocolate.Types": "15.1.17"
         }
       },
-      "HtmlAgilityPack": {
-        "type": "Transitive",
-        "resolved": "1.12.4",
-        "contentHash": "ljqvBabvFwKoLniuoQKO8b5bJfJweKLs4fUNS/V5dsvpo0A8MlJqxxn9XVmP2DaskbUXty6IYaWAi1SArGIMeQ=="
-      },
       "HtmlSanitizer": {
         "type": "Transitive",
-        "resolved": "9.1.973",
-        "contentHash": "0gDDlj8SZiYFn9fxdWOrxp5mO9y+5jOE0dunOzJ6EELr/FBtlPasvdLR/K3YVgbo4FiPKT3YomlarsvhLm/H2A==",
+        "resolved": "9.2.995",
+        "contentHash": "Yws4FratoTx4FDlvOjQTfuE49ATTVwAxNosv2CE2XqnOcmPuWWOWbLwEYP5w9uqvrGRyOgQloisKVokrgxKaXg==",
         "dependencies": {
-          "AngleSharp": "1.6.0",
-          "AngleSharp.Css": "1.0.0"
+          "AngleSharp": "1.7.1",
+          "AngleSharp.Css": "1.0.1"
         }
       },
       "J2N": {
@@ -426,19 +422,19 @@
       },
       "Kentico.Xperience.Core": {
         "type": "Transitive",
-        "resolved": "31.7.2",
-        "contentHash": "O4TfBddUhaNXvZu2Gep3hCrudidli0pAODLwyFB2ppY71wqlO/ITnvAKyrox4MoYuRK9/qLbPXol6E5ReUb8MQ==",
+        "resolved": "31.8.0",
+        "contentHash": "YKIlHtYGwgCxhM5RA5TsvcNPgfxwObeZNXxVfhuIU5m0m/J4ikN4xAYldt2rXe7rZ5HvsxHVXyRvtrHCgWY58w==",
         "dependencies": {
-          "AngleSharp": "1.6.0",
+          "AngleSharp": "1.7.1",
           "Kentico.Aira.Client": "6.1.0",
-          "Magick.NET-Q8-AnyCPU": "14.15.0",
+          "Magick.NET-Q8-AnyCPU": "14.16.0",
           "MailKit": "4.17.0",
           "Microsoft.Data.SqlClient": "7.0.0",
           "Mono.Cecil": "0.11.6",
           "Newtonsoft.Json": "13.0.4",
-          "ReverseMarkdown": "5.5.0",
+          "ReverseMarkdown": "6.1.1",
           "System.CodeDom": "8.0.0",
-          "System.IO.Hashing": "10.0.9"
+          "System.IO.Hashing": "10.0.10"
         }
       },
       "Kentico.Xperience.Lucene.Admin": {
@@ -521,16 +517,16 @@
       },
       "Magick.NET-Q8-AnyCPU": {
         "type": "Transitive",
-        "resolved": "14.15.0",
-        "contentHash": "GYcT4dC2Dxgq/FN/PwVY+PHJEuZc5ZfQm0bj0BmvmSRXPjPPJzdOV8tbcMyNUQtHcRnsp6E/mJ5Tf62I8in3bg==",
+        "resolved": "14.16.0",
+        "contentHash": "mV5igNia0VyUtRAmqUpI/ZBEL78+0A+JxPoOs7clwlZEvPCsvk+uF0hLl10zaFYmH5I8BaqVpI2+R+td1bbNrg==",
         "dependencies": {
-          "Magick.NET.Core": "14.15.0"
+          "Magick.NET.Core": "14.16.0"
         }
       },
       "Magick.NET.Core": {
         "type": "Transitive",
-        "resolved": "14.15.0",
-        "contentHash": "xgD1zqb4KQ1gMQcd3eIRp8hFMHBxzW9fOpLLDR7BWN0oCwZ0i6NW7rIUiCdsEi/NuZi1UlCLWBHh3v7Y2E3LIw=="
+        "resolved": "14.16.0",
+        "contentHash": "ddBX/Zb0sCsX4agqHdHeqUx+grfw8I7GFU+lgut3mtNl7roxbxemSQFGLIJXtzwPuAHxbaMtkXA+ijVl02EUhQ=="
       },
       "MailKit": {
         "type": "Transitive",
@@ -542,47 +538,63 @@
       },
       "Microsoft.Agents.AI": {
         "type": "Transitive",
-        "resolved": "1.13.0",
-        "contentHash": "IQ9ZubJ30SPZevXFUIy8Z67cyYfgvpRpQHU22h98RUyojn6A+OqBfB7EplVxcv7iMO2QWIJDW2jh6xTKmO8BjQ==",
+        "resolved": "1.17.0",
+        "contentHash": "yBX6ujNMX24tda1b3w6RF2gq0kDdIH1Gn0rrvqwltcR0p7fMbcYQoDd7G8mXH0V143n1/KrHi5ggATji41nJIQ==",
         "dependencies": {
-          "Microsoft.Agents.AI.Abstractions": "1.13.0",
-          "Microsoft.Extensions.AI": "10.6.0",
-          "Microsoft.Extensions.AI.Abstractions": "10.6.0",
-          "Microsoft.Extensions.AI.Evaluation": "10.6.0",
+          "Microsoft.Agents.AI.Abstractions": "1.17.0",
+          "Microsoft.Extensions.AI": "10.7.0",
+          "Microsoft.Extensions.AI.Abstractions": "10.7.0",
+          "Microsoft.Extensions.AI.Evaluation": "10.7.0",
           "Microsoft.Extensions.Compliance.Abstractions": "10.5.0",
-          "Microsoft.Extensions.VectorData.Abstractions": "9.7.0",
+          "Microsoft.Extensions.VectorData.Abstractions": "10.7.0",
           "Microsoft.ML.Tokenizers": "2.0.0"
         }
       },
       "Microsoft.Agents.AI.Abstractions": {
         "type": "Transitive",
-        "resolved": "1.13.0",
-        "contentHash": "HS2Bf/Iwm7VHK1OmYRy9MYssty+Wm8csouSiPTZHfeUzYVpI4YEowXxld0ITZFKnnzaxFMWaslDiC8HXBsAiPw==",
+        "resolved": "1.17.0",
+        "contentHash": "FoVGnguJhZa95xOgRrGueoZpL8Tz9eQCycwxpiLjiq1SSryu4WaYuryaRKnnaCavJ3tvJBMnWKsHzGO0wyhv0w==",
         "dependencies": {
-          "Microsoft.Extensions.AI.Abstractions": "10.6.0"
+          "Microsoft.Extensions.AI.Abstractions": "10.7.0"
         }
       },
       "Microsoft.Agents.AI.OpenAI": {
         "type": "Transitive",
-        "resolved": "1.13.0",
-        "contentHash": "T8/dmvpxxjn3ulQdPTMjgrYuefWTHYKUVpGN8AI6a17U3p6mHtXU4WkAy77ro6IHiHCL+9mFPDlQ+gd6sGfUfA==",
+        "resolved": "1.17.0",
+        "contentHash": "5hIcZ69tgNtPJfs8ITCBSTseVkLbdUVUXdoGY9gDWyZ+2XroERuQyr7ozVhQCQT1g7VofD4CB8pS5jM5JsSmpA==",
         "dependencies": {
-          "Microsoft.Agents.AI": "1.13.0",
-          "Microsoft.Extensions.AI": "10.6.0",
-          "Microsoft.Extensions.AI.Abstractions": "10.6.0",
-          "Microsoft.Extensions.AI.Evaluation": "10.6.0",
+          "Microsoft.Agents.AI": "1.17.0",
+          "Microsoft.Extensions.AI": "10.7.0",
+          "Microsoft.Extensions.AI.Abstractions": "10.7.0",
+          "Microsoft.Extensions.AI.Evaluation": "10.7.0",
           "Microsoft.Extensions.AI.OpenAI": "10.6.0",
           "Microsoft.Extensions.Compliance.Abstractions": "10.5.0",
-          "Microsoft.Extensions.VectorData.Abstractions": "9.7.0",
+          "Microsoft.Extensions.VectorData.Abstractions": "10.7.0",
           "Microsoft.ML.Tokenizers": "2.0.0",
           "OpenAI": "2.10.0",
           "System.ClientModel": "1.14.0"
         }
       },
+      "Microsoft.Agents.AI.Workflows": {
+        "type": "Transitive",
+        "resolved": "1.17.0",
+        "contentHash": "fXPIZBgQWdHSO9Sl82nBiSe8mZ1TqOozJhDfI+6eeGUWjo/ARICRj2xj3TEUIvUagzFemSdvmDUFdkC434vgtQ==",
+        "dependencies": {
+          "Microsoft.Agents.AI": "1.17.0",
+          "Microsoft.Agents.AI.Abstractions": "1.17.0",
+          "Microsoft.Extensions.AI": "10.7.0",
+          "Microsoft.Extensions.AI.Abstractions": "10.7.0",
+          "Microsoft.Extensions.AI.Evaluation": "10.7.0",
+          "Microsoft.Extensions.Compliance.Abstractions": "10.5.0",
+          "Microsoft.Extensions.VectorData.Abstractions": "10.7.0",
+          "Microsoft.ML.Tokenizers": "2.0.0",
+          "OpenTelemetry.Api": "1.15.3"
+        }
+      },
       "Microsoft.AspNetCore.SpaServices.Extensions": {
         "type": "Transitive",
-        "resolved": "8.0.28",
-        "contentHash": "GDPRtUWm1MN9kW4weOMUFX3IQFGQ9FCsRg7zfUrsLg6adhRaFrP05wPdoGAFPIZNLcGPSm0dFDfXNCr1n+NTfQ=="
+        "resolved": "8.0.29",
+        "contentHash": "eITCT1PzxeFMqnCXj5M+6/hySth4c3NL+eDiWVWhDFOITxnNbtFRC4aomBgxs5AnSe/ypcpqPavr4TIXOvF4pA=="
       },
       "Microsoft.Bcl.AsyncInterfaces": {
         "type": "Transitive",
@@ -630,24 +642,24 @@
       },
       "Microsoft.Extensions.AI": {
         "type": "Transitive",
-        "resolved": "10.7.0",
-        "contentHash": "r8z4uyPq0kTk4+jH92/hPshf3HNUXKOQ9axJwp57QFz43G45BG4DNYpVE0vuSan1dI69LtWx9ttF0Z2ibnghNg==",
+        "resolved": "10.8.3",
+        "contentHash": "VdT9SiqiqmrhsVx//xnfyaaNPuMbo6+vOLm8D/EvtkZfQFpBzPyaJG7W1gFpTJQoQ4nN4k0J9j+NzpScGeEZUQ==",
         "dependencies": {
-          "Microsoft.Extensions.AI.Abstractions": "10.7.0",
-          "System.Numerics.Tensors": "10.0.9"
+          "Microsoft.Extensions.AI.Abstractions": "10.8.3",
+          "System.Numerics.Tensors": "10.0.10"
         }
       },
       "Microsoft.Extensions.AI.Abstractions": {
         "type": "Transitive",
-        "resolved": "10.7.0",
-        "contentHash": "Lf822igMm8NkTYHZhTp7kjoNYkLLEvJnX3SkG/LVBvsZHC0Y9choogHz8YtITBoy0TOylM3kVUZ6iaHf0my0ug=="
+        "resolved": "10.8.3",
+        "contentHash": "K0B05oApxmviWalNHPMBBcRC7erKiDATz3ENNR/jqTR9JwIwLRefgDhj2jCRwL1aca99pXUe0qyQC73/xIuZig=="
       },
       "Microsoft.Extensions.AI.Evaluation": {
         "type": "Transitive",
-        "resolved": "10.6.0",
-        "contentHash": "fHu9H93p7jM2KiXC/6Kd511Gly1rR/VVSIr0FpQ0K381KSHNkSKgp7UAceAPe8wuUMBNXlhcI0q8UocjneuBVg==",
+        "resolved": "10.7.0",
+        "contentHash": "BdbJNfhc/pb3RkD19Sm/XuLK3x5AdU+AB+0HC8Nlu7WZTrVLnA8lpqIx1BB4k+KIKy5ZSH5RVH5HHfT+gwL9yg==",
         "dependencies": {
-          "Microsoft.Extensions.AI.Abstractions": "10.6.0"
+          "Microsoft.Extensions.AI.Abstractions": "10.7.0"
         }
       },
       "Microsoft.Extensions.AI.OpenAI": {
@@ -671,15 +683,15 @@
       },
       "Microsoft.Extensions.FileProviders.Embedded": {
         "type": "Transitive",
-        "resolved": "8.0.28",
-        "contentHash": "T8BuohFYe/7B0hZO3c7HWOXDL3BkWU3aBjfXH8wlgxUFPBOcUBAcjFwZCsqrPwn4nbVC4m3cNLaoVXxD9elXNg=="
+        "resolved": "8.0.29",
+        "contentHash": "f15AkilRlfMqEtv520LLb/IC0RhWTt1YKbY+qZ5SRQNx2cXOBmeMCPGUG/QnYhIobN/oQwfzj0yGGZdbE5P6sg=="
       },
       "Microsoft.Extensions.VectorData.Abstractions": {
         "type": "Transitive",
-        "resolved": "9.7.0",
-        "contentHash": "Vth/omSCX2vR0JabzSRU/hdPhr0CvUVZlaS2lJPWHrEwvak8ntrQLDtLMtMiWKSvviGBe/WmjUW8gA3qqn9tjw==",
+        "resolved": "10.7.0",
+        "contentHash": "eh0JLxoztc9Wz7TrFVRQyotMY9CBh2t22lMPvzy61yaBDDFBsrisrFOD4NId2z/ujwsHVKDtyfDb9tkXwSV5Vw==",
         "dependencies": {
-          "Microsoft.Extensions.AI.Abstractions": "9.5.0"
+          "Microsoft.Extensions.AI.Abstractions": "10.7.0"
         }
       },
       "Microsoft.IdentityModel.Abstractions": {
@@ -780,12 +792,17 @@
         "resolved": "11.6.1",
         "contentHash": "WA4z8iK+0SOh2/qoo7rtEanj/LjJZ8oWWoXI8u1xcYMk6VzHONqpabJBYGrzqDO41ld+VQHOFL+B8MXncIVSSA=="
       },
+      "OpenTelemetry.Api": {
+        "type": "Transitive",
+        "resolved": "1.15.3",
+        "contentHash": "fX+fkCysfPut+qCcT3bKqyX4QN9Saf4CgX8HLOHywEVD+Xr7sULtfuypITpoDysjx8R59dn/3mWhgimMH8cm/g=="
+      },
       "ReverseMarkdown": {
         "type": "Transitive",
-        "resolved": "5.5.0",
-        "contentHash": "oAO57uVzfODQmNZiIc0kCQCaHMn53KEpdSQyi0Usseen5/tnsMimrkL5YipK6vyRk/0NZX/d26vho8ddmpz0vA==",
+        "resolved": "6.1.1",
+        "contentHash": "c3ZFeVCNFnwIV2xlclazeTh1syliThjjBEYFbFYtsjAlX+IlJkUMW6ioxf1Xxd4Un6gu6l2U8meFyDTWvGXSjQ==",
         "dependencies": {
-          "HtmlAgilityPack": "1.12.4"
+          "AngleSharp": "1.5.2"
         }
       },
       "Sidio.Sitemap.Core": {
@@ -825,8 +842,8 @@
       },
       "System.IO.Hashing": {
         "type": "Transitive",
-        "resolved": "10.0.9",
-        "contentHash": "vixglGnKEexAJDeIRhyayZYzxyrgK1K9GU3K/zRZVwDbaDcMkSqj4WDHoVmQMNfsdUtLALfNSJw6mBIpdxie4A=="
+        "resolved": "10.0.10",
+        "contentHash": "eE839zyWZD/UBZYzP2lu9fhHX6RWe63/jz3Jxf+JumzO/db+Vc2s7CMiDwxk9ti2NTUft2tdRx31Rw2OjKbecA=="
       },
       "System.Memory.Data": {
         "type": "Transitive",
@@ -835,8 +852,8 @@
       },
       "System.Numerics.Tensors": {
         "type": "Transitive",
-        "resolved": "10.0.9",
-        "contentHash": "Rb71S3gggYVwEce9ugNw91vbr4vC4gThtx/imSJtLBW3AupEKujJPPQL6xF9q0DcNm6+z7hnYk7XqXaUpA4wDg=="
+        "resolved": "10.0.10",
+        "contentHash": "9Ildb4Y9maDztB0ZRGxsNShbpCQ2Tjv2dr4IjskBxpTGhH7aIz1+oC+Hl833ASs/htWwsH6myNe+sRpeyCzeMQ=="
       },
       "System.Security.Cryptography.Pkcs": {
         "type": "Transitive",
@@ -859,10 +876,10 @@
       "goldfinch.core": {
         "type": "Project",
         "dependencies": {
-          "AngleSharp": "[1.6.0, )",
-          "Kentico.Xperience.Admin": "[31.7.2, )",
+          "AngleSharp": "[1.7.1, )",
+          "Kentico.Xperience.Admin": "[31.8.0, )",
           "Kentico.Xperience.Lucene": "[15.0.5, )",
-          "Kentico.Xperience.WebApp": "[31.7.2, )",
+          "Kentico.Xperience.WebApp": "[31.8.0, )",
           "Lucene.Net.Highlighter": "[4.8.0-beta00018, )",
           "OpenAI": "[2.12.0, )",
           "Sidio.Sitemap.AspNetCore": "[3.1.1, )"
@@ -870,9 +887,9 @@
       },
       "AngleSharp": {
         "type": "CentralTransitive",
-        "requested": "[1.6.0, )",
-        "resolved": "1.6.0",
-        "contentHash": "kVnhnZlM4Yww2KWqW3uSL8isvhYsrTTBMSPAgoF8ZhMrLSoay6783AP6dQxAj1J9gvWKi3OIM4ZezdE2Y4ufCQ=="
+        "requested": "[1.7.1, )",
+        "resolved": "1.7.1",
+        "contentHash": "QBblGpRB3SYD66Mls7fHyl1mWkP93n7ErWDWHc1vd9sPHhdlTkmUoY3CjgfjcWNxGF9m7xjNyztRfErXqoBKOA=="
       },
       "Kentico.Xperience.Lucene": {
         "type": "CentralTransitive",

--- a/src/Goldfinch.Core/packages.lock.json
+++ b/src/Goldfinch.Core/packages.lock.json
@@ -4,24 +4,25 @@
     "net10.0": {
       "AngleSharp": {
         "type": "Direct",
-        "requested": "[1.6.0, )",
-        "resolved": "1.6.0",
-        "contentHash": "kVnhnZlM4Yww2KWqW3uSL8isvhYsrTTBMSPAgoF8ZhMrLSoay6783AP6dQxAj1J9gvWKi3OIM4ZezdE2Y4ufCQ=="
+        "requested": "[1.7.1, )",
+        "resolved": "1.7.1",
+        "contentHash": "QBblGpRB3SYD66Mls7fHyl1mWkP93n7ErWDWHc1vd9sPHhdlTkmUoY3CjgfjcWNxGF9m7xjNyztRfErXqoBKOA=="
       },
       "Kentico.Xperience.Admin": {
         "type": "Direct",
-        "requested": "[31.7.2, )",
-        "resolved": "31.7.2",
-        "contentHash": "gb+E5l+uSUmYKZoqQkT90xG0OhoL2Zey6zpHby7fdRXIdJ2UjmKJfTfguaNmqkSDej4EFa8WNm7SqatK7bJxcw==",
+        "requested": "[31.8.0, )",
+        "resolved": "31.8.0",
+        "contentHash": "3qs1T88jnoIeLuJWQgGgAhBjnv7dten2r8mgynTawm3wo0wyr0dQe3df26zgrrFPW0fqak0H788pWN6YuwpDvg==",
         "dependencies": {
           "Azure.AI.OpenAI": "2.1.0",
           "Kentico.Aira.Client": "6.1.0",
-          "Kentico.Xperience.WebApp": "[31.7.2]",
-          "Microsoft.Agents.AI": "1.13.0",
-          "Microsoft.Agents.AI.OpenAI": "1.13.0",
-          "Microsoft.AspNetCore.SpaServices.Extensions": "8.0.28",
-          "Microsoft.Extensions.AI": "10.7.0",
-          "Microsoft.Extensions.FileProviders.Embedded": "8.0.28",
+          "Kentico.Xperience.WebApp": "[31.8.0]",
+          "Microsoft.Agents.AI": "1.17.0",
+          "Microsoft.Agents.AI.OpenAI": "1.17.0",
+          "Microsoft.Agents.AI.Workflows": "1.17.0",
+          "Microsoft.AspNetCore.SpaServices.Extensions": "8.0.29",
+          "Microsoft.Extensions.AI": "10.8.3",
+          "Microsoft.Extensions.FileProviders.Embedded": "8.0.29",
           "NJsonSchema": "11.6.1"
         }
       },
@@ -37,18 +38,18 @@
       },
       "Kentico.Xperience.WebApp": {
         "type": "Direct",
-        "requested": "[31.7.2, )",
-        "resolved": "31.7.2",
-        "contentHash": "vqkul3ZYBza+jjfOYXz0hkys1kalIfugeA/oqtZ8c5TruVi9XgSR6YxKTD6xeQGhYmUYUZUzc/Phxuxw5qmkAg==",
+        "requested": "[31.8.0, )",
+        "resolved": "31.8.0",
+        "contentHash": "8B1piJ2FLl8z7KIPNLpTrXUpjtbs+5Gn4Np5JXEGUVifDhsqkZJ7UKt3XqHXRnToCrlktQfr1rimmZj3PDSL1w==",
         "dependencies": {
           "CommandLineParser": "2.9.1",
           "HotChocolate.AspNetCore": "15.1.17",
           "HotChocolate.Data": "15.1.17",
-          "HtmlSanitizer": "9.1.973",
-          "Kentico.Xperience.Core": "[31.7.2]",
-          "Microsoft.AspNetCore.Components": "8.0.28",
-          "Microsoft.Extensions.Caching.Memory": "9.0.17",
-          "Microsoft.Extensions.FileProviders.Embedded": "8.0.28"
+          "HtmlSanitizer": "9.2.995",
+          "Kentico.Xperience.Core": "[31.8.0]",
+          "Microsoft.AspNetCore.Components": "8.0.29",
+          "Microsoft.Extensions.Caching.Memory": "9.0.18",
+          "Microsoft.Extensions.FileProviders.Embedded": "8.0.29"
         }
       },
       "Lucene.Net.Highlighter": {
@@ -82,8 +83,8 @@
       },
       "AngleSharp.Css": {
         "type": "Transitive",
-        "resolved": "1.0.0",
-        "contentHash": "yMpYcNkI/ZHTt+qZMczhHEAHZV0AZf75nqJ5LqERFXvJGOFLJjwr0eqaYXqYlt9JPojOd+OkZLlGbnsmKjmh+g==",
+        "resolved": "1.0.1",
+        "contentHash": "6S13xNHH+SUGPZd6EO1MhkuDbpEnFroUM6A8DZpLJHQnLRTvtBJb3Ydu65s618E4gWF9FSWmM5jhKk4RIfwT2A==",
         "dependencies": {
           "AngleSharp": "[1.5.0, 2.0.0)"
         }
@@ -461,18 +462,13 @@
           "Microsoft.Extensions.Options": "9.0.2"
         }
       },
-      "HtmlAgilityPack": {
-        "type": "Transitive",
-        "resolved": "1.12.4",
-        "contentHash": "ljqvBabvFwKoLniuoQKO8b5bJfJweKLs4fUNS/V5dsvpo0A8MlJqxxn9XVmP2DaskbUXty6IYaWAi1SArGIMeQ=="
-      },
       "HtmlSanitizer": {
         "type": "Transitive",
-        "resolved": "9.1.973",
-        "contentHash": "0gDDlj8SZiYFn9fxdWOrxp5mO9y+5jOE0dunOzJ6EELr/FBtlPasvdLR/K3YVgbo4FiPKT3YomlarsvhLm/H2A==",
+        "resolved": "9.2.995",
+        "contentHash": "Yws4FratoTx4FDlvOjQTfuE49ATTVwAxNosv2CE2XqnOcmPuWWOWbLwEYP5w9uqvrGRyOgQloisKVokrgxKaXg==",
         "dependencies": {
-          "AngleSharp": "1.6.0",
-          "AngleSharp.Css": "1.0.0"
+          "AngleSharp": "1.7.1",
+          "AngleSharp.Css": "1.0.1"
         }
       },
       "J2N": {
@@ -496,27 +492,27 @@
       },
       "Kentico.Xperience.Core": {
         "type": "Transitive",
-        "resolved": "31.7.2",
-        "contentHash": "O4TfBddUhaNXvZu2Gep3hCrudidli0pAODLwyFB2ppY71wqlO/ITnvAKyrox4MoYuRK9/qLbPXol6E5ReUb8MQ==",
+        "resolved": "31.8.0",
+        "contentHash": "YKIlHtYGwgCxhM5RA5TsvcNPgfxwObeZNXxVfhuIU5m0m/J4ikN4xAYldt2rXe7rZ5HvsxHVXyRvtrHCgWY58w==",
         "dependencies": {
-          "AngleSharp": "1.6.0",
+          "AngleSharp": "1.7.1",
           "Kentico.Aira.Client": "6.1.0",
-          "Magick.NET-Q8-AnyCPU": "14.15.0",
+          "Magick.NET-Q8-AnyCPU": "14.16.0",
           "MailKit": "4.17.0",
           "Microsoft.Data.SqlClient": "7.0.0",
-          "Microsoft.Extensions.Caching.Memory": "9.0.17",
+          "Microsoft.Extensions.Caching.Memory": "9.0.18",
           "Microsoft.Extensions.Configuration": "8.0.0",
           "Microsoft.Extensions.DependencyInjection": "8.0.1",
           "Microsoft.Extensions.FileProviders.Physical": "8.0.0",
           "Microsoft.Extensions.Hosting.Abstractions": "8.0.1",
-          "Microsoft.Extensions.Localization": "8.0.28",
+          "Microsoft.Extensions.Localization": "8.0.29",
           "Microsoft.Extensions.Logging": "8.0.1",
           "Microsoft.Extensions.Options.ConfigurationExtensions": "8.0.0",
           "Mono.Cecil": "0.11.6",
           "Newtonsoft.Json": "13.0.4",
-          "ReverseMarkdown": "5.5.0",
+          "ReverseMarkdown": "6.1.1",
           "System.CodeDom": "8.0.0",
-          "System.IO.Hashing": "10.0.9"
+          "System.IO.Hashing": "10.0.10"
         }
       },
       "Kentico.Xperience.Lucene.Admin": {
@@ -600,16 +596,16 @@
       },
       "Magick.NET-Q8-AnyCPU": {
         "type": "Transitive",
-        "resolved": "14.15.0",
-        "contentHash": "GYcT4dC2Dxgq/FN/PwVY+PHJEuZc5ZfQm0bj0BmvmSRXPjPPJzdOV8tbcMyNUQtHcRnsp6E/mJ5Tf62I8in3bg==",
+        "resolved": "14.16.0",
+        "contentHash": "mV5igNia0VyUtRAmqUpI/ZBEL78+0A+JxPoOs7clwlZEvPCsvk+uF0hLl10zaFYmH5I8BaqVpI2+R+td1bbNrg==",
         "dependencies": {
-          "Magick.NET.Core": "14.15.0"
+          "Magick.NET.Core": "14.16.0"
         }
       },
       "Magick.NET.Core": {
         "type": "Transitive",
-        "resolved": "14.15.0",
-        "contentHash": "xgD1zqb4KQ1gMQcd3eIRp8hFMHBxzW9fOpLLDR7BWN0oCwZ0i6NW7rIUiCdsEi/NuZi1UlCLWBHh3v7Y2E3LIw=="
+        "resolved": "14.16.0",
+        "contentHash": "ddBX/Zb0sCsX4agqHdHeqUx+grfw8I7GFU+lgut3mtNl7roxbxemSQFGLIJXtzwPuAHxbaMtkXA+ijVl02EUhQ=="
       },
       "MailKit": {
         "type": "Transitive",
@@ -621,82 +617,101 @@
       },
       "Microsoft.Agents.AI": {
         "type": "Transitive",
-        "resolved": "1.13.0",
-        "contentHash": "IQ9ZubJ30SPZevXFUIy8Z67cyYfgvpRpQHU22h98RUyojn6A+OqBfB7EplVxcv7iMO2QWIJDW2jh6xTKmO8BjQ==",
+        "resolved": "1.17.0",
+        "contentHash": "yBX6ujNMX24tda1b3w6RF2gq0kDdIH1Gn0rrvqwltcR0p7fMbcYQoDd7G8mXH0V143n1/KrHi5ggATji41nJIQ==",
         "dependencies": {
-          "Microsoft.Agents.AI.Abstractions": "1.13.0",
-          "Microsoft.Extensions.AI": "10.6.0",
-          "Microsoft.Extensions.AI.Abstractions": "10.6.0",
-          "Microsoft.Extensions.AI.Evaluation": "10.6.0",
+          "Microsoft.Agents.AI.Abstractions": "1.17.0",
+          "Microsoft.Extensions.AI": "10.7.0",
+          "Microsoft.Extensions.AI.Abstractions": "10.7.0",
+          "Microsoft.Extensions.AI.Evaluation": "10.7.0",
           "Microsoft.Extensions.Compliance.Abstractions": "10.5.0",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.9",
           "Microsoft.Extensions.FileSystemGlobbing": "10.0.6",
           "Microsoft.Extensions.Logging.Abstractions": "10.0.9",
-          "Microsoft.Extensions.VectorData.Abstractions": "9.7.0",
+          "Microsoft.Extensions.VectorData.Abstractions": "10.7.0",
           "Microsoft.ML.Tokenizers": "2.0.0"
         }
       },
       "Microsoft.Agents.AI.Abstractions": {
         "type": "Transitive",
-        "resolved": "1.13.0",
-        "contentHash": "HS2Bf/Iwm7VHK1OmYRy9MYssty+Wm8csouSiPTZHfeUzYVpI4YEowXxld0ITZFKnnzaxFMWaslDiC8HXBsAiPw==",
+        "resolved": "1.17.0",
+        "contentHash": "FoVGnguJhZa95xOgRrGueoZpL8Tz9eQCycwxpiLjiq1SSryu4WaYuryaRKnnaCavJ3tvJBMnWKsHzGO0wyhv0w==",
         "dependencies": {
-          "Microsoft.Extensions.AI.Abstractions": "10.6.0"
+          "Microsoft.Extensions.AI.Abstractions": "10.7.0"
         }
       },
       "Microsoft.Agents.AI.OpenAI": {
         "type": "Transitive",
-        "resolved": "1.13.0",
-        "contentHash": "T8/dmvpxxjn3ulQdPTMjgrYuefWTHYKUVpGN8AI6a17U3p6mHtXU4WkAy77ro6IHiHCL+9mFPDlQ+gd6sGfUfA==",
+        "resolved": "1.17.0",
+        "contentHash": "5hIcZ69tgNtPJfs8ITCBSTseVkLbdUVUXdoGY9gDWyZ+2XroERuQyr7ozVhQCQT1g7VofD4CB8pS5jM5JsSmpA==",
         "dependencies": {
-          "Microsoft.Agents.AI": "1.13.0",
-          "Microsoft.Extensions.AI": "10.6.0",
-          "Microsoft.Extensions.AI.Abstractions": "10.6.0",
-          "Microsoft.Extensions.AI.Evaluation": "10.6.0",
+          "Microsoft.Agents.AI": "1.17.0",
+          "Microsoft.Extensions.AI": "10.7.0",
+          "Microsoft.Extensions.AI.Abstractions": "10.7.0",
+          "Microsoft.Extensions.AI.Evaluation": "10.7.0",
           "Microsoft.Extensions.AI.OpenAI": "10.6.0",
           "Microsoft.Extensions.Compliance.Abstractions": "10.5.0",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.9",
           "Microsoft.Extensions.FileSystemGlobbing": "10.0.6",
           "Microsoft.Extensions.Logging.Abstractions": "10.0.9",
-          "Microsoft.Extensions.VectorData.Abstractions": "9.7.0",
+          "Microsoft.Extensions.VectorData.Abstractions": "10.7.0",
           "Microsoft.ML.Tokenizers": "2.0.0",
           "OpenAI": "2.10.0",
           "System.ClientModel": "1.14.0"
         }
       },
+      "Microsoft.Agents.AI.Workflows": {
+        "type": "Transitive",
+        "resolved": "1.17.0",
+        "contentHash": "fXPIZBgQWdHSO9Sl82nBiSe8mZ1TqOozJhDfI+6eeGUWjo/ARICRj2xj3TEUIvUagzFemSdvmDUFdkC434vgtQ==",
+        "dependencies": {
+          "Microsoft.Agents.AI": "1.17.0",
+          "Microsoft.Agents.AI.Abstractions": "1.17.0",
+          "Microsoft.Extensions.AI": "10.7.0",
+          "Microsoft.Extensions.AI.Abstractions": "10.7.0",
+          "Microsoft.Extensions.AI.Evaluation": "10.7.0",
+          "Microsoft.Extensions.Compliance.Abstractions": "10.5.0",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.9",
+          "Microsoft.Extensions.FileSystemGlobbing": "10.0.6",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.9",
+          "Microsoft.Extensions.VectorData.Abstractions": "10.7.0",
+          "Microsoft.ML.Tokenizers": "2.0.0",
+          "OpenTelemetry.Api": "1.15.3"
+        }
+      },
       "Microsoft.AspNetCore.Authorization": {
         "type": "Transitive",
-        "resolved": "8.0.28",
-        "contentHash": "GmPOLqxrZl05wwfwYlgcpJaxt5OF2Cb9llylCZgLjoYoS53ow1SMKUxwN5ICwK+Z2ZY3h+vaGNmfFlMLnG49nA==",
+        "resolved": "8.0.29",
+        "contentHash": "IMVrMqYF7LASYMWVt/sL9f5vkA8qtfvsLEaxSchEc1Pk/zxdQt1fP1W3hN6Wxm0+wJjAKO+DhF/1mi22AtAfCQ==",
         "dependencies": {
-          "Microsoft.AspNetCore.Metadata": "8.0.28",
+          "Microsoft.AspNetCore.Metadata": "8.0.29",
           "Microsoft.Extensions.Logging.Abstractions": "8.0.3",
           "Microsoft.Extensions.Options": "8.0.2"
         }
       },
       "Microsoft.AspNetCore.Components": {
         "type": "Transitive",
-        "resolved": "8.0.28",
-        "contentHash": "plu56CQv1VXVAy3fTSK/TuZCd2E+lVY3U+VDSaAKtoikpdfzc1TiEXfkhfqG3pzTIUE79Hx1Nj+z6KJunHQBnw==",
+        "resolved": "8.0.29",
+        "contentHash": "1ZNdFYtEORG9LOYFJf0AtNMSAtkQ8WQ5XEGQXdEDvRMYBp4MS5t6mPAiWGVMb5aKpPfaeXOGHQqDcZHP3QfuAA==",
         "dependencies": {
-          "Microsoft.AspNetCore.Authorization": "8.0.28",
-          "Microsoft.AspNetCore.Components.Analyzers": "8.0.28"
+          "Microsoft.AspNetCore.Authorization": "8.0.29",
+          "Microsoft.AspNetCore.Components.Analyzers": "8.0.29"
         }
       },
       "Microsoft.AspNetCore.Components.Analyzers": {
         "type": "Transitive",
-        "resolved": "8.0.28",
-        "contentHash": "b8zvsihdheG8cUGWupxZrkoAjI3Cq6QZZ9xZay8fmIOd00OQfpQ3tdO7vmqPzl/0y/KHtAjiBFUu+MvEkxfxFA=="
+        "resolved": "8.0.29",
+        "contentHash": "AoGUtJ3CgKhihjGCga7vNCawzWUHb7QNMtxzBJKjTYYhM9HwkGE/xmg6sZNO3Tw5W+ke5PoUO411Squ//jgiTQ=="
       },
       "Microsoft.AspNetCore.Metadata": {
         "type": "Transitive",
-        "resolved": "8.0.28",
-        "contentHash": "mhdcxZEO5AzXWVKiMxedNP6g4ie/Odf0ZG1rcx+CS/3ihiLGoV8lS2NRQZ8qKIHFjmhjx2BkW4BUvGqVpI+jpQ=="
+        "resolved": "8.0.29",
+        "contentHash": "5Oyb4tncDGft/tXVJoyO7iWy1fnz1AzgycQfzPPSJqafmp3J+xLhgfDSTB+hzVVyG9mcb9z/8m9RDEx7bCj3Kw=="
       },
       "Microsoft.AspNetCore.SpaServices.Extensions": {
         "type": "Transitive",
-        "resolved": "8.0.28",
-        "contentHash": "GDPRtUWm1MN9kW4weOMUFX3IQFGQ9FCsRg7zfUrsLg6adhRaFrP05wPdoGAFPIZNLcGPSm0dFDfXNCr1n+NTfQ==",
+        "resolved": "8.0.29",
+        "contentHash": "eITCT1PzxeFMqnCXj5M+6/hySth4c3NL+eDiWVWhDFOITxnNbtFRC4aomBgxs5AnSe/ypcpqPavr4TIXOvF4pA==",
         "dependencies": {
           "Microsoft.Extensions.FileProviders.Physical": "8.0.0"
         }
@@ -748,27 +763,27 @@
       },
       "Microsoft.Extensions.AI": {
         "type": "Transitive",
-        "resolved": "10.7.0",
-        "contentHash": "r8z4uyPq0kTk4+jH92/hPshf3HNUXKOQ9axJwp57QFz43G45BG4DNYpVE0vuSan1dI69LtWx9ttF0Z2ibnghNg==",
+        "resolved": "10.8.3",
+        "contentHash": "VdT9SiqiqmrhsVx//xnfyaaNPuMbo6+vOLm8D/EvtkZfQFpBzPyaJG7W1gFpTJQoQ4nN4k0J9j+NzpScGeEZUQ==",
         "dependencies": {
-          "Microsoft.Extensions.AI.Abstractions": "10.7.0",
-          "Microsoft.Extensions.Caching.Abstractions": "10.0.9",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.9",
-          "Microsoft.Extensions.Logging.Abstractions": "10.0.9",
-          "System.Numerics.Tensors": "10.0.9"
+          "Microsoft.Extensions.AI.Abstractions": "10.8.3",
+          "Microsoft.Extensions.Caching.Abstractions": "10.0.10",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.10",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.10",
+          "System.Numerics.Tensors": "10.0.10"
         }
       },
       "Microsoft.Extensions.AI.Abstractions": {
         "type": "Transitive",
-        "resolved": "10.7.0",
-        "contentHash": "Lf822igMm8NkTYHZhTp7kjoNYkLLEvJnX3SkG/LVBvsZHC0Y9choogHz8YtITBoy0TOylM3kVUZ6iaHf0my0ug=="
+        "resolved": "10.8.3",
+        "contentHash": "K0B05oApxmviWalNHPMBBcRC7erKiDATz3ENNR/jqTR9JwIwLRefgDhj2jCRwL1aca99pXUe0qyQC73/xIuZig=="
       },
       "Microsoft.Extensions.AI.Evaluation": {
         "type": "Transitive",
-        "resolved": "10.6.0",
-        "contentHash": "fHu9H93p7jM2KiXC/6Kd511Gly1rR/VVSIr0FpQ0K381KSHNkSKgp7UAceAPe8wuUMBNXlhcI0q8UocjneuBVg==",
+        "resolved": "10.7.0",
+        "contentHash": "BdbJNfhc/pb3RkD19Sm/XuLK3x5AdU+AB+0HC8Nlu7WZTrVLnA8lpqIx1BB4k+KIKy5ZSH5RVH5HHfT+gwL9yg==",
         "dependencies": {
-          "Microsoft.Extensions.AI.Abstractions": "10.6.0"
+          "Microsoft.Extensions.AI.Abstractions": "10.7.0"
         }
       },
       "Microsoft.Extensions.AI.OpenAI": {
@@ -782,10 +797,10 @@
       },
       "Microsoft.Extensions.Caching.Abstractions": {
         "type": "Transitive",
-        "resolved": "10.0.9",
-        "contentHash": "5fGxcw2vuYp8s0wio9H1ECiuk4iKSdTIlNuigdLIrkhg+5XAwgFVDB/5Ots3pfN/QhABLYXutA79JFtnUKDSHA==",
+        "resolved": "10.0.10",
+        "contentHash": "4ZFBNE+jzR+CrWWlhOesnmywCW7pYKT0dxyAQRdL11yJwxe4jvcAu31eorFtEkoFeCDcUTeNssgPv2yaRRptaQ==",
         "dependencies": {
-          "Microsoft.Extensions.Primitives": "10.0.9"
+          "Microsoft.Extensions.Primitives": "10.0.10"
         }
       },
       "Microsoft.Extensions.Caching.Hybrid": {
@@ -855,8 +870,8 @@
       },
       "Microsoft.Extensions.DependencyInjection.Abstractions": {
         "type": "Transitive",
-        "resolved": "10.0.9",
-        "contentHash": "g41l/30G3K4B/d/L8kjux0+30e27c8D0FVQ/PFCpbekgfDpj9mnDhieP67EqXWvl1EWNeZh2rpR4F5B/jcDOHA=="
+        "resolved": "10.0.10",
+        "contentHash": "z/2xXlFw2aLGjHyEm6E0tQ+In6VfzQzTrtArbQ2c0TQE16ZbyDCMGPvaUT9I0s8rgy9sRWlU2P9waW37qV04qA=="
       },
       "Microsoft.Extensions.Diagnostics": {
         "type": "Transitive",
@@ -887,8 +902,8 @@
       },
       "Microsoft.Extensions.FileProviders.Embedded": {
         "type": "Transitive",
-        "resolved": "8.0.28",
-        "contentHash": "T8BuohFYe/7B0hZO3c7HWOXDL3BkWU3aBjfXH8wlgxUFPBOcUBAcjFwZCsqrPwn4nbVC4m3cNLaoVXxD9elXNg==",
+        "resolved": "8.0.29",
+        "contentHash": "f15AkilRlfMqEtv520LLb/IC0RhWTt1YKbY+qZ5SRQNx2cXOBmeMCPGUG/QnYhIobN/oQwfzj0yGGZdbE5P6sg==",
         "dependencies": {
           "Microsoft.Extensions.FileProviders.Abstractions": "8.0.0"
         }
@@ -935,19 +950,19 @@
       },
       "Microsoft.Extensions.Localization": {
         "type": "Transitive",
-        "resolved": "8.0.28",
-        "contentHash": "fZKLrvaStmqV4i+PUrJRRZh7jYOu3a1GBRgpWywY+VoN1URL5EEtZ+uUseowYn67YF6YoCgoszTV3W2W5BjNNQ==",
+        "resolved": "8.0.29",
+        "contentHash": "Zts1Jk75HvejkJqtYrDzTfFonPM+hODVCaXl1/qpdaNT+Jvyri/LxUdNOpFEi8M9lTV/8vu0uIe3FSby7Rer9Q==",
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection.Abstractions": "8.0.2",
-          "Microsoft.Extensions.Localization.Abstractions": "8.0.28",
+          "Microsoft.Extensions.Localization.Abstractions": "8.0.29",
           "Microsoft.Extensions.Logging.Abstractions": "8.0.3",
           "Microsoft.Extensions.Options": "8.0.2"
         }
       },
       "Microsoft.Extensions.Localization.Abstractions": {
         "type": "Transitive",
-        "resolved": "8.0.28",
-        "contentHash": "DgI4p/Gu5cfXhbEqX2QmEKMMJLvQJFBo2odOsyvgeJr9hUJ0//fmslKYcjDAq04psjQGpcpIVSWC/xm6G6p+EQ=="
+        "resolved": "8.0.29",
+        "contentHash": "OCbXCCp4OgmiRUNSJ9nhbHkwGireO0OmhCs1jNQGw9R1bV749SClPeTFpUaQijGoUEXBTgFzUAenJAMQbqEZpQ=="
       },
       "Microsoft.Extensions.Logging": {
         "type": "Transitive",
@@ -961,10 +976,10 @@
       },
       "Microsoft.Extensions.Logging.Abstractions": {
         "type": "Transitive",
-        "resolved": "10.0.9",
-        "contentHash": "9S/DFt4cohlMPpzIxjG6kk0L8MuN2vDm9pbMCulxtJzzk82oJHVLBd8vuQxaPskaYQwKqmFmbannf5eoChgjYg==",
+        "resolved": "10.0.10",
+        "contentHash": "zkFxGYUvdxAvIKTyXHrmW+Sux53D4SezD9dMyZ6hrwwzPQJNuwCRy1f5W7AvYTqacEGhWF2XderRQG1OvbV8og==",
         "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.9"
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.10"
         }
       },
       "Microsoft.Extensions.ObjectPool": {
@@ -995,15 +1010,15 @@
       },
       "Microsoft.Extensions.Primitives": {
         "type": "Transitive",
-        "resolved": "10.0.9",
-        "contentHash": "fmEbAUFsaIKirgLt/lYhuFRBwhcSJN31jjHgCdbQxJiWOum6EdLjkbgGuukSP9z/a+9LibaxII/kF+GwOXgC4g=="
+        "resolved": "10.0.10",
+        "contentHash": "5wu/GrYVd8mG2DVUw3vFJzF+O336TyTGg/Kmcgw9bfwYhCoFiV5lR5QeEmKecJyrW4W54nMfD3p3589E8a7czQ=="
       },
       "Microsoft.Extensions.VectorData.Abstractions": {
         "type": "Transitive",
-        "resolved": "9.7.0",
-        "contentHash": "Vth/omSCX2vR0JabzSRU/hdPhr0CvUVZlaS2lJPWHrEwvak8ntrQLDtLMtMiWKSvviGBe/WmjUW8gA3qqn9tjw==",
+        "resolved": "10.7.0",
+        "contentHash": "eh0JLxoztc9Wz7TrFVRQyotMY9CBh2t22lMPvzy61yaBDDFBsrisrFOD4NId2z/ujwsHVKDtyfDb9tkXwSV5Vw==",
         "dependencies": {
-          "Microsoft.Extensions.AI.Abstractions": "9.5.0"
+          "Microsoft.Extensions.AI.Abstractions": "10.7.0"
         }
       },
       "Microsoft.IdentityModel.Abstractions": {
@@ -1105,12 +1120,17 @@
         "resolved": "11.6.1",
         "contentHash": "WA4z8iK+0SOh2/qoo7rtEanj/LjJZ8oWWoXI8u1xcYMk6VzHONqpabJBYGrzqDO41ld+VQHOFL+B8MXncIVSSA=="
       },
+      "OpenTelemetry.Api": {
+        "type": "Transitive",
+        "resolved": "1.15.3",
+        "contentHash": "fX+fkCysfPut+qCcT3bKqyX4QN9Saf4CgX8HLOHywEVD+Xr7sULtfuypITpoDysjx8R59dn/3mWhgimMH8cm/g=="
+      },
       "ReverseMarkdown": {
         "type": "Transitive",
-        "resolved": "5.5.0",
-        "contentHash": "oAO57uVzfODQmNZiIc0kCQCaHMn53KEpdSQyi0Usseen5/tnsMimrkL5YipK6vyRk/0NZX/d26vho8ddmpz0vA==",
+        "resolved": "6.1.1",
+        "contentHash": "c3ZFeVCNFnwIV2xlclazeTh1syliThjjBEYFbFYtsjAlX+IlJkUMW6ioxf1Xxd4Un6gu6l2U8meFyDTWvGXSjQ==",
         "dependencies": {
-          "HtmlAgilityPack": "1.12.4"
+          "AngleSharp": "1.5.2"
         }
       },
       "Sidio.Sitemap.Core": {
@@ -1162,8 +1182,8 @@
       },
       "System.IO.Hashing": {
         "type": "Transitive",
-        "resolved": "10.0.9",
-        "contentHash": "vixglGnKEexAJDeIRhyayZYzxyrgK1K9GU3K/zRZVwDbaDcMkSqj4WDHoVmQMNfsdUtLALfNSJw6mBIpdxie4A=="
+        "resolved": "10.0.10",
+        "contentHash": "eE839zyWZD/UBZYzP2lu9fhHX6RWe63/jz3Jxf+JumzO/db+Vc2s7CMiDwxk9ti2NTUft2tdRx31Rw2OjKbecA=="
       },
       "System.Memory.Data": {
         "type": "Transitive",
@@ -1172,8 +1192,8 @@
       },
       "System.Numerics.Tensors": {
         "type": "Transitive",
-        "resolved": "10.0.9",
-        "contentHash": "Rb71S3gggYVwEce9ugNw91vbr4vC4gThtx/imSJtLBW3AupEKujJPPQL6xF9q0DcNm6+z7hnYk7XqXaUpA4wDg=="
+        "resolved": "10.0.10",
+        "contentHash": "9Ildb4Y9maDztB0ZRGxsNShbpCQ2Tjv2dr4IjskBxpTGhH7aIz1+oC+Hl833ASs/htWwsH6myNe+sRpeyCzeMQ=="
       },
       "System.Security.Cryptography.Pkcs": {
         "type": "Transitive",

--- a/src/Goldfinch.Web/App_Data/CIRepository/@global/cms.class/aira.conversation.xml
+++ b/src/Goldfinch.Web/App_Data/CIRepository/@global/cms.class/aira.conversation.xml
@@ -18,6 +18,7 @@
           <defaultvalue>[]</defaultvalue>
         </properties>
       </field>
+      <field allowempty="true" column="AiraConversationCheckpoint" columnprecision="0" columntype="longtext" enabled="true" guid="c6dda998-5e1f-4279-ae86-1270f2d8c914" system="true" />
     </form>
   </ClassFormDefinition>
   <ClassGUID>50e0749f-a123-4cd7-aa41-e48d2166fb35</ClassGUID>

--- a/src/Goldfinch.Web/packages.lock.json
+++ b/src/Goldfinch.Web/packages.lock.json
@@ -4,46 +4,47 @@
     "net10.0": {
       "Kentico.Xperience.Admin": {
         "type": "Direct",
-        "requested": "[31.7.2, )",
-        "resolved": "31.7.2",
-        "contentHash": "gb+E5l+uSUmYKZoqQkT90xG0OhoL2Zey6zpHby7fdRXIdJ2UjmKJfTfguaNmqkSDej4EFa8WNm7SqatK7bJxcw==",
+        "requested": "[31.8.0, )",
+        "resolved": "31.8.0",
+        "contentHash": "3qs1T88jnoIeLuJWQgGgAhBjnv7dten2r8mgynTawm3wo0wyr0dQe3df26zgrrFPW0fqak0H788pWN6YuwpDvg==",
         "dependencies": {
           "Azure.AI.OpenAI": "2.1.0",
           "Kentico.Aira.Client": "6.1.0",
-          "Kentico.Xperience.WebApp": "[31.7.2]",
-          "Microsoft.Agents.AI": "1.13.0",
-          "Microsoft.Agents.AI.OpenAI": "1.13.0",
-          "Microsoft.AspNetCore.SpaServices.Extensions": "8.0.28",
-          "Microsoft.Extensions.AI": "10.7.0",
-          "Microsoft.Extensions.FileProviders.Embedded": "8.0.28",
+          "Kentico.Xperience.WebApp": "[31.8.0]",
+          "Microsoft.Agents.AI": "1.17.0",
+          "Microsoft.Agents.AI.OpenAI": "1.17.0",
+          "Microsoft.Agents.AI.Workflows": "1.17.0",
+          "Microsoft.AspNetCore.SpaServices.Extensions": "8.0.29",
+          "Microsoft.Extensions.AI": "10.8.3",
+          "Microsoft.Extensions.FileProviders.Embedded": "8.0.29",
           "NJsonSchema": "11.6.1"
         }
       },
       "Kentico.Xperience.AzureStorage": {
         "type": "Direct",
-        "requested": "[31.7.2, )",
-        "resolved": "31.7.2",
-        "contentHash": "TmDAB35hGiVkBCnnCUDiqA//eZcJCLG7q9vhEWaTQQy7Ws5OR45OFIY/ReAvstbCrWQNYeXAQ0vwt8CAoT3XQw==",
+        "requested": "[31.8.0, )",
+        "resolved": "31.8.0",
+        "contentHash": "A0z65u5IlDY50/tVQpqWf8Ydh5YPm0hHbNk8bCK+m4OSDx7dKcCu0OjA3yPScOBt0SN/WKFTjXgV94/nXtbLnw==",
         "dependencies": {
           "Azure.Storage.Blobs": "12.29.1",
-          "Kentico.Xperience.Core": "31.7.2",
+          "Kentico.Xperience.Core": "31.8.0",
           "Newtonsoft.Json": "13.0.4",
-          "System.IO.Hashing": "10.0.9"
+          "System.IO.Hashing": "10.0.10"
         }
       },
       "Kentico.Xperience.ManagementApi": {
         "type": "Direct",
-        "requested": "[31.7.2-preview, )",
-        "resolved": "31.7.2-preview",
-        "contentHash": "NpriFVZ7njPEEwAHJdDJH5e8RNxNP7rDkNlzPI/fCBPP20XqIjQDmJ2JXVgn5tVoNnY75IozmrsOM8d4SXjr3w==",
+        "requested": "[31.8.0-preview, )",
+        "resolved": "31.8.0-preview",
+        "contentHash": "hjGpizAA1//NECLwNtnZBd+EQPt200Zk5EebYhkhfWRWUXxbIS+hb++IUW6QbFy9SPFKyjFtiLjR4NVx0AVSDQ==",
         "dependencies": {
           "Asp.Versioning.Mvc": "8.1.1",
           "Asp.Versioning.Mvc.ApiExplorer": "8.1.1",
-          "Kentico.Xperience.Admin": "31.7.2",
-          "Kentico.Xperience.Core": "31.7.2",
+          "Kentico.Xperience.Admin": "31.8.0",
+          "Kentico.Xperience.Core": "31.8.0",
           "NJsonSchema": "11.6.1",
           "Swashbuckle.AspNetCore": "10.2.3",
-          "Vogen": "8.0.6"
+          "Vogen": "8.0.7"
         }
       },
       "Kentico.Xperience.MiniProfiler": {
@@ -59,16 +60,16 @@
       },
       "Kentico.Xperience.WebApp": {
         "type": "Direct",
-        "requested": "[31.7.2, )",
-        "resolved": "31.7.2",
-        "contentHash": "vqkul3ZYBza+jjfOYXz0hkys1kalIfugeA/oqtZ8c5TruVi9XgSR6YxKTD6xeQGhYmUYUZUzc/Phxuxw5qmkAg==",
+        "requested": "[31.8.0, )",
+        "resolved": "31.8.0",
+        "contentHash": "8B1piJ2FLl8z7KIPNLpTrXUpjtbs+5Gn4Np5JXEGUVifDhsqkZJ7UKt3XqHXRnToCrlktQfr1rimmZj3PDSL1w==",
         "dependencies": {
           "CommandLineParser": "2.9.1",
           "HotChocolate.AspNetCore": "15.1.17",
           "HotChocolate.Data": "15.1.17",
-          "HtmlSanitizer": "9.1.973",
-          "Kentico.Xperience.Core": "[31.7.2]",
-          "Microsoft.Extensions.FileProviders.Embedded": "8.0.28"
+          "HtmlSanitizer": "9.2.995",
+          "Kentico.Xperience.Core": "[31.8.0]",
+          "Microsoft.Extensions.FileProviders.Embedded": "8.0.29"
         }
       },
       "Schema.NET": {
@@ -104,8 +105,8 @@
       },
       "AngleSharp.Css": {
         "type": "Transitive",
-        "resolved": "1.0.0",
-        "contentHash": "yMpYcNkI/ZHTt+qZMczhHEAHZV0AZf75nqJ5LqERFXvJGOFLJjwr0eqaYXqYlt9JPojOd+OkZLlGbnsmKjmh+g==",
+        "resolved": "1.0.1",
+        "contentHash": "6S13xNHH+SUGPZd6EO1MhkuDbpEnFroUM6A8DZpLJHQnLRTvtBJb3Ydu65s618E4gWF9FSWmM5jhKk4RIfwT2A==",
         "dependencies": {
           "AngleSharp": "[1.5.0, 2.0.0)"
         }
@@ -514,18 +515,13 @@
           "HotChocolate.Types": "15.1.17"
         }
       },
-      "HtmlAgilityPack": {
-        "type": "Transitive",
-        "resolved": "1.12.4",
-        "contentHash": "ljqvBabvFwKoLniuoQKO8b5bJfJweKLs4fUNS/V5dsvpo0A8MlJqxxn9XVmP2DaskbUXty6IYaWAi1SArGIMeQ=="
-      },
       "HtmlSanitizer": {
         "type": "Transitive",
-        "resolved": "9.1.973",
-        "contentHash": "0gDDlj8SZiYFn9fxdWOrxp5mO9y+5jOE0dunOzJ6EELr/FBtlPasvdLR/K3YVgbo4FiPKT3YomlarsvhLm/H2A==",
+        "resolved": "9.2.995",
+        "contentHash": "Yws4FratoTx4FDlvOjQTfuE49ATTVwAxNosv2CE2XqnOcmPuWWOWbLwEYP5w9uqvrGRyOgQloisKVokrgxKaXg==",
         "dependencies": {
-          "AngleSharp": "1.6.0",
-          "AngleSharp.Css": "1.0.0"
+          "AngleSharp": "1.7.1",
+          "AngleSharp.Css": "1.0.1"
         }
       },
       "J2N": {
@@ -544,19 +540,19 @@
       },
       "Kentico.Xperience.Core": {
         "type": "Transitive",
-        "resolved": "31.7.2",
-        "contentHash": "O4TfBddUhaNXvZu2Gep3hCrudidli0pAODLwyFB2ppY71wqlO/ITnvAKyrox4MoYuRK9/qLbPXol6E5ReUb8MQ==",
+        "resolved": "31.8.0",
+        "contentHash": "YKIlHtYGwgCxhM5RA5TsvcNPgfxwObeZNXxVfhuIU5m0m/J4ikN4xAYldt2rXe7rZ5HvsxHVXyRvtrHCgWY58w==",
         "dependencies": {
-          "AngleSharp": "1.6.0",
+          "AngleSharp": "1.7.1",
           "Kentico.Aira.Client": "6.1.0",
-          "Magick.NET-Q8-AnyCPU": "14.15.0",
+          "Magick.NET-Q8-AnyCPU": "14.16.0",
           "MailKit": "4.17.0",
           "Microsoft.Data.SqlClient": "7.0.0",
           "Mono.Cecil": "0.11.6",
           "Newtonsoft.Json": "13.0.4",
-          "ReverseMarkdown": "5.5.0",
+          "ReverseMarkdown": "6.1.1",
           "System.CodeDom": "8.0.0",
-          "System.IO.Hashing": "10.0.9"
+          "System.IO.Hashing": "10.0.10"
         }
       },
       "Kentico.Xperience.Lucene.Admin": {
@@ -639,16 +635,16 @@
       },
       "Magick.NET-Q8-AnyCPU": {
         "type": "Transitive",
-        "resolved": "14.15.0",
-        "contentHash": "GYcT4dC2Dxgq/FN/PwVY+PHJEuZc5ZfQm0bj0BmvmSRXPjPPJzdOV8tbcMyNUQtHcRnsp6E/mJ5Tf62I8in3bg==",
+        "resolved": "14.16.0",
+        "contentHash": "mV5igNia0VyUtRAmqUpI/ZBEL78+0A+JxPoOs7clwlZEvPCsvk+uF0hLl10zaFYmH5I8BaqVpI2+R+td1bbNrg==",
         "dependencies": {
-          "Magick.NET.Core": "14.15.0"
+          "Magick.NET.Core": "14.16.0"
         }
       },
       "Magick.NET.Core": {
         "type": "Transitive",
-        "resolved": "14.15.0",
-        "contentHash": "xgD1zqb4KQ1gMQcd3eIRp8hFMHBxzW9fOpLLDR7BWN0oCwZ0i6NW7rIUiCdsEi/NuZi1UlCLWBHh3v7Y2E3LIw=="
+        "resolved": "14.16.0",
+        "contentHash": "ddBX/Zb0sCsX4agqHdHeqUx+grfw8I7GFU+lgut3mtNl7roxbxemSQFGLIJXtzwPuAHxbaMtkXA+ijVl02EUhQ=="
       },
       "MailKit": {
         "type": "Transitive",
@@ -660,47 +656,63 @@
       },
       "Microsoft.Agents.AI": {
         "type": "Transitive",
-        "resolved": "1.13.0",
-        "contentHash": "IQ9ZubJ30SPZevXFUIy8Z67cyYfgvpRpQHU22h98RUyojn6A+OqBfB7EplVxcv7iMO2QWIJDW2jh6xTKmO8BjQ==",
+        "resolved": "1.17.0",
+        "contentHash": "yBX6ujNMX24tda1b3w6RF2gq0kDdIH1Gn0rrvqwltcR0p7fMbcYQoDd7G8mXH0V143n1/KrHi5ggATji41nJIQ==",
         "dependencies": {
-          "Microsoft.Agents.AI.Abstractions": "1.13.0",
-          "Microsoft.Extensions.AI": "10.6.0",
-          "Microsoft.Extensions.AI.Abstractions": "10.6.0",
-          "Microsoft.Extensions.AI.Evaluation": "10.6.0",
+          "Microsoft.Agents.AI.Abstractions": "1.17.0",
+          "Microsoft.Extensions.AI": "10.7.0",
+          "Microsoft.Extensions.AI.Abstractions": "10.7.0",
+          "Microsoft.Extensions.AI.Evaluation": "10.7.0",
           "Microsoft.Extensions.Compliance.Abstractions": "10.5.0",
-          "Microsoft.Extensions.VectorData.Abstractions": "9.7.0",
+          "Microsoft.Extensions.VectorData.Abstractions": "10.7.0",
           "Microsoft.ML.Tokenizers": "2.0.0"
         }
       },
       "Microsoft.Agents.AI.Abstractions": {
         "type": "Transitive",
-        "resolved": "1.13.0",
-        "contentHash": "HS2Bf/Iwm7VHK1OmYRy9MYssty+Wm8csouSiPTZHfeUzYVpI4YEowXxld0ITZFKnnzaxFMWaslDiC8HXBsAiPw==",
+        "resolved": "1.17.0",
+        "contentHash": "FoVGnguJhZa95xOgRrGueoZpL8Tz9eQCycwxpiLjiq1SSryu4WaYuryaRKnnaCavJ3tvJBMnWKsHzGO0wyhv0w==",
         "dependencies": {
-          "Microsoft.Extensions.AI.Abstractions": "10.6.0"
+          "Microsoft.Extensions.AI.Abstractions": "10.7.0"
         }
       },
       "Microsoft.Agents.AI.OpenAI": {
         "type": "Transitive",
-        "resolved": "1.13.0",
-        "contentHash": "T8/dmvpxxjn3ulQdPTMjgrYuefWTHYKUVpGN8AI6a17U3p6mHtXU4WkAy77ro6IHiHCL+9mFPDlQ+gd6sGfUfA==",
+        "resolved": "1.17.0",
+        "contentHash": "5hIcZ69tgNtPJfs8ITCBSTseVkLbdUVUXdoGY9gDWyZ+2XroERuQyr7ozVhQCQT1g7VofD4CB8pS5jM5JsSmpA==",
         "dependencies": {
-          "Microsoft.Agents.AI": "1.13.0",
-          "Microsoft.Extensions.AI": "10.6.0",
-          "Microsoft.Extensions.AI.Abstractions": "10.6.0",
-          "Microsoft.Extensions.AI.Evaluation": "10.6.0",
+          "Microsoft.Agents.AI": "1.17.0",
+          "Microsoft.Extensions.AI": "10.7.0",
+          "Microsoft.Extensions.AI.Abstractions": "10.7.0",
+          "Microsoft.Extensions.AI.Evaluation": "10.7.0",
           "Microsoft.Extensions.AI.OpenAI": "10.6.0",
           "Microsoft.Extensions.Compliance.Abstractions": "10.5.0",
-          "Microsoft.Extensions.VectorData.Abstractions": "9.7.0",
+          "Microsoft.Extensions.VectorData.Abstractions": "10.7.0",
           "Microsoft.ML.Tokenizers": "2.0.0",
           "OpenAI": "2.10.0",
           "System.ClientModel": "1.14.0"
         }
       },
+      "Microsoft.Agents.AI.Workflows": {
+        "type": "Transitive",
+        "resolved": "1.17.0",
+        "contentHash": "fXPIZBgQWdHSO9Sl82nBiSe8mZ1TqOozJhDfI+6eeGUWjo/ARICRj2xj3TEUIvUagzFemSdvmDUFdkC434vgtQ==",
+        "dependencies": {
+          "Microsoft.Agents.AI": "1.17.0",
+          "Microsoft.Agents.AI.Abstractions": "1.17.0",
+          "Microsoft.Extensions.AI": "10.7.0",
+          "Microsoft.Extensions.AI.Abstractions": "10.7.0",
+          "Microsoft.Extensions.AI.Evaluation": "10.7.0",
+          "Microsoft.Extensions.Compliance.Abstractions": "10.5.0",
+          "Microsoft.Extensions.VectorData.Abstractions": "10.7.0",
+          "Microsoft.ML.Tokenizers": "2.0.0",
+          "OpenTelemetry.Api": "1.15.3"
+        }
+      },
       "Microsoft.AspNetCore.SpaServices.Extensions": {
         "type": "Transitive",
-        "resolved": "8.0.28",
-        "contentHash": "GDPRtUWm1MN9kW4weOMUFX3IQFGQ9FCsRg7zfUrsLg6adhRaFrP05wPdoGAFPIZNLcGPSm0dFDfXNCr1n+NTfQ=="
+        "resolved": "8.0.29",
+        "contentHash": "eITCT1PzxeFMqnCXj5M+6/hySth4c3NL+eDiWVWhDFOITxnNbtFRC4aomBgxs5AnSe/ypcpqPavr4TIXOvF4pA=="
       },
       "Microsoft.Bcl.AsyncInterfaces": {
         "type": "Transitive",
@@ -748,24 +760,24 @@
       },
       "Microsoft.Extensions.AI": {
         "type": "Transitive",
-        "resolved": "10.7.0",
-        "contentHash": "r8z4uyPq0kTk4+jH92/hPshf3HNUXKOQ9axJwp57QFz43G45BG4DNYpVE0vuSan1dI69LtWx9ttF0Z2ibnghNg==",
+        "resolved": "10.8.3",
+        "contentHash": "VdT9SiqiqmrhsVx//xnfyaaNPuMbo6+vOLm8D/EvtkZfQFpBzPyaJG7W1gFpTJQoQ4nN4k0J9j+NzpScGeEZUQ==",
         "dependencies": {
-          "Microsoft.Extensions.AI.Abstractions": "10.7.0",
-          "System.Numerics.Tensors": "10.0.9"
+          "Microsoft.Extensions.AI.Abstractions": "10.8.3",
+          "System.Numerics.Tensors": "10.0.10"
         }
       },
       "Microsoft.Extensions.AI.Abstractions": {
         "type": "Transitive",
-        "resolved": "10.7.0",
-        "contentHash": "Lf822igMm8NkTYHZhTp7kjoNYkLLEvJnX3SkG/LVBvsZHC0Y9choogHz8YtITBoy0TOylM3kVUZ6iaHf0my0ug=="
+        "resolved": "10.8.3",
+        "contentHash": "K0B05oApxmviWalNHPMBBcRC7erKiDATz3ENNR/jqTR9JwIwLRefgDhj2jCRwL1aca99pXUe0qyQC73/xIuZig=="
       },
       "Microsoft.Extensions.AI.Evaluation": {
         "type": "Transitive",
-        "resolved": "10.6.0",
-        "contentHash": "fHu9H93p7jM2KiXC/6Kd511Gly1rR/VVSIr0FpQ0K381KSHNkSKgp7UAceAPe8wuUMBNXlhcI0q8UocjneuBVg==",
+        "resolved": "10.7.0",
+        "contentHash": "BdbJNfhc/pb3RkD19Sm/XuLK3x5AdU+AB+0HC8Nlu7WZTrVLnA8lpqIx1BB4k+KIKy5ZSH5RVH5HHfT+gwL9yg==",
         "dependencies": {
-          "Microsoft.Extensions.AI.Abstractions": "10.6.0"
+          "Microsoft.Extensions.AI.Abstractions": "10.7.0"
         }
       },
       "Microsoft.Extensions.AI.OpenAI": {
@@ -794,15 +806,15 @@
       },
       "Microsoft.Extensions.FileProviders.Embedded": {
         "type": "Transitive",
-        "resolved": "8.0.28",
-        "contentHash": "T8BuohFYe/7B0hZO3c7HWOXDL3BkWU3aBjfXH8wlgxUFPBOcUBAcjFwZCsqrPwn4nbVC4m3cNLaoVXxD9elXNg=="
+        "resolved": "8.0.29",
+        "contentHash": "f15AkilRlfMqEtv520LLb/IC0RhWTt1YKbY+qZ5SRQNx2cXOBmeMCPGUG/QnYhIobN/oQwfzj0yGGZdbE5P6sg=="
       },
       "Microsoft.Extensions.VectorData.Abstractions": {
         "type": "Transitive",
-        "resolved": "9.7.0",
-        "contentHash": "Vth/omSCX2vR0JabzSRU/hdPhr0CvUVZlaS2lJPWHrEwvak8ntrQLDtLMtMiWKSvviGBe/WmjUW8gA3qqn9tjw==",
+        "resolved": "10.7.0",
+        "contentHash": "eh0JLxoztc9Wz7TrFVRQyotMY9CBh2t22lMPvzy61yaBDDFBsrisrFOD4NId2z/ujwsHVKDtyfDb9tkXwSV5Vw==",
         "dependencies": {
-          "Microsoft.Extensions.AI.Abstractions": "9.5.0"
+          "Microsoft.Extensions.AI.Abstractions": "10.7.0"
         }
       },
       "Microsoft.Identity.Client": {
@@ -946,12 +958,17 @@
         "resolved": "11.6.1",
         "contentHash": "WA4z8iK+0SOh2/qoo7rtEanj/LjJZ8oWWoXI8u1xcYMk6VzHONqpabJBYGrzqDO41ld+VQHOFL+B8MXncIVSSA=="
       },
+      "OpenTelemetry.Api": {
+        "type": "Transitive",
+        "resolved": "1.15.3",
+        "contentHash": "fX+fkCysfPut+qCcT3bKqyX4QN9Saf4CgX8HLOHywEVD+Xr7sULtfuypITpoDysjx8R59dn/3mWhgimMH8cm/g=="
+      },
       "ReverseMarkdown": {
         "type": "Transitive",
-        "resolved": "5.5.0",
-        "contentHash": "oAO57uVzfODQmNZiIc0kCQCaHMn53KEpdSQyi0Usseen5/tnsMimrkL5YipK6vyRk/0NZX/d26vho8ddmpz0vA==",
+        "resolved": "6.1.1",
+        "contentHash": "c3ZFeVCNFnwIV2xlclazeTh1syliThjjBEYFbFYtsjAlX+IlJkUMW6ioxf1Xxd4Un6gu6l2U8meFyDTWvGXSjQ==",
         "dependencies": {
-          "HtmlAgilityPack": "1.12.4"
+          "AngleSharp": "1.5.2"
         }
       },
       "Sidio.Sitemap.Core": {
@@ -1023,8 +1040,8 @@
       },
       "System.IO.Hashing": {
         "type": "Transitive",
-        "resolved": "10.0.9",
-        "contentHash": "vixglGnKEexAJDeIRhyayZYzxyrgK1K9GU3K/zRZVwDbaDcMkSqj4WDHoVmQMNfsdUtLALfNSJw6mBIpdxie4A=="
+        "resolved": "10.0.10",
+        "contentHash": "eE839zyWZD/UBZYzP2lu9fhHX6RWe63/jz3Jxf+JumzO/db+Vc2s7CMiDwxk9ti2NTUft2tdRx31Rw2OjKbecA=="
       },
       "System.Memory.Data": {
         "type": "Transitive",
@@ -1033,8 +1050,8 @@
       },
       "System.Numerics.Tensors": {
         "type": "Transitive",
-        "resolved": "10.0.9",
-        "contentHash": "Rb71S3gggYVwEce9ugNw91vbr4vC4gThtx/imSJtLBW3AupEKujJPPQL6xF9q0DcNm6+z7hnYk7XqXaUpA4wDg=="
+        "resolved": "10.0.10",
+        "contentHash": "9Ildb4Y9maDztB0ZRGxsNShbpCQ2Tjv2dr4IjskBxpTGhH7aIz1+oC+Hl833ASs/htWwsH6myNe+sRpeyCzeMQ=="
       },
       "System.Security.Cryptography.Pkcs": {
         "type": "Transitive",
@@ -1048,8 +1065,8 @@
       },
       "Vogen": {
         "type": "Transitive",
-        "resolved": "8.0.6",
-        "contentHash": "YJDSaX2JO7yZ8tohWYF2Fy4G/LCoWmdVf/2oaUOip3KUGlUlYY2Vc2+C5VQfSnoopvrvbMT/ty7kEy1FqtyXCA=="
+        "resolved": "8.0.7",
+        "contentHash": "0DrJ2ZPEGoJlzwqhum2LaZJ2FzJzgy5HP0km+XYL2MC/hS4Sn5/C35oRyob146Yjlf5xit2tmPx5xhI2BXkhLw=="
       },
       "Yarp.ReverseProxy": {
         "type": "Transitive",
@@ -1063,17 +1080,17 @@
         "type": "Project",
         "dependencies": {
           "Goldfinch.Core": "[1.0.0, )",
-          "Kentico.Xperience.Admin": "[31.7.2, )",
-          "Kentico.Xperience.WebApp": "[31.7.2, )"
+          "Kentico.Xperience.Admin": "[31.8.0, )",
+          "Kentico.Xperience.WebApp": "[31.8.0, )"
         }
       },
       "goldfinch.core": {
         "type": "Project",
         "dependencies": {
-          "AngleSharp": "[1.6.0, )",
-          "Kentico.Xperience.Admin": "[31.7.2, )",
+          "AngleSharp": "[1.7.1, )",
+          "Kentico.Xperience.Admin": "[31.8.0, )",
           "Kentico.Xperience.Lucene": "[15.0.5, )",
-          "Kentico.Xperience.WebApp": "[31.7.2, )",
+          "Kentico.Xperience.WebApp": "[31.8.0, )",
           "Lucene.Net.Highlighter": "[4.8.0-beta00018, )",
           "OpenAI": "[2.12.0, )",
           "Sidio.Sitemap.AspNetCore": "[3.1.1, )"
@@ -1081,9 +1098,9 @@
       },
       "AngleSharp": {
         "type": "CentralTransitive",
-        "requested": "[1.6.0, )",
-        "resolved": "1.6.0",
-        "contentHash": "kVnhnZlM4Yww2KWqW3uSL8isvhYsrTTBMSPAgoF8ZhMrLSoay6783AP6dQxAj1J9gvWKi3OIM4ZezdE2Y4ufCQ=="
+        "requested": "[1.7.1, )",
+        "resolved": "1.7.1",
+        "contentHash": "QBblGpRB3SYD66Mls7fHyl1mWkP93n7ErWDWHc1vd9sPHhdlTkmUoY3CjgfjcWNxGF9m7xjNyztRfErXqoBKOA=="
       },
       "Kentico.Xperience.Lucene": {
         "type": "CentralTransitive",


### PR DESCRIPTION
Updates Xperience by Kentico from **31.7.2** to **31.8.0** (August 2026 Refresh).

## Changes

- `Kentico.Xperience.Admin` / `AzureStorage` / `WebApp` → 31.8.0
- `Kentico.Xperience.ManagementApi` → 31.8.0-preview
- `@kentico/xperience-admin-base` / `admin-components` / `webpack-config` → 31.8.0
- Database migrated via `--kxp-update`
- CI objects re-serialized via `--kxp-ci-store`

### AngleSharp bump (NU1605)

`Kentico.Xperience.Core 31.8.0` requires `AngleSharp >= 1.7.1`, but it was pinned at 1.6.0, failing restore with a package downgrade error. AngleSharp is used directly by `Goldfinch.Core/Search/WebScraperHtmlSanitizer.cs`, so the pin was bumped to 1.7.1 rather than dropped.

### CI repository

One file changed — a new system field (`AiraConversationCheckpoint`) on the AIRA conversation class, introduced by 31.8.0. The Lucene `luceneindexassemblyversionitem` exclusion held; no per-environment index state leaked into CI.

## Release notes review — no manual steps required

Checked each 31.8.0 change against this codebase:

| Change | Impact |
|---|---|
| React Router 6 → 7 (shared admin dep) | None — admin client has no `react-router` dependency |
| `StorageInitializationModule` migration guide | None — already migrated to storage path mapping |
| Custom data type `SupportedTargets` | None — no custom data types registered |
| `ReadOnlyModeOptions.VariantCache` | None — read-only mode not used |
| CPM in project templates | None — already on Central Package Management |

31.7.3 (security hotfix) and 31.7.4 (update-timeout fix, only affects projects below 31.7.0) needed no action.

> [!NOTE]
> Media libraries are hidden in the admin UI from 31.8.0 and **fully removed in the September 2026 Refresh**. This project uses content item assets throughout and has no media library objects in the CI repository, so the removal should be a non-event — worth a sanity check next Refresh.

## Testing

- `dotnet build` — 0 warnings, 0 errors
- Admin client webpack build — compiled successfully
- Route smoke test against the running app — `/`, `/blog`, `/about`, `/admin`, `/rss.xml` all returned 200
- Manually verified blog detail rendering, page builder widgets, and search

🤖 Generated with [Claude Code](https://claude.com/claude-code)
